### PR TITLE
installer/windows: fix the VC++ link

### DIFF
--- a/installer/windows/README.md
+++ b/installer/windows/README.md
@@ -9,7 +9,7 @@ We don't check `.exe`s into git, so you'll have to provide them yourself. There 
 1. `chain-core.exe` (aka `cored`).
 2. `ChainMgr.exe` 
 3. The Postgres Installer, called `postgresql-9.5.4-2-windows-x64.exe`
-4. The VC++ Redistributable (which is required to run the Postgres Installer), called `vcredist_x64.exe`
+4. The VC++ Redistributable for Visual Studio 2013 (which is required to run the Postgres Installer), called `vcredist_x64.exe`
 
 You will want to put them into this directory like this: 
 
@@ -21,8 +21,8 @@ You will want to put them into this directory like this:
       | ChainMgr.exe
    |-ChainPackage
    |-Postgres
-      | postgres-installer.exe
-      | postgres dll exe
+      | postgresql-9.5.4-2-windows-x64.exe
+      | vcredist_x64.exe
 ```
 
 `ChainMgr.exe` and `chain-core.exe` can be compiled from any machine using `GOOS` and `GOARCH`: 
@@ -34,7 +34,7 @@ GOOS=windows GOARCH=amd64 go build chain/installer/windows/ChainMgr
 
 The Postgres Installer can be downloaded from http://www.enterprisedb.com/products-services-training/pgdownload
 
-The VC++ Redistributable can be downloaded from https://www.microsoft.com/en-us/download/search.aspx?q=redistributable+package&first=11
+The VC++ Redistributable can be downloaded from https://www.microsoft.com/en-us/download/details.aspx?id=40784 
 
 Make sure you have the 64-bit versions. Chain Core Windows does not support 32-bit. Do not actually run these installers, just provide them.
 


### PR DESCRIPTION
Clarify which version of the VC++ Redistributable is needed, and fix the download link.
