### PR TITLE
docs/core: add 'release notes' page to docs

### DIFF
--- a/docs/core/reference/release-notes.md
+++ b/docs/core/reference/release-notes.md
@@ -1,0 +1,5 @@
+Release notes
+
+## Chain Core Developer Edition
+
+Release notes for Chain Core Developer Edition are available [here](https://github.com/chain/chain/blob/main/ReleaseNotes.md).

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -66,6 +66,7 @@
             <li><a href="/docs/core/reference/api-objects">API Objects</a></li>
             <li><a href="/docs/core/reference/product-roadmap">Product Roadmap</a></li>
             <li><a href="/docs/core/reference/license" class="skip-next-up">License</a></li>
+            <li><a href="/docs/core/reference/release-notes" class="skip-next-up">Release Notes</a></li>
           </ul>
         </li>
 


### PR DESCRIPTION
This commit adds a page to the docs with a link to the release notes for Chain Core Developer Edition on Github. In the future it may contain links to the Mac app release notes, or incorporate the content of those files rather than just linking to them.
