### PR TITLE
cmd/testbot: fetch pull request instead of branch ref

### DIFF
--- a/cmd/testbot/main.go
+++ b/cmd/testbot/main.go
@@ -101,10 +101,11 @@ func prHandler(w http.ResponseWriter, r *http.Request) {
 					panic(req)
 				}
 			}
+			ref := fmt.Sprintf("%s/%s", remote, req.PR.Head.Ref)
 			runInNReport(sourcedir, &out, exec.Command("git", "fetch", remote), req)
 			runInNReport(sourcedir, &out, exec.Command("git", "clean", "-xdf"), req)
-			runInNReport(sourcedir, &out, exec.Command("git", "checkout", req.PR.Head.Ref, "--"), req)
-			runInNReport(sourcedir, &out, exec.Command("git", "reset", "--hard", fmt.Sprintf("%s/%s", remote, req.PR.Head.Ref)), req)
+			runInNReport(sourcedir, &out, exec.Command("git", "checkout", ref, "--"), req)
+			runInNReport(sourcedir, &out, exec.Command("git", "reset", "--hard", ref), req)
 			runInNReport(sourcedir, &out, exec.Command("sh", "docker/testbot/tests.sh"), req)
 			postToGithub(req.PR.StatusesURL, map[string]string{
 				"state":       "success",

--- a/cmd/testbot/main.go
+++ b/cmd/testbot/main.go
@@ -36,15 +36,8 @@ type pullRequest struct {
 	Action string
 	PR     struct {
 		Head struct {
-			Repo struct {
-				Name     string `json:"full_name"`
-				CloneURL string `json:"clone_url"`
-			}
 			Ref string
 			Sha string
-		}
-		User struct {
-			Login string
 		}
 		StatusesURL string `json:"statuses_url"`
 	} `json:"pull_request"`

--- a/cmd/testbot/main.go
+++ b/cmd/testbot/main.go
@@ -35,7 +35,8 @@ var (
 type pullRequest struct {
 	Action string
 	PR     struct {
-		Head struct {
+		Number string
+		Head   struct {
 			Ref string
 			Sha string
 		}
@@ -77,10 +78,9 @@ func prHandler(w http.ResponseWriter, r *http.Request) {
 			sha := req.PR.Head.Sha
 			defer uploadToS3(sha, &out)
 			defer catch(&out)
-			runIn(sourcedir, &out, exec.Command("git", "fetch", "origin"), req)
+			runIn(sourcedir, &out, exec.Command("git", "fetch", "origin", "pull/"+req.PR.Number+"/head"), req)
 			runIn(sourcedir, &out, exec.Command("git", "clean", "-xdf"), req)
 			runIn(sourcedir, &out, exec.Command("git", "checkout", sha, "--"), req)
-			runIn(sourcedir, &out, exec.Command("git", "reset", "--hard", sha), req)
 			runIn(sourcedir, &out, exec.Command("sh", "docker/testbot/tests.sh"), req)
 			postToGithub(req.PR.StatusesURL, map[string]string{
 				"state":       "success",


### PR DESCRIPTION
This fixes a bug that didn't allow testbot to run
against pull requests from forked repos.