### PR TITLE
database/pg: remove context convenience funcs

### DIFF
--- a/core/b32enc_test.go
+++ b/core/b32enc_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"chain/database/pg"
 	"chain/database/pg/pgtest"
 )
 
@@ -36,10 +35,11 @@ func TestB32encCrockford(t *testing.T) {
 		{"\x00\x11\x22\x33\x44\x55\x66\x77", "008J4CT4ANK7E"},
 	}
 
-	ctx := pg.NewContext(context.Background(), pgtest.NewTx(t))
+	db := pgtest.NewTx(t)
+	ctx := context.Background()
 	for _, test := range cases {
 		var got string
-		err := pg.QueryRow(ctx, `SELECT b32enc_crockford($1)`, test.decoded).Scan(&got)
+		err := db.QueryRow(ctx, `SELECT b32enc_crockford($1)`, test.decoded).Scan(&got)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 			continue

--- a/core/mockhsm/mockhsm.go
+++ b/core/mockhsm/mockhsm.go
@@ -79,7 +79,7 @@ func (h *HSM) createChainKDKey(ctx context.Context, alias string, get bool) (*XP
 			}
 
 			var xpubBytes []byte
-			err = pg.QueryRow(ctx, `SELECT pub FROM mockhsm WHERE alias = $1`, alias).Scan(&xpubBytes)
+			err = h.db.QueryRow(ctx, `SELECT pub FROM mockhsm WHERE alias = $1`, alias).Scan(&xpubBytes)
 			if err != nil {
 				return nil, false, errors.Wrapf(err, "reading existing xpub with alias %s", alias)
 			}
@@ -124,7 +124,7 @@ func (h *HSM) createEd25519Key(ctx context.Context, alias string, get bool) (*Pu
 			}
 
 			var pubBytes []byte
-			err = pg.QueryRow(ctx, `SELECT pub FROM mockhsm WHERE alias = $1`, alias).Scan(&pubBytes)
+			err = h.db.QueryRow(ctx, `SELECT pub FROM mockhsm WHERE alias = $1`, alias).Scan(&pubBytes)
 			if err != nil {
 				return nil, false, errors.Wrapf(err, "reading existing pub with alias %s", alias)
 			}

--- a/core/transact_test.go
+++ b/core/transact_test.go
@@ -23,7 +23,7 @@ func TestLocalAccountTransfer(t *testing.T) {
 	c := prottest.NewChain(t)
 	assets := asset.NewRegistry(db, c, bc.Hash{})
 	accounts := account.NewManager(db, c)
-	h := &Handler{Assets: assets, Accounts: accounts, Chain: c}
+	h := &Handler{Assets: assets, Accounts: accounts, DB: db, Chain: c}
 
 	acc, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, nil)
 	if err != nil {

--- a/core/txdb/txdb_test.go
+++ b/core/txdb/txdb_test.go
@@ -63,8 +63,9 @@ func TestInsertPoolTx(t *testing.T) {
 }
 
 func TestGetBlock(t *testing.T) {
+	ctx := context.Background()
 	dbtx := pgtest.NewTx(t)
-	pgtest.Exec(pg.NewContext(context.Background(), dbtx), t, `
+	pgtest.Exec(ctx, dbtx, t, `
 		INSERT INTO blocks (block_hash, height, data, header)
 		VALUES
 		('0000000000000000000000000000000000000000000000000000000000000000', 0, '', ''),
@@ -76,7 +77,6 @@ func TestGetBlock(t *testing.T) {
 		);
 	`)
 	store := NewStore(dbtx)
-	ctx := context.Background()
 	got, err := store.GetBlock(ctx, 1)
 	if err != nil {
 		t.Fatalf("err got = %v want nil", err)

--- a/core/txfeed/txfeed_test.go
+++ b/core/txfeed/txfeed_test.go
@@ -12,14 +12,15 @@ import (
 )
 
 func TestInsertTxFeed(t *testing.T) {
-	ctx := pg.NewContext(context.Background(), pgtest.NewTx(t))
+	ctx := context.Background()
+	db := pgtest.NewTx(t)
 	token := "test_token"
 	alias := "test_txfeed"
 	feed := &TxFeed{
 		Alias: &alias,
 	}
 
-	result, err := insertTxFeed(ctx, feed, &token)
+	result, err := insertTxFeed(ctx, db, feed, &token)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -31,7 +32,7 @@ func TestInsertTxFeed(t *testing.T) {
 	// Verify that the txfeed was created.
 	var resultAlias string
 	var checkQ = `SELECT alias FROM txfeeds`
-	err = pg.QueryRow(ctx, checkQ).Scan(&resultAlias)
+	err = db.QueryRow(ctx, checkQ).Scan(&resultAlias)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -41,19 +42,20 @@ func TestInsertTxFeed(t *testing.T) {
 }
 
 func TestInsertTxFeedRepeatToken(t *testing.T) {
-	ctx := pg.NewContext(context.Background(), pgtest.NewTx(t))
+	ctx := context.Background()
+	db := pgtest.NewTx(t)
 	token := "test_token"
 	alias := "test_txfeed"
 	feed := &TxFeed{
 		Alias: &alias,
 	}
 
-	result0, err := insertTxFeed(ctx, feed, &token)
+	result0, err := insertTxFeed(ctx, db, feed, &token)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	result1, err := insertTxFeed(ctx, feed, &token)
+	result1, err := insertTxFeed(ctx, db, feed, &token)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -65,7 +67,8 @@ func TestInsertTxFeedRepeatToken(t *testing.T) {
 }
 
 func TestInsertTxFeedDuplicateAlias(t *testing.T) {
-	ctx := pg.NewContext(context.Background(), pgtest.NewTx(t))
+	ctx := context.Background()
+	db := pgtest.NewTx(t)
 	token0 := "test_token_0"
 	token1 := "test_token_1"
 	alias := "test_txfeed"
@@ -73,12 +76,12 @@ func TestInsertTxFeedDuplicateAlias(t *testing.T) {
 		Alias: &alias,
 	}
 
-	_, err := insertTxFeed(ctx, feed, &token0)
+	_, err := insertTxFeed(ctx, db, feed, &token0)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	_, err = insertTxFeed(ctx, feed, &token1)
+	_, err = insertTxFeed(ctx, db, feed, &token1)
 	if err.Error() != "non-unique alias: httpjson: bad request" {
 		t.Errorf("expected ErrBadRequest, got %v", err)
 	}

--- a/database/pg/context.go
+++ b/database/pg/context.go
@@ -93,18 +93,3 @@ func NewContext(ctx context.Context, db DB) context.Context {
 func FromContext(ctx context.Context) DB {
 	return ctx.Value(dbKey).(DB)
 }
-
-// Query is a short form of FromContext(ctx).Query
-func Query(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
-	return FromContext(ctx).Query(ctx, query, args...)
-}
-
-// QueryRow is a short form of FromContext(ctx).QueryRow
-func QueryRow(ctx context.Context, query string, args ...interface{}) *sql.Row {
-	return FromContext(ctx).QueryRow(ctx, query, args...)
-}
-
-// Exec is a short form of FromContext(ctx).Exec
-func Exec(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
-	return FromContext(ctx).Exec(ctx, query, args...)
-}

--- a/database/pg/pgtest/pgtest.go
+++ b/database/pg/pgtest/pgtest.go
@@ -250,8 +250,8 @@ func formatPrefix(prefix string, t time.Time) string {
 
 // Exec executes q in the database or transaction in ctx.
 // If there is an error, it fails t.
-func Exec(ctx context.Context, t testing.TB, q string, args ...interface{}) {
-	_, err := pg.Exec(ctx, q, args...)
+func Exec(ctx context.Context, db pg.DB, t testing.TB, q string, args ...interface{}) {
+	_, err := db.Exec(ctx, q, args...)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}


### PR DESCRIPTION
Delete `pg.Query`, `pg.QueryRow` and `pg.Exec` and update all call sites to either use an explicit db handle in scope or use `pg.FromContext(ctx)`.