### PR TITLE
core: use specific error code for non-unique alias

### DIFF
--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -16,12 +16,13 @@ import (
 	"chain/database/pg"
 	"chain/database/sql"
 	"chain/errors"
-	"chain/net/http/httpjson"
 	"chain/protocol"
 	"chain/protocol/vmutil"
 )
 
 const maxAccountCache = 100
+
+var ErrDuplicateAlias = errors.New("duplicate account alias")
 
 func NewManager(db *sql.DB, chain *protocol.Chain) *Manager {
 	return &Manager{
@@ -87,7 +88,7 @@ func (m *Manager) Create(ctx context.Context, xpubs []string, quorum int, alias 
 	`
 	_, err = m.db.Exec(ctx, q, signer.ID, aliasSQL, tagsParam)
 	if pg.IsUniqueViolation(err) {
-		return nil, errors.WithDetail(httpjson.ErrBadRequest, "non-unique alias")
+		return nil, errors.WithDetail(ErrDuplicateAlias, "an account with the provided alias already exists")
 	} else if err != nil {
 		return nil, errors.Wrap(err)
 	}

--- a/core/account/accounts_test.go
+++ b/core/account/accounts_test.go
@@ -8,7 +8,6 @@ import (
 
 	"chain/database/pg/pgtest"
 	"chain/errors"
-	"chain/net/http/httpjson"
 	"chain/protocol/prottest"
 	"chain/protocol/vm"
 	"chain/testutil"
@@ -64,8 +63,8 @@ func TestCreateAccountReusedAlias(t *testing.T) {
 	m.createTestAccount(ctx, t, "some-account", nil)
 
 	_, err := m.Create(ctx, []string{dummyXPub}, 1, "some-account", nil, nil)
-	if errors.Root(err) != httpjson.ErrBadRequest {
-		t.Errorf("Expected %s when reusing an alias, got %v", httpjson.ErrBadRequest, err)
+	if errors.Root(err) != ErrDuplicateAlias {
+		t.Errorf("Expected %s when reusing an alias, got %v", ErrDuplicateAlias, err)
 	}
 }
 

--- a/core/errors.go
+++ b/core/errors.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"chain/core/accesstoken"
+	"chain/core/account"
 	"chain/core/account/utxodb"
+	"chain/core/asset"
 	"chain/core/blocksigner"
 	"chain/core/mockhsm"
 	"chain/core/query"
@@ -12,6 +14,7 @@ import (
 	"chain/core/rpc"
 	"chain/core/signers"
 	"chain/core/txbuilder"
+	"chain/core/txfeed"
 	"chain/database/pg"
 	"chain/errors"
 	"chain/net/http/httpjson"
@@ -48,14 +51,18 @@ var (
 	// See chain.com/docs.
 	errorInfoTab = map[error]errorInfo{
 		// General error namespace (0xx)
-		context.DeadlineExceeded: errorInfo{408, "CH001", "Request timed out"},
-		pg.ErrUserInputNotFound:  errorInfo{400, "CH002", "Not found"},
-		httpjson.ErrBadRequest:   errorInfo{400, "CH003", "Invalid request body"},
-		errBadReqHeader:          errorInfo{400, "CH004", "Invalid request header"},
-		errNotFound:              errorInfo{404, "CH006", "Not found"},
-		errRateLimited:           errorInfo{429, "CH007", "Request limit exceeded"},
-		errLeaderElection:        errorInfo{503, "CH008", "Electing a new leader for the core; try again soon"},
-		errNotAuthenticated:      errorInfo{401, "CH009", "Request could not be authenticated"},
+		context.DeadlineExceeded:     errorInfo{408, "CH001", "Request timed out"},
+		pg.ErrUserInputNotFound:      errorInfo{400, "CH002", "Not found"},
+		httpjson.ErrBadRequest:       errorInfo{400, "CH003", "Invalid request body"},
+		errBadReqHeader:              errorInfo{400, "CH004", "Invalid request header"},
+		errNotFound:                  errorInfo{404, "CH006", "Not found"},
+		errRateLimited:               errorInfo{429, "CH007", "Request limit exceeded"},
+		errLeaderElection:            errorInfo{503, "CH008", "Electing a new leader for the core; try again soon"},
+		errNotAuthenticated:          errorInfo{401, "CH009", "Request could not be authenticated"},
+		asset.ErrDuplicateAlias:      errorInfo{400, "CH050", "Alias already exists"},
+		account.ErrDuplicateAlias:    errorInfo{400, "CH050", "Alias already exists"},
+		txfeed.ErrDuplicateAlias:     errorInfo{400, "CH050", "Alias already exists"},
+		mockhsm.ErrDuplicateKeyAlias: errorInfo{400, "CH050", "Alias already exists"},
 
 		// Core error namespace
 		errUnconfigured:                errorInfo{400, "CH100", "This core still needs to be configured"},
@@ -111,7 +118,6 @@ var (
 		utxodb.ErrReserved:     errorInfo{400, "CH761", "Some outputs are reserved; try again"},
 
 		// Mock HSM error namespace (80x)
-		mockhsm.ErrDuplicateKeyAlias:    errorInfo{400, "CH800", "Duplicate alias for Mock HSM key"},
 		mockhsm.ErrInvalidAfter:         errorInfo{400, "CH801", "Invalid `after` in query"},
 		mockhsm.ErrTooManyAliasesToList: errorInfo{400, "CH802", "Too many aliases to list"},
 	}

--- a/core/txfeed/txfeed.go
+++ b/core/txfeed/txfeed.go
@@ -8,8 +8,9 @@ import (
 	"chain/core/query/filter"
 	"chain/database/pg"
 	"chain/errors"
-	"chain/net/http/httpjson"
 )
+
+var ErrDuplicateAlias = errors.New("duplicate feed alias")
 
 type Tracker struct {
 	DB pg.DB
@@ -63,7 +64,7 @@ func insertTxFeed(ctx context.Context, db pg.DB, feed *TxFeed, clientToken *stri
 		clientToken).Scan(&feed.ID)
 
 	if pg.IsUniqueViolation(err) {
-		return nil, errors.WithDetail(httpjson.ErrBadRequest, "non-unique alias")
+		return nil, errors.WithDetail(ErrDuplicateAlias, "a transaction feed with the provided alias already exists")
 	} else if err == sql.ErrNoRows && clientToken != nil {
 		// There is already a txfeed with the provided client
 		// token. We should return the existing txfeed

--- a/core/txfeed/txfeed_test.go
+++ b/core/txfeed/txfeed_test.go
@@ -81,8 +81,8 @@ func TestInsertTxFeedDuplicateAlias(t *testing.T) {
 	}
 
 	_, err = insertTxFeed(ctx, db, feed, &token1)
-	if err.Error() != "non-unique alias: httpjson: bad request" {
-		t.Errorf("expected ErrBadRequest, got %v", err)
+	if errors.Root(err) != ErrDuplicateAlias {
+		t.Errorf("expected ErrDuplicateAlias, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Use a specific Chain error code for errors that try to create an object
with an alias that already exists. Previously, this error was bundled
under the generic bad request error code. It's useful to distinguish so
that clients can write get-or-create functions.

I'm not sure what the appropriate error namespace for this is.