### PR TITLE
core/txbuilder: return error info for all actions

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -104,6 +104,7 @@ var (
 		errBadAction:            errorInfo{400, "CH703", "Invalid action object"},
 		txbuilder.ErrBadAmount:  errorInfo{400, "CH704", "Invalid asset amount"},
 		txbuilder.ErrBlankCheck: errorInfo{400, "CH705", "Unsafe transaction: leaves assets to be taken without requiring payment"},
+		txbuilder.ErrMulti:      errorInfo{400, "CH706", "Multiple errors: see attached data for each action"},
 
 		// Submit error namespace (73x)
 		txbuilder.ErrMissingRawTx:          errorInfo{400, "CH730", "Missing raw transaction"},
@@ -150,4 +151,14 @@ func errInfo(err error) (body detailedError, info errorInfo) {
 		Temporary: temporaryErrorCodes[info.ChainCode],
 	}
 	return body, info
+}
+
+// errInfoBodyList calls errInfo for each element in errs
+// and returns the "body".
+func errInfoBodyList(errs []error) (a []detailedError) {
+	for _, err := range errs {
+		body, _ := errInfo(err)
+		a = append(a, body)
+	}
+	return a
 }

--- a/core/errors.go
+++ b/core/errors.go
@@ -104,7 +104,7 @@ var (
 		errBadAction:            errorInfo{400, "CH703", "Invalid action object"},
 		txbuilder.ErrBadAmount:  errorInfo{400, "CH704", "Invalid asset amount"},
 		txbuilder.ErrBlankCheck: errorInfo{400, "CH705", "Unsafe transaction: leaves assets to be taken without requiring payment"},
-		txbuilder.ErrMulti:      errorInfo{400, "CH706", "Multiple errors: see attached data for each action"},
+		txbuilder.ErrAction:     errorInfo{400, "CH706", "One or more actions had an error: see attached data"},
 
 		// Submit error namespace (73x)
 		txbuilder.ErrMissingRawTx:          errorInfo{400, "CH730", "Missing raw transaction"},

--- a/core/transact.go
+++ b/core/transact.go
@@ -54,7 +54,7 @@ func (h *Handler) buildSingle(ctx context.Context, req *buildRequest) (*txbuilde
 	}
 	maxTime := time.Now().Add(ttl)
 	tpl, err := txbuilder.Build(ctx, req.Tx, actions, maxTime)
-	if errors.Root(err) == txbuilder.ErrMulti {
+	if errors.Root(err) == txbuilder.ErrAction {
 		err = errors.WithData(err, errInfoBodyList(errors.Data(err).([]error)))
 	}
 	if err != nil {

--- a/core/transact.go
+++ b/core/transact.go
@@ -54,6 +54,9 @@ func (h *Handler) buildSingle(ctx context.Context, req *buildRequest) (*txbuilde
 	}
 	maxTime := time.Now().Add(ttl)
 	tpl, err := txbuilder.Build(ctx, req.Tx, actions, maxTime)
+	if errors.Root(err) == txbuilder.ErrMulti {
+		err = errors.WithData(err, errInfoBodyList(errors.Data(err).([]error)))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -23,7 +23,7 @@ var (
 	ErrBadWitnessComponent = errors.New("invalid witness component")
 	ErrBadAmount           = errors.New("bad asset amount")
 	ErrBlankCheck          = errors.New("unsafe transaction: leaves assets free to control")
-	ErrMulti               = errors.New("errors occurred in more than one action")
+	ErrAction              = errors.New("errors occurred in one or more actions")
 )
 
 // Build builds or adds on to a transaction.
@@ -115,10 +115,8 @@ result:
 
 	}
 
-	if len(errs) > 1 {
-		return nil, errors.WithData(ErrMulti, errs)
-	} else if len(errs) == 1 {
-		return nil, errs[0]
+	if len(errs) > 0 {
+		return nil, errors.WithData(ErrAction, errs)
 	}
 
 	err := checkBlankCheck(tx)


### PR DESCRIPTION
It will be useful for clients to see all available error messages at once, so they can fix them all without having to make multiple requests.