### PR TITLE
installer/windows: rename chain-core.exe to cored.exe

### DIFF
--- a/installer/windows/ChainMgr/ChainMgr.go
+++ b/installer/windows/ChainMgr/ChainMgr.go
@@ -19,7 +19,7 @@ import (
 const (
 
 	// The Chain Core executable itself.
-	chainCoreExe = `C:/Program Files (x86)/Chain/chain-core.exe`
+	chainCoreExe = `C:/Program Files (x86)/Chain/cored.exe`
 
 	// Data directory for Postgres to store all of its stuff for a specific db.
 	pgDataDir = `C:/Program Files (x86)/Chain/data`

--- a/installer/windows/ChainPackage/ChainCoreInstaller.wxs
+++ b/installer/windows/ChainPackage/ChainCoreInstaller.wxs
@@ -56,7 +56,7 @@
   <Fragment>
     <ComponentGroup Id="ChainCoreComponents" Directory="INSTALLFOLDER">
        <Component>
-         <File Source="../chain-core.exe" />
+         <File Source="../cored.exe" />
        </Component>
        <Component>
          <File Source="../ChainMgr/ChainMgr.exe" />

--- a/installer/windows/README.md
+++ b/installer/windows/README.md
@@ -2,25 +2,25 @@
 
 ## Installing Chain Core
 
-To install Chain Core Developer Edition for Windows, please visit [our downloads page](https://chain.com/docs/core/get-started/install). 
+To install Chain Core Developer Edition for Windows, please visit [our downloads page](https://chain.com/docs/core/get-started/install).
 
 ## Building the Windows Installer
-### Dependencies 
+### Dependencies
 
 These instructions assume that your PATH includes the wix tools binary. My wix tools binary is located at `C:\Program Files (x86)\WiX Toolset v3.10\bin`.
 
 We don't check `.exe`s into git, so you'll have to provide them yourself. There are four `.exe`s:
 
-1. `chain-core.exe` (aka `cored`).
-2. `ChainMgr.exe` 
+1. `cored.exe`
+2. `ChainMgr.exe`
 3. The Postgres Installer, called `postgresql-9.5.4-2-windows-x64.exe`
 4. The VC++ Redistributable for Visual Studio 2013 (which is required to run the Postgres Installer), called `vcredist_x64.exe`
 
-You will want to put them into this directory like this: 
+You will want to put them into this directory like this:
 
 ```
 |-windows
-   | chain-core.exe
+   | cored.exe
    |-ChainBundle
    |-ChainMgr
       | ChainMgr.exe
@@ -30,7 +30,7 @@ You will want to put them into this directory like this:
       | vcredist_x64.exe
 ```
 
-`ChainMgr.exe` and `chain-core.exe` can be compiled from any machine using `GOOS` and `GOARCH`: 
+`ChainMgr.exe` and `cored.exe` can be compiled from any machine using `GOOS` and `GOARCH`:
 
 ```
 GOOS=windows GOARCH=amd64 go build chain/cmd/cored
@@ -39,15 +39,15 @@ GOOS=windows GOARCH=amd64 go build chain/installer/windows/ChainMgr
 
 The Postgres Installer can be downloaded from http://www.enterprisedb.com/products-services-training/pgdownload
 
-The VC++ Redistributable can be downloaded from https://www.microsoft.com/en-us/download/details.aspx?id=40784 
+The VC++ Redistributable can be downloaded from https://www.microsoft.com/en-us/download/details.aspx?id=40784
 
 Make sure you have the 64-bit versions. Chain Core Windows does not support 32-bit. Do not actually run these installers, just provide them.
 
 ### Build
 
-The chain bundler is capable of building multiple .msi's and .exe's into a single installer .exe. 
+The chain bundler is capable of building multiple .msi's and .exe's into a single installer .exe.
 
-First, build the chain core msi. To do this, from inside of `installer/windows` run: 
+First, build the chain core msi. To do this, from inside of `installer/windows` run:
 
 ```
 cd ChainPackage
@@ -56,15 +56,15 @@ candle -ext WixHttpExtension -ext WixUtilExtension ChainCoreInstaller.wxs
 
 This generates `ChainPackage/ChainCoreInstaller.wixobj`
 
-Next, run 
+Next, run
 
 ```
 light -ext WixHttpExtension -ext WixUtilExtension ChainCoreInstaller.wixobj
 ```
 
-to generate `ChainPackage/ChainCoreInstaller.msi`. 
+to generate `ChainPackage/ChainCoreInstaller.msi`.
 
-Next, build the Chain Bundle. Run 
+Next, build the Chain Bundle. Run
 
 ```
 cd ../ChainBundle
@@ -75,7 +75,7 @@ candle Bundle.wxs \
   -dPostgresPackage.TargetPath='Z:\chain\installer\windows\Postgres\postgresql-9.5.4-2-windows-x64.exe' \
   -dVCRPackage.TargetPath='Z:\chain\installer\windows\Postgres\vcredist_x64.exe'
 ```
-(but obviously sub out your path for my target paths) 
+(but obviously sub out your path for my target paths)
 
 This generates `ChainBundle/Bundle.wixobj`. Next, run
 
@@ -83,28 +83,28 @@ This generates `ChainBundle/Bundle.wixobj`. Next, run
 light Bundle.wixobj -ext WixBalExtension
 ```
 
-This generates Bundle.exe in your current working directory. 
+This generates Bundle.exe in your current working directory.
 
 ### Code Signing
 
-In order for Chain to appear as the publisher, some of the files inside the installer need to be signed with the private key of Chain's code signing certificate. 
+In order for Chain to appear as the publisher, some of the files inside the installer need to be signed with the private key of Chain's code signing certificate.
 
 To do this, you will need:
 
 * A `.pfx` file ([generated from the certificate](https://www.digicert.com/code-signing/exporting-code-signing-certificate.htm)). In order to prevent as many security warnings as possible, the certificate should be an EV Certificate.
-* `signtool`, which is packaged inside the Windows SDK. The Windows SDK is from Microsoft and can be downloaded here: https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk 
+* `signtool`, which is packaged inside the Windows SDK. The Windows SDK is from Microsoft and can be downloaded here: https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk
 
 You will need to sign:
 
-* `chain-core.exe`
+* `cored.exe`
 * `ChainMgr.exe`
 * `cab1.cab` (a build artifact from building `ChainCoreInstaller.msi`)
-* `Bundle.exe` 
+* `Bundle.exe`
 * The Burn engine contained inside `Bundle.exe`
 
-To sign a file, do the following. The following commands assume that both the Wix Tools binaries and the signtool are in your path. My signtool was installed at `C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe`. 
+To sign a file, do the following. The following commands assume that both the Wix Tools binaries and the signtool are in your path. My signtool was installed at `C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe`.
 
-1. Sign `chain-core.exe` and `ChainMgr.exe` by running signtool:
+1. Sign `cored.exe` and `ChainMgr.exe` by running signtool:
 
 ```
 signtool sign -v -f [x.pfx] -p [password] [file to sign]
@@ -117,7 +117,7 @@ signtool sign -v -f [x.pfx] -p [password] [file to sign]
 signtool sign -v -f [x.pfx] -p [password] ChainPackage/cab1.cab
 ```
 
-4. Build `Bundle.exe` using `candle` and `light`, as above. 
+4. Build `Bundle.exe` using `candle` and `light`, as above.
 5. Extract `engine.exe` from the bundle and sign it:
 
 ```
@@ -126,10 +126,10 @@ signtool sign -v -f [x.pfx] -p [password] engine.exe
 insignia -ab engine.exe Bundle.exe -o Chain_Core_Latest.exe -v
 ```
 
-6. Sign `Chain_Core_Latest.exe` directly: 
+6. Sign `Chain_Core_Latest.exe` directly:
 
 ```
 signtool sign -v -f [x.pfx] -p [password] ChainBundle/Chain_Core_Latest.exe
 ```
 
-Clicking on `Chain_Core_Latest.exe` will install Chain Core as an application on your PC. 
+Clicking on `Chain_Core_Latest.exe` will install Chain Core as an application on your PC.


### PR DESCRIPTION
`cored` gets compiled as `cored.exe`. Let's let `cored`s be `cored`s. (Honestly it's just annoying to rename it every time.) 

This PR also fixes some wonky whitespace in the README.