### PR TITLE
errors: add a field for arbitrary data

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,6 +15,7 @@ func New(text string) error {
 type wrapperError struct {
 	msg    string
 	detail []string
+	data   interface{}
 	stack  []StackFrame
 	root   error
 }
@@ -108,4 +109,25 @@ func WithDetailf(err error, format string, v ...interface{}) error {
 func Detail(err error) string {
 	wrapper, _ := err.(wrapperError)
 	return strings.Join(wrapper.detail, "; ")
+}
+
+// WithData returns a new error that wraps err
+// as a chain error message containing v as
+// an extra data item.
+// Calling Data on the returned error yields v.
+// Note that if err already has a data item,
+// it will not be accessible via the returned error value.
+func WithData(err error, v interface{}) error {
+	if err == nil {
+		return nil
+	}
+	e1 := wrap(err, "", 1).(wrapperError)
+	e1.data = v
+	return e1
+}
+
+// Data returns the data item in err, if any.
+func Data(err error) interface{} {
+	wrapper, _ := err.(wrapperError)
+	return wrapper.data
 }

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -96,3 +96,27 @@ func TestDetail(t *testing.T) {
 		}
 	}
 }
+
+func TestData(t *testing.T) {
+	root := errors.New("foo")
+	cases := []struct {
+		err  error
+		data interface{}
+	}{
+		{root, nil},
+		{WithData(root, 1), 1},
+		{WithData(root, map[string]string{"a": "b"}), map[string]string{"a": "b"}},
+		{WithData(root, "bar"), "bar"},
+		{WithData(WithData(root, "bar"), "baz"), "baz"},
+		{Wrap(WithData(root, "bar"), "baz"), "bar"},
+	}
+
+	for _, test := range cases {
+		if got := Data(test.err); !reflect.DeepEqual(got, test.data) {
+			t.Errorf("Data(%#v) = %v want %v", test.err, got, test.data)
+		}
+		if got := Root(test.err); got != root {
+			t.Errorf("Root(%#v) = %v want %v", test.err, got, root)
+		}
+	}
+}


### PR DESCRIPTION
We plan to use this to report more error detail to RPC clients in a structured format. The Detail functions provide only unstructured text.