### PR TITLE
docs/core/introduction: add introductory paragraph on Chain Core

### DIFF
--- a/docs/core/get-started/introduction.md
+++ b/docs/core/get-started/introduction.md
@@ -1,5 +1,9 @@
 # Introduction
 
+## Chain Core
+
+Chain Core is enterprise software that enables institutions to issue and transfer financial assets on permissioned blockchain networks. Using Chain Core, institutions can launch and operate a blockchain network, or connect to a growing list of other networks that are transforming how assets move around the world.
+
 ## Chain Core Developer Edition
 
 Chain Core Developer Edition is a free, downloadable version of Chain Core that is [open source](https://github.com/chain/chain) and licensed under [AGPL](https://github.com/chain/chain/blob/main/LICENSE). Individuals and organizations can use Chain Core Developer Edition to learn, experiment, and build prototypes.


### PR DESCRIPTION
The previous docs did not include a summary or description of Chain Core. This commit adds a paragraph taken from the website [FAQ](https://chain.com/faq/) to the Introduction section.