### PR TITLE
core/signers: take explicit db handle

### DIFF
--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -55,9 +55,7 @@ type Account struct {
 
 // Create creates a new Account.
 func (m *Manager) Create(ctx context.Context, xpubs []string, quorum int, alias string, tags map[string]interface{}, clientToken *string) (*Account, error) {
-	// TODO(jackson): remove dbctx when the signers package doesn't need it
-	dbctx := pg.NewContext(ctx, m.db)
-	signer, err := signers.Create(dbctx, "account", xpubs, quorum, clientToken)
+	signer, err := signers.Create(ctx, m.db, "account", xpubs, quorum, clientToken)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
@@ -119,9 +117,7 @@ func (m *Manager) findByID(ctx context.Context, id string) (*signers.Signer, err
 	if ok {
 		return cached.(*signers.Signer), nil
 	}
-	// TODO(jackson): remove dbctx when the signers package doesn't need it
-	dbctx := pg.NewContext(ctx, m.db)
-	account, err := signers.Find(dbctx, "account", id)
+	account, err := signers.Find(ctx, m.db, "account", id)
 	if err != nil {
 		return nil, err
 	}

--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -64,9 +64,7 @@ type Asset struct {
 
 // Define defines a new Asset.
 func (reg *Registry) Define(ctx context.Context, xpubs []string, quorum int, definition map[string]interface{}, alias string, tags map[string]interface{}, clientToken *string) (*Asset, error) {
-	// TODO(jackson): remove the dbctx when the signers package doesn't need it
-	dbctx := pg.NewContext(ctx, reg.db)
-	assetSigner, err := signers.Create(dbctx, "asset", xpubs, quorum, clientToken)
+	assetSigner, err := signers.Create(ctx, reg.db, "asset", xpubs, quorum, clientToken)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Instead of pulling the db handle out of the context.Context, take an
explicit pg.DB as a parameter.

If we want, we could go farther and have the signers package keep its
own db handle, but the signers abstraction is a little leaky in a few
places. Both the account and asset packages do JOINs on the signers SQL
table.