### PR TITLE
sdk/java: support additional error details

### DIFF
--- a/docs/core/examples/java/BatchOperations.java
+++ b/docs/core/examples/java/BatchOperations.java
@@ -30,7 +30,7 @@ class BatchOperations {
     // endsnippet
 
     // snippet asset-create-batch
-    BatchResponse<Asset> assetBatch = Asset.createBatch(client, assetBuilders);
+    BatchResponse<Asset,APIException> assetBatch = Asset.createBatch(client, assetBuilders);
     // endsnippet
 
     // snippet asset-create-handle-errors
@@ -119,15 +119,15 @@ class BatchOperations {
     // endsnippet
 
     // snippet batch-build-handle-errors
-    BatchResponse<Transaction.Template> buildTxBatch = Transaction.buildBatch(client, txBuilders);
+    BatchResponse<Transaction.Template,BuildException> buildTxBatch = Transaction.buildBatch(client, txBuilders);
 
-    for(Map.Entry<Integer, APIException> err : buildTxBatch.errorsByIndex().entrySet()) {
+    for(Map.Entry<Integer, BuildException> err : buildTxBatch.errorsByIndex().entrySet()) {
       System.out.println("Error building transaction " + err.getKey() + ": " + err.getValue());
     }
     // endsnippet
 
     // snippet batch-sign
-    BatchResponse<Transaction.Template> signTxBatch = HsmSigner.signBatch(buildTxBatch.successes());
+    BatchResponse<Transaction.Template,APIException> signTxBatch = HsmSigner.signBatch(buildTxBatch.successes());
 
     for(Map.Entry<Integer, APIException> err : signTxBatch.errorsByIndex().entrySet()) {
       System.out.println("Error signing transaction " + err.getKey() + ": " + err.getValue());
@@ -135,7 +135,7 @@ class BatchOperations {
     // endsnippet
 
     // snippet batch-submit
-    BatchResponse<Transaction.SubmitResponse> submitTxBatch = Transaction.submitBatch(client, signTxBatch.successes());
+    BatchResponse<Transaction.SubmitResponse,APIException> submitTxBatch = Transaction.submitBatch(client, signTxBatch.successes());
 
     for(Map.Entry<Integer, APIException> err : submitTxBatch.errorsByIndex().entrySet()) {
       System.out.println("Error submitting transaction " + err.getKey() + ": " + err.getValue());

--- a/sdk/java/src/main/java/com/chain/api/Account.java
+++ b/sdk/java/src/main/java/com/chain/api/Account.java
@@ -75,12 +75,12 @@ public class Account {
    * @throws HTTPException This exception is raised when errors occur making http requests.
    * @throws JSONException This exception is raised due to malformed json requests or responses.
    */
-  public static BatchResponse<Account> createBatch(Client client, List<Builder> builders)
+  public static BatchResponse<Account,APIException> createBatch(Client client, List<Builder> builders)
       throws ChainException {
     for (Builder builder : builders) {
       builder.clientToken = UUID.randomUUID().toString();
     }
-    return client.batchRequest("create-account", builders, Account.class);
+    return client.batchRequest("create-account", builders, Account.class, APIException.class);
   }
 
   /**
@@ -175,7 +175,7 @@ public class Account {
      * @throws JSONException This exception is raised due to malformed json requests or responses.
      */
     public Account create(Client client) throws ChainException {
-      return client.singletonBatchRequest("create-account", Arrays.asList(this), Account.class);
+      return client.singletonBatchRequest("create-account", Arrays.asList(this), Account.class, APIException.class);
     }
 
     /**

--- a/sdk/java/src/main/java/com/chain/api/Asset.java
+++ b/sdk/java/src/main/java/com/chain/api/Asset.java
@@ -75,12 +75,12 @@ public class Asset {
    * @throws HTTPException This exception is raised when errors occur making http requests.
    * @throws JSONException This exception is raised due to malformed json requests or responses.
    */
-  public static BatchResponse<Asset> createBatch(Client client, List<Builder> builders)
+  public static BatchResponse<Asset,APIException> createBatch(Client client, List<Builder> builders)
       throws ChainException {
     for (Builder asset : builders) {
       asset.clientToken = UUID.randomUUID().toString();
     }
-    return client.batchRequest("create-asset", builders, Asset.class);
+    return client.batchRequest("create-asset", builders, Asset.class, APIException.class);
   }
 
   /**
@@ -205,7 +205,7 @@ public class Asset {
      * @throws JSONException This exception is raised due to malformed json requests or responses.
      */
     public Asset create(Client client) throws ChainException {
-      return client.singletonBatchRequest("create-asset", Arrays.asList(this), Asset.class);
+      return client.singletonBatchRequest("create-asset", Arrays.asList(this), Asset.class, APIException.class);
     }
 
     /**

--- a/sdk/java/src/main/java/com/chain/api/ControlProgram.java
+++ b/sdk/java/src/main/java/com/chain/api/ControlProgram.java
@@ -38,9 +38,9 @@ public class ControlProgram {
    * @throws HTTPException This exception is raised when errors occur making http requests.
    * @throws JSONException This exception is raised due to malformed json requests or responses.
    */
-  public static BatchResponse<ControlProgram> createBatch(Client client, List<Builder> programs)
+  public static BatchResponse<ControlProgram,APIException> createBatch(Client client, List<Builder> programs)
       throws ChainException {
-    return client.batchRequest("create-control-program", programs, ControlProgram.class);
+    return client.batchRequest("create-control-program", programs, ControlProgram.class, APIException.class);
   }
 
   /**
@@ -76,7 +76,7 @@ public class ControlProgram {
      */
     public ControlProgram create(Client client) throws ChainException {
       return client.singletonBatchRequest(
-          "create-control-program", Arrays.asList(this), ControlProgram.class);
+          "create-control-program", Arrays.asList(this), ControlProgram.class, APIException.class);
     }
 
     /**

--- a/sdk/java/src/main/java/com/chain/api/Transaction.java
+++ b/sdk/java/src/main/java/com/chain/api/Transaction.java
@@ -485,15 +485,15 @@ public class Transaction {
    * @param client client object which makes server requests
    * @param builders list of transaction builders
    * @return a list of transaction templates
-   * @throws APIException This exception is raised if the api returns errors while building transaction templates.
+   * @throws APIException This exception is raised if the api returns errors while processing the API request.
    * @throws BadURLException This exception wraps java.net.MalformedURLException.
    * @throws ConnectivityException This exception is raised if there are connectivity issues with the server.
    * @throws HTTPException This exception is raised when errors occur making http requests.
    * @throws JSONException This exception is raised due to malformed json requests or responses.
    */
-  public static BatchResponse<Template> buildBatch(
+  public static BatchResponse<Template,BuildException> buildBatch(
       Client client, List<Transaction.Builder> builders) throws ChainException {
-    return client.batchRequest("build-transaction", builders, Template.class);
+    return client.batchRequest("build-transaction", builders, Template.class, BuildException.class);
   }
 
   /**
@@ -507,11 +507,11 @@ public class Transaction {
    * @throws HTTPException This exception is raised when errors occur making http requests.
    * @throws JSONException This exception is raised due to malformed json requests or responses.
    */
-  public static BatchResponse<SubmitResponse> submitBatch(Client client, List<Template> templates)
+  public static BatchResponse<SubmitResponse,APIException> submitBatch(Client client, List<Template> templates)
       throws ChainException {
     HashMap<String, Object> body = new HashMap<>();
     body.put("transactions", templates);
-    return client.batchRequest("submit-transaction", body, SubmitResponse.class);
+    return client.batchRequest("submit-transaction", body, SubmitResponse.class, APIException.class);
   }
 
   /**
@@ -528,7 +528,7 @@ public class Transaction {
   public static SubmitResponse submit(Client client, Template template) throws ChainException {
     HashMap<String, Object> body = new HashMap<>();
     body.put("transactions", Arrays.asList(template));
-    return client.singletonBatchRequest("submit-transaction", body, SubmitResponse.class);
+    return client.singletonBatchRequest("submit-transaction", body, SubmitResponse.class, APIException.class);
   }
 
   /**
@@ -995,14 +995,15 @@ public class Transaction {
      * Builds a single transaction template.
      * @param client client object which makes requests to the server
      * @return a transaction template
-     * @throws APIException This exception is raised if the api returns errors while building the transaction.
+     * @throws BuildException This exception is raised if one or more actions error during building.
+     * @throws APIException This exception is raised if the api returns errors processing the request.
      * @throws BadURLException This exception wraps java.net.MalformedURLException.
      * @throws ConnectivityException This exception is raised if there are connectivity issues with the server.
      * @throws HTTPException This exception is raised when errors occur making http requests.
      * @throws JSONException This exception is raised due to malformed json requests or responses.
      */
     public Template build(Client client) throws ChainException {
-      return client.singletonBatchRequest("build-transaction", Arrays.asList(this), Template.class);
+      return client.singletonBatchRequest("build-transaction", Arrays.asList(this), Template.class, BuildException.class);
     }
 
     /**

--- a/sdk/java/src/main/java/com/chain/exception/APIException.java
+++ b/sdk/java/src/main/java/com/chain/exception/APIException.java
@@ -36,6 +36,10 @@ import com.google.gson.annotations.SerializedName;
  * CH700 - Reference data does not match previous transaction's reference data<br>
  * CH701 - Invalid action type<br>
  * CH702 - Invalid alias on action<br>
+ * CH703 - Invalid action object<br>
+ * CH704 - Invalid asset amount<br>
+ * CH705 - Unsafe transaction: leaves assets to be taken without requiring payment<br>
+ * CH706 - One or more actions had an error: see attached data<br>
  * CH730 - Missing raw transaction<br>
  * CH731 - Too many signing instructions in template for transaction<br>
  * CH732 - Invalid transaction input index<br>

--- a/sdk/java/src/main/java/com/chain/exception/BuildException.java
+++ b/sdk/java/src/main/java/com/chain/exception/BuildException.java
@@ -1,0 +1,40 @@
+package com.chain.exception;
+
+import java.util.List;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * BuildException wraps errors returned by the build-transaction endpoint.
+ */
+public class BuildException extends APIException {
+
+    public BuildException(String message, String requestId) {
+        super(message, requestId);
+    }
+
+    public static class ActionError extends APIException {
+
+        public static class Data {
+            /**
+             * The index of the action that caused this error.
+             */
+            @SerializedName("action_index")
+            public Integer index;
+        }
+
+        public ActionError(String message, String requestId) {
+            super(message, requestId);
+        }
+
+        /**
+         * Additional data pertaining to the error.
+         */
+        public Data data;
+    }
+
+    /**
+     * A list of errors resulting from building actions.
+     */
+    @SerializedName("data")
+    public List<ActionError> actionErrors;
+}

--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -139,16 +139,17 @@ public class Client {
    * @param action The requested API action
    * @param body Body payload sent to the API as JSON
    * @param tClass Type of object to be deserialized from the response JSON
+   * @param eClass Type of object to be deserialized from errors in the response JSON
    * @return the result of the post request
    * @throws ChainException
    */
-  public <T> BatchResponse<T> batchRequest(String action, Object body, Type tClass)
+  public <T,E extends APIException> BatchResponse<T,E> batchRequest(String action, Object body, Type tClass, Type eClass)
       throws ChainException {
     return post(
         action,
         body,
         (Response response, Gson deserializer) ->
-            new BatchResponse(response, deserializer, tClass));
+            new BatchResponse(response, deserializer, tClass, eClass));
   }
 
   /**
@@ -164,18 +165,19 @@ public class Client {
    * @param action The requested API action
    * @param body Body payload sent to the API as JSON
    * @param tClass Type of object to be deserialized from the repsonse JSON
+   * @param eClass Type of object to be deserialized from errors in the response JSON
    * @return the result of the post request
    * @throws ChainException
    */
-  public <T> T singletonBatchRequest(String action, Object body, Type tClass)
+  public <T,E extends APIException> T singletonBatchRequest(String action, Object body, Type tClass, Type eClass)
       throws ChainException {
     return post(
         action,
         body,
         (Response response, Gson deserializer) -> {
-          BatchResponse<T> batch = new BatchResponse(response, deserializer, tClass);
+          BatchResponse<T,E> batch = new BatchResponse(response, deserializer, tClass, eClass);
 
-          List<APIException> errors = batch.errors();
+          List<E> errors = batch.errors();
           if (errors.size() == 1) {
             // This throw must occur within this lambda in order for APIClient's
             // retry logic to take effect.

--- a/sdk/java/src/main/java/com/chain/signing/HsmSigner.java
+++ b/sdk/java/src/main/java/com/chain/signing/HsmSigner.java
@@ -66,7 +66,7 @@ public class HsmSigner {
       HashMap<String, Object> body = new HashMap();
       body.put("transactions", Arrays.asList(template));
       body.put("xpubs", entry.getValue());
-      template = hsm.singletonBatchRequest("sign-transaction", body, Transaction.Template.class);
+      template = hsm.singletonBatchRequest("sign-transaction", body, Transaction.Template.class, APIException.class);
     }
     return template;
   }
@@ -80,7 +80,7 @@ public class HsmSigner {
   // TODO(boymanjor): Currently this method trusts the hsm to return a tx template
   // in the event it is unable to sign it. Moving forward we should employ a filter
   // step and only send txs to the HSM that holds the proper key material to sign.
-  public static BatchResponse<Transaction.Template> signBatch(List<Transaction.Template> tmpls)
+  public static BatchResponse<Transaction.Template,APIException> signBatch(List<Transaction.Template> tmpls)
       throws ChainException {
     int[] originalIndex = new int[tmpls.size()];
     for (int i = 0; i < tmpls.size(); i++) {
@@ -94,8 +94,8 @@ public class HsmSigner {
       HashMap<String, Object> requestBody = new HashMap();
       requestBody.put("transactions", tmpls);
       requestBody.put("xpubs", entry.getValue());
-      BatchResponse<Transaction.Template> batch =
-          hsm.batchRequest("sign-transaction", requestBody, Transaction.Template.class);
+      BatchResponse<Transaction.Template,APIException> batch =
+          hsm.batchRequest("sign-transaction", requestBody, Transaction.Template.class, APIException.class);
 
       // We need to work towards a single, final BatchResponse that uses the
       // original indexes. For the next cycle, we should retain only those

--- a/sdk/java/src/test/java/com/chain/integration/CreateTest.java
+++ b/sdk/java/src/test/java/com/chain/integration/CreateTest.java
@@ -99,7 +99,7 @@ public class CreateTest {
     Account.Builder failure =
         new Account.Builder().setAlias(alice).addRootXpub(key.xpub).setQuorum(1);
 
-    BatchResponse<Account> resp = Account.createBatch(client, Arrays.asList(builder, failure));
+    BatchResponse<Account,APIException> resp = Account.createBatch(client, Arrays.asList(builder, failure));
     assertEquals(1, resp.successes().size());
     assertEquals(1, resp.errors().size());
   }
@@ -161,7 +161,7 @@ public class CreateTest {
 
     Asset.Builder failure = new Asset.Builder().setAlias(asset).addRootXpub(key.xpub).setQuorum(1);
 
-    BatchResponse<Asset> resp = Asset.createBatch(client, Arrays.asList(builder, failure));
+    BatchResponse<Asset,APIException> resp = Asset.createBatch(client, Arrays.asList(builder, failure));
     assertEquals(1, resp.successes().size());
     assertEquals(1, resp.errors().size());
   }
@@ -210,7 +210,7 @@ public class CreateTest {
 
     ControlProgram.Builder failure = new ControlProgram.Builder().controlWithAccountById("bad-id");
 
-    BatchResponse<ControlProgram> resp =
+    BatchResponse<ControlProgram,APIException> resp =
         ControlProgram.createBatch(client, Arrays.asList(builder, failure));
     assertEquals(1, resp.successes().size());
     assertEquals(1, resp.errors().size());

--- a/sdk/java/src/test/java/com/chain/integration/TransactionTest.java
+++ b/sdk/java/src/test/java/com/chain/integration/TransactionTest.java
@@ -9,6 +9,8 @@ import com.chain.api.MockHsm;
 import com.chain.api.PagedItems;
 import com.chain.api.Transaction;
 import com.chain.api.UnspentOutput;
+import com.chain.exception.APIException;
+import com.chain.exception.BuildException;
 import com.chain.http.BatchResponse;
 import com.chain.http.Client;
 import com.chain.signing.HsmSigner;
@@ -298,17 +300,17 @@ public class TransactionTest {
             .addAction(
                 new Transaction.Action.SetTransactionReferenceData()
                     .addReferenceDataField("test", test));
-    BatchResponse<Transaction.Template> buildResponses =
+    BatchResponse<Transaction.Template,BuildException> buildResponses =
         Transaction.buildBatch(client, Arrays.asList(aliceBuilder, bobTheBuilder));
     assertEquals(2, buildResponses.successes().size());
 
-    BatchResponse<Transaction.Template> signResponses =
+    BatchResponse<Transaction.Template,APIException> signResponses =
         HsmSigner.signBatch(
             Arrays.asList(buildResponses.successes().get(0), new Transaction.Template()));
     List<Transaction.Template> templates = signResponses.successes();
     templates.add(buildResponses.successes().get(1));
 
-    BatchResponse<Transaction.SubmitResponse> submitResponses =
+    BatchResponse<Transaction.SubmitResponse,APIException> submitResponses =
         Transaction.submitBatch(client, templates);
     assertNotNull(signResponses.errors().get(0));
     assertEquals(2, submitResponses.size());


### PR DESCRIPTION
In 411d336 we changed the response of the build endpoint. Errors when
building actions now result in a CH706 error. Additional error details
per-action are included on a nested `data` key. This adds support for
this in the SDK by adding a BuildException class and parameterizing
BatchResponse.