### PR TITLE
core/account/utxodb: encapsulate storage

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -20,7 +20,6 @@ import (
 	"chain/core"
 	"chain/core/accesstoken"
 	"chain/core/account"
-	"chain/core/account/utxodb"
 	"chain/core/asset"
 	"chain/core/blocksigner"
 	"chain/core/fetch"
@@ -289,7 +288,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, config *core.Config, 
 	go leader.Run(db, *listenAddr, func(ctx context.Context) {
 		ctx = pg.NewContext(ctx, db)
 
-		go utxodb.ExpireReservations(ctx, expireReservationsPeriod)
+		go h.Accounts.ExpireReservations(ctx, expireReservationsPeriod)
 		if config.IsGenerator {
 			go generator.Generate(ctx, c, generatorSigners, db, blockPeriod, genhealth)
 		} else {

--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -52,9 +52,8 @@ func (m *Manager) IndexAccounts(indexer Saver) {
 	m.chain.AddBlockCallback(m.indexAccountUTXOs)
 }
 
-// ExpireReservations removes reservations that have expired on the provided
-// period until the context is cancelled. It blocks until the context is
-// cancelled.
+// ExpireReservations removes reservations that have expired periodically.
+// It blocks until the context is canceled.
 func (m *Manager) ExpireReservations(ctx context.Context, period time.Duration) {
 	m.utxoDB.ExpireReservations(ctx, period)
 }

--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -3,15 +3,18 @@ package account
 
 import (
 	"context"
-	"database/sql"
+	stdsql "database/sql"
 	"encoding/json"
 	"sync"
+	"time"
 
 	"github.com/golang/groupcache/lru"
 
+	"chain/core/account/utxodb"
 	"chain/core/signers"
 	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg"
+	"chain/database/sql"
 	"chain/errors"
 	"chain/net/http/httpjson"
 	"chain/protocol"
@@ -20,11 +23,12 @@ import (
 
 const maxAccountCache = 100
 
-func NewManager(db pg.DB, chain *protocol.Chain) *Manager {
+func NewManager(db *sql.DB, chain *protocol.Chain) *Manager {
 	return &Manager{
-		db:    db,
-		chain: chain,
-		cache: lru.New(maxAccountCache),
+		db:     db,
+		chain:  chain,
+		utxoDB: &utxodb.Reserver{DB: db},
+		cache:  lru.New(maxAccountCache),
 	}
 }
 
@@ -32,6 +36,7 @@ func NewManager(db pg.DB, chain *protocol.Chain) *Manager {
 type Manager struct {
 	db      pg.DB
 	chain   *protocol.Chain
+	utxoDB  *utxodb.Reserver
 	indexer Saver
 
 	cacheMu sync.Mutex
@@ -45,6 +50,13 @@ type Manager struct {
 func (m *Manager) IndexAccounts(indexer Saver) {
 	m.indexer = indexer
 	m.chain.AddBlockCallback(m.indexAccountUTXOs)
+}
+
+// ExpireReservations removes reservations that have expired on the provided
+// period until the context is cancelled. It blocks until the context is
+// cancelled.
+func (m *Manager) ExpireReservations(ctx context.Context, period time.Duration) {
+	m.utxoDB.ExpireReservations(ctx, period)
 }
 
 type Account struct {
@@ -65,7 +77,7 @@ func (m *Manager) Create(ctx context.Context, xpubs []string, quorum int, alias 
 		return nil, err
 	}
 
-	aliasSQL := sql.NullString{
+	aliasSQL := stdsql.NullString{
 		String: alias,
 		Valid:  alias != "",
 	}
@@ -100,7 +112,7 @@ func (m *Manager) FindByAlias(ctx context.Context, alias string) (*signers.Signe
 	const q = `SELECT account_id FROM accounts WHERE alias=$1`
 	var accountID string
 	err := m.db.QueryRow(ctx, q, alias).Scan(&accountID)
-	if err == sql.ErrNoRows {
+	if err == stdsql.ErrNoRows {
 		return nil, errors.WithDetailf(pg.ErrUserInputNotFound, "alias: %s", alias)
 	}
 	if err != nil {
@@ -185,7 +197,7 @@ func (m *Manager) nextIndex(ctx context.Context) (uint64, error) {
 	return n, nil
 }
 
-func tagsToNullString(tags map[string]interface{}) (*sql.NullString, error) {
+func tagsToNullString(tags map[string]interface{}) (*stdsql.NullString, error) {
 	var tagsJSON []byte
 	if len(tags) != 0 {
 		var err error
@@ -194,5 +206,5 @@ func tagsToNullString(tags map[string]interface{}) (*sql.NullString, error) {
 			return nil, errors.Wrap(err)
 		}
 	}
-	return &sql.NullString{String: string(tagsJSON), Valid: len(tagsJSON) > 0}, nil
+	return &stdsql.NullString{String: string(tagsJSON), Valid: len(tagsJSON) > 0}, nil
 }

--- a/core/account/accounts_test.go
+++ b/core/account/accounts_test.go
@@ -17,7 +17,8 @@ import (
 var dummyXPub = testutil.TestXPub.String()
 
 func TestCreateAccount(t *testing.T) {
-	m := NewManager(pgtest.NewTx(t), prottest.NewChain(t))
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	m := NewManager(db, prottest.NewChain(t))
 	ctx := context.Background()
 
 	account, err := m.Create(ctx, []string{dummyXPub}, 1, "", nil, nil)
@@ -38,7 +39,8 @@ func TestCreateAccount(t *testing.T) {
 }
 
 func TestCreateAccountIdempotency(t *testing.T) {
-	m := NewManager(pgtest.NewTx(t), prottest.NewChain(t))
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	m := NewManager(db, prottest.NewChain(t))
 	ctx := context.Background()
 	var clientToken = "a-unique-client-token"
 
@@ -56,7 +58,8 @@ func TestCreateAccountIdempotency(t *testing.T) {
 }
 
 func TestCreateAccountReusedAlias(t *testing.T) {
-	m := NewManager(pgtest.NewTx(t), prottest.NewChain(t))
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	m := NewManager(db, prottest.NewChain(t))
 	ctx := context.Background()
 	m.createTestAccount(ctx, t, "some-account", nil)
 
@@ -115,7 +118,8 @@ func (m *Manager) createTestControlProgram(ctx context.Context, t testing.TB, ac
 }
 
 func TestFindByID(t *testing.T) {
-	m := NewManager(pgtest.NewTx(t), prottest.NewChain(t))
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	m := NewManager(db, prottest.NewChain(t))
 	ctx := context.Background()
 	account := m.createTestAccount(ctx, t, "", nil)
 
@@ -130,7 +134,8 @@ func TestFindByID(t *testing.T) {
 }
 
 func TestFindByAlias(t *testing.T) {
-	m := NewManager(pgtest.NewTx(t), prottest.NewChain(t))
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	m := NewManager(db, prottest.NewChain(t))
 	ctx := context.Background()
 	account := m.createTestAccount(ctx, t, "some-alias", nil)
 

--- a/core/account/annotate_test.go
+++ b/core/account/annotate_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestAnnotateTxs(t *testing.T) {
-	m := NewManager(pgtest.NewTx(t), prottest.NewChain(t))
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	m := NewManager(db, prottest.NewChain(t))
 	ctx := context.Background()
 	acc1 := m.createTestAccount(ctx, t, "", nil)
 	acc2 := m.createTestAccount(ctx, t, "", map[string]interface{}{"one": "foo", "two": "bar"})

--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -58,7 +58,7 @@ func (a *spendAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.
 	}
 	utxodbSources := []utxodb.Source{utxodbSource}
 	dbctx := pg.NewContext(ctx, a.accounts.db) // TODO(jackson): remove dbctx
-	reserved, change, err := utxodb.Reserve(dbctx, utxodbSources, maxTime)
+	reserved, change, err := a.accounts.utxoDB.Reserve(dbctx, utxodbSources, maxTime)
 	if err != nil {
 		return nil, errors.Wrap(err, "reserving utxos")
 	}
@@ -114,7 +114,7 @@ type spendUTXOAction struct {
 
 func (a *spendUTXOAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.BuildResult, error) {
 	dbctx := pg.NewContext(ctx, a.accounts.db) // TODO(jackson): remove dbctx
-	r, err := utxodb.ReserveUTXO(dbctx, a.TxHash, a.TxOut, a.ClientToken, maxTime)
+	r, err := a.accounts.utxoDB.ReserveUTXO(dbctx, a.TxHash, a.TxOut, a.ClientToken, maxTime)
 	if err != nil {
 		return nil, err
 	}

--- a/core/account/indexer_test.go
+++ b/core/account/indexer_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestLoadAccountInfo(t *testing.T) {
-	m := NewManager(pgtest.NewTx(t), prottest.NewChain(t))
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	m := NewManager(db, prottest.NewChain(t))
 	ctx := context.Background()
 
 	acc := m.createTestAccount(ctx, t, "", nil)
@@ -39,7 +40,8 @@ func TestLoadAccountInfo(t *testing.T) {
 }
 
 func TestDeleteUTXOs(t *testing.T) {
-	m := NewManager(pgtest.NewTx(t), prottest.NewChain(t))
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	m := NewManager(db, prottest.NewChain(t))
 	ctx := context.Background()
 
 	assetID := bc.AssetID{}


### PR DESCRIPTION
Unfortunately, this means a few tests need to use pgtest.NewDB
instead of pgtest.NewTx to satisfy the account.NewManager signature.