### PR TITLE
core/accesstoken: encapsulate storage

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -16,7 +16,6 @@ import (
 	"chain/core/migrate"
 	"chain/core/mockhsm"
 	"chain/crypto/ed25519"
-	"chain/database/pg"
 	"chain/database/sql"
 	"chain/env"
 	"chain/log"
@@ -165,8 +164,9 @@ func createToken(db *sql.DB, args []string) {
 		fatalln(usage)
 	}
 
+	accessTokens := &accesstoken.CredentialStore{DB: db}
 	typ := map[bool]string{true: "network", false: "client"}[*flagNet]
-	tok, err := accesstoken.Create(pg.NewContext(context.Background(), db), args[0], typ)
+	tok, err := accessTokens.Create(context.Background(), args[0], typ)
 	if err != nil {
 		fatalln("error:", err)
 	}

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kr/secureheader"
 
 	"chain/core"
+	"chain/core/accesstoken"
 	"chain/core/account"
 	"chain/core/account/utxodb"
 	"chain/core/asset"
@@ -246,17 +247,18 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, config *core.Config, 
 	go core.CleanupSubmittedTxs(ctx, db)
 
 	h := &core.Handler{
-		Chain:    c,
-		Store:    store,
-		Assets:   assets,
-		Accounts: accounts,
-		HSM:      hsm,
-		Indexer:  indexer,
-		Config:   config,
-		DB:       db,
-		Addr:     *listenAddr,
-		Signer:   signBlockHandler,
-		AltAuth:  authLoopbackInDev,
+		Chain:        c,
+		Store:        store,
+		Assets:       assets,
+		Accounts:     accounts,
+		HSM:          hsm,
+		Indexer:      indexer,
+		AccessTokens: &accesstoken.CredentialStore{DB: db},
+		Config:       config,
+		DB:           db,
+		Addr:         *listenAddr,
+		Signer:       signBlockHandler,
+		AltAuth:      authLoopbackInDev,
 	}
 	if *rpsToken > 0 {
 		h.RequestLimits = append(h.RequestLimits, core.RequestLimit{

--- a/core/access_tokens.go
+++ b/core/access_tokens.go
@@ -11,7 +11,7 @@ import (
 var errCurrentToken = errors.New("token cannot delete itself")
 
 func (h *Handler) createAccessToken(ctx context.Context, x struct{ ID, Type string }) (*accesstoken.Token, error) {
-	return accesstoken.Create(ctx, x.ID, x.Type)
+	return h.AccessTokens.Create(ctx, x.ID, x.Type)
 }
 
 func (h *Handler) listAccessTokens(ctx context.Context, x requestQuery) (*page, error) {
@@ -20,7 +20,7 @@ func (h *Handler) listAccessTokens(ctx context.Context, x requestQuery) (*page, 
 		limit = defGenericPageSize
 	}
 
-	tokens, next, err := accesstoken.List(ctx, x.Type, x.After, limit)
+	tokens, next, err := h.AccessTokens.List(ctx, x.Type, x.After, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -40,5 +40,5 @@ func (h *Handler) deleteAccessToken(ctx context.Context, x struct{ ID string }) 
 	if currentID == x.ID {
 		return errCurrentToken
 	}
-	return accesstoken.Delete(ctx, x.ID)
+	return h.AccessTokens.Delete(ctx, x.ID)
 }

--- a/core/api.go
+++ b/core/api.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"chain/core/accesstoken"
 	"chain/core/account"
 	"chain/core/asset"
 	"chain/core/leader"
@@ -53,6 +54,7 @@ type Handler struct {
 	Accounts      *account.Manager
 	HSM           *mockhsm.HSM
 	Indexer       *query.Indexer
+	AccessTokens  *accesstoken.CredentialStore
 	Config        *Config
 	DB            pg.DB
 	Addr          string
@@ -163,6 +165,7 @@ func (h *Handler) init() {
 	})
 
 	var handler = (&apiAuthn{
+		tokens:   h.AccessTokens,
 		tokenMap: make(map[string]tokenResult),
 		alt:      h.AltAuth,
 	}).handler(latencyHandler)


### PR DESCRIPTION
Remove the dependency on the Context's database in the
`core/accesstoken` package.