### PR TITLE
core: remove errors from /health response

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -109,7 +109,7 @@ func (h *Handler) init() {
 
 	m := http.NewServeMux()
 	m.Handle("/", alwaysError(errNotFound))
-	m.Handle("/health", jsonHandler(h.health))
+	m.Handle("/health", jsonHandler(func() {}))
 
 	m.Handle("/create-account", needConfig(h.createAccount))
 	m.Handle("/create-asset", needConfig(h.createAsset))


### PR DESCRIPTION
We provide errors in the /info response, which is
authenticated. But /health is not authenticated, and we
don't need to serve the errors in both places. Our
alerting on these errors should provide credentials.