### PR TITLE
cmd/cored: fix auth on unconfigured core

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -134,7 +134,11 @@ func main() {
 		h = launchConfiguredCore(ctx, db, config, processID)
 	} else {
 		chainlog.Messagef(ctx, "Launching as unconfigured Core.")
-		h = &core.Handler{DB: db, AltAuth: authLoopbackInDev}
+		h = &core.Handler{
+			DB:           db,
+			AltAuth:      authLoopbackInDev,
+			AccessTokens: &accesstoken.CredentialStore{DB: db},
+		}
 	}
 
 	secureheader.DefaultConfig.PermitClearLoopback = true


### PR DESCRIPTION
Populate the core.Handler with an accesstoken.CredentialStore when
launching an unconfigured Core. Unconfigured routes still need access
token authentication.

Bug was introduced in #48.