### PR TITLE
dashboard: ensure list views are always full height

### DIFF
--- a/dashboard/src/features/shared/components/BaseList/BaseList.jsx
+++ b/dashboard/src/features/shared/components/BaseList/BaseList.jsx
@@ -62,7 +62,7 @@ class ItemList extends React.Component {
       const Wrapper = this.props.wrapperComponent
 
       return(
-        <div>
+        <div className='flex-container'>
           {header}
 
           <PageContent>


### PR DESCRIPTION
Prevents a background paint issue in Safari when switching
between pages.
