### PR TITLE
bin/upload-docs: set content type on extensionless files

### DIFF
--- a/bin/upload-docs
+++ b/bin/upload-docs
@@ -21,11 +21,9 @@ echo
 echo "Uploading docs...."
 aws s3 sync --delete $generate_dest_path $bucket_url/docs
 
-# Set text/html MIME types for all files without extensions
-cd $generate_dest_path
-
 echo
 echo "Setting content type for extensionless files, this will take a while..."
+cd $generate_dest_path
 find . -type f ! -name "*.*" |
   sed -e "s/^.\\///" |
   xargs -I {} aws s3api copy-object \

--- a/bin/upload-docs
+++ b/bin/upload-docs
@@ -3,11 +3,13 @@ set -ef -o pipefail
 
 # TODO: when production is viable target, add commandline option to upload to
 # the production bucket.
-bucket="s3://chain-staging.chain.com"
+bucket="chain-staging.chain.com"
 if [ "$1" = "prod" ];
 then
-  bucket="s3://chain.com"
+  bucket="chain.com"
 fi
+
+bucket_url=s3://$bucket
 
 # Print output from generate-docs to stdout, but capture last line (the actual
 # output directory) in a variable.
@@ -17,5 +19,18 @@ trap "rm -rf $generate_dest_path" EXIT
 
 echo
 echo "Uploading docs...."
-aws s3 sync --delete $generate_dest_path $bucket/docs
+aws s3 sync --delete $generate_dest_path $bucket_url/docs
 
+# Set text/html MIME types for all files without extensions
+cd $generate_dest_path
+
+echo
+echo "Setting content type for extensionless files, this will take a while..."
+find . -type f ! -name "*.*" |
+  sed -e "s/^.\\///" |
+  xargs -I {} aws s3api copy-object \
+    --bucket $bucket \
+    --content-type "text/html" \
+    --copy-source $bucket/docs/{} \
+    --key docs/{} \
+    --metadata-directive "REPLACE" > /dev/null


### PR DESCRIPTION
We strip file extensions when rendering static files in order to
provide for pretty, extension-free URLs. Unfortunately, this
removes S3's ability to deduce the MIME type from the extension.

This commit adds a post-sync step that iterates over every
extensionless file in the generated docs, and updates the content
type to text/html. For now, we're not concerned about false
positives.

One other option we explored was having md2html render non-index
leaf pages as BASENAME/index.html, but this caused relative URLs
in the content to be off by one level of depth. Changing relative
URLs to root-prefixed URLs (/foo/bar) was a deep change, and broke
the ability to browse the Markdown links from GitHub.