### PR TITLE
sdk/java: add BuildException for build errors

### DIFF
--- a/sdk/java/src/main/java/com/chain/api/Account.java
+++ b/sdk/java/src/main/java/com/chain/api/Account.java
@@ -80,7 +80,7 @@ public class Account {
     for (Builder builder : builders) {
       builder.clientToken = UUID.randomUUID().toString();
     }
-    return client.batchRequest("create-account", builders, Account.class);
+    return client.batchRequest("create-account", builders, Account.class, APIException.class);
   }
 
   /**
@@ -175,7 +175,7 @@ public class Account {
      * @throws JSONException This exception is raised due to malformed json requests or responses.
      */
     public Account create(Client client) throws ChainException {
-      return client.singletonBatchRequest("create-account", Arrays.asList(this), Account.class);
+      return client.singletonBatchRequest("create-account", Arrays.asList(this), Account.class, APIException.class);
     }
 
     /**

--- a/sdk/java/src/main/java/com/chain/api/Asset.java
+++ b/sdk/java/src/main/java/com/chain/api/Asset.java
@@ -80,7 +80,7 @@ public class Asset {
     for (Builder asset : builders) {
       asset.clientToken = UUID.randomUUID().toString();
     }
-    return client.batchRequest("create-asset", builders, Asset.class);
+    return client.batchRequest("create-asset", builders, Asset.class, APIException.class);
   }
 
   /**
@@ -205,7 +205,7 @@ public class Asset {
      * @throws JSONException This exception is raised due to malformed json requests or responses.
      */
     public Asset create(Client client) throws ChainException {
-      return client.singletonBatchRequest("create-asset", Arrays.asList(this), Asset.class);
+      return client.singletonBatchRequest("create-asset", Arrays.asList(this), Asset.class, APIException.class);
     }
 
     /**

--- a/sdk/java/src/main/java/com/chain/api/ControlProgram.java
+++ b/sdk/java/src/main/java/com/chain/api/ControlProgram.java
@@ -40,7 +40,7 @@ public class ControlProgram {
    */
   public static BatchResponse<ControlProgram> createBatch(Client client, List<Builder> programs)
       throws ChainException {
-    return client.batchRequest("create-control-program", programs, ControlProgram.class);
+    return client.batchRequest("create-control-program", programs, ControlProgram.class, APIException.class);
   }
 
   /**
@@ -76,7 +76,7 @@ public class ControlProgram {
      */
     public ControlProgram create(Client client) throws ChainException {
       return client.singletonBatchRequest(
-          "create-control-program", Arrays.asList(this), ControlProgram.class);
+          "create-control-program", Arrays.asList(this), ControlProgram.class, APIException.class);
     }
 
     /**

--- a/sdk/java/src/main/java/com/chain/api/Transaction.java
+++ b/sdk/java/src/main/java/com/chain/api/Transaction.java
@@ -493,7 +493,7 @@ public class Transaction {
    */
   public static BatchResponse<Template> buildBatch(
       Client client, List<Transaction.Builder> builders) throws ChainException {
-    return client.batchRequest("build-transaction", builders, Template.class);
+    return client.batchRequest("build-transaction", builders, Template.class, BuildException.class);
   }
 
   /**
@@ -511,7 +511,7 @@ public class Transaction {
       throws ChainException {
     HashMap<String, Object> body = new HashMap<>();
     body.put("transactions", templates);
-    return client.batchRequest("submit-transaction", body, SubmitResponse.class);
+    return client.batchRequest("submit-transaction", body, SubmitResponse.class, APIException.class);
   }
 
   /**
@@ -528,7 +528,7 @@ public class Transaction {
   public static SubmitResponse submit(Client client, Template template) throws ChainException {
     HashMap<String, Object> body = new HashMap<>();
     body.put("transactions", Arrays.asList(template));
-    return client.singletonBatchRequest("submit-transaction", body, SubmitResponse.class);
+    return client.singletonBatchRequest("submit-transaction", body, SubmitResponse.class, APIException.class);
   }
 
   /**
@@ -1002,7 +1002,7 @@ public class Transaction {
      * @throws JSONException This exception is raised due to malformed json requests or responses.
      */
     public Template build(Client client) throws ChainException {
-      return client.singletonBatchRequest("build-transaction", Arrays.asList(this), Template.class);
+      return client.singletonBatchRequest("build-transaction", Arrays.asList(this), Template.class, BuildException.class);
     }
 
     /**

--- a/sdk/java/src/main/java/com/chain/exception/BuildException.java
+++ b/sdk/java/src/main/java/com/chain/exception/BuildException.java
@@ -1,0 +1,40 @@
+package com.chain.exception;
+
+import java.util.List;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * BuildException wraps errors returned by the build-transaction endpoint.
+ */
+public class BuildException extends APIException {
+
+    public BuildException(String message, String requestId) {
+        super(message, requestId);
+    }
+
+    public static class ActionError extends APIException {
+
+        public static class Data {
+            /**
+             * The index of the action that caused this error.
+             */
+            @SerializedName("action_index")
+            public Integer index;
+        }
+
+        public ActionError(String message, String requestId) {
+            super(message, requestId);
+        }
+
+        /**
+         * Additional data pertaining to the error.
+         */
+        public Data data;
+    }
+
+    /**
+     * A list of errors resulting from building actions.
+     */
+    @SerializedName("data")
+    public List<ActionError> actionErrors;
+}

--- a/sdk/java/src/main/java/com/chain/http/BatchResponse.java
+++ b/sdk/java/src/main/java/com/chain/http/BatchResponse.java
@@ -24,7 +24,7 @@ public class BatchResponse<T> {
   /**
    * This constructor is used when deserializing a response from an API call.
    */
-  public BatchResponse(Response response, Gson serializer, Type tClass)
+  public BatchResponse(Response response, Gson serializer, Type tClass, Type eClass)
       throws ChainException, IOException {
     this.response = response;
 
@@ -34,7 +34,7 @@ public class BatchResponse<T> {
         JsonElement elem = root.get(i);
 
         // Test for interleaved errors
-        APIException err = serializer.fromJson(elem, APIException.class);
+        APIException err = serializer.fromJson(elem, eClass);
         if (err.code != null) {
           errorsByIndex.put(i, err);
           continue;

--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -139,16 +139,17 @@ public class Client {
    * @param action The requested API action
    * @param body Body payload sent to the API as JSON
    * @param tClass Type of object to be deserialized from the response JSON
+   * @param eClass Type of error object to be deserialized from the response JSON
    * @return the result of the post request
    * @throws ChainException
    */
-  public <T> BatchResponse<T> batchRequest(String action, Object body, Type tClass)
+  public <T> BatchResponse<T> batchRequest(String action, Object body, Type tClass, Type eClass)
       throws ChainException {
     return post(
         action,
         body,
         (Response response, Gson deserializer) ->
-            new BatchResponse(response, deserializer, tClass));
+            new BatchResponse(response, deserializer, tClass, eClass));
   }
 
   /**
@@ -167,13 +168,13 @@ public class Client {
    * @return the result of the post request
    * @throws ChainException
    */
-  public <T> T singletonBatchRequest(String action, Object body, Type tClass)
+  public <T> T singletonBatchRequest(String action, Object body, Type tClass, Type eClass)
       throws ChainException {
     return post(
         action,
         body,
         (Response response, Gson deserializer) -> {
-          BatchResponse<T> batch = new BatchResponse(response, deserializer, tClass);
+          BatchResponse<T> batch = new BatchResponse(response, deserializer, tClass, eClass);
 
           List<APIException> errors = batch.errors();
           if (errors.size() == 1) {

--- a/sdk/java/src/main/java/com/chain/signing/HsmSigner.java
+++ b/sdk/java/src/main/java/com/chain/signing/HsmSigner.java
@@ -66,7 +66,7 @@ public class HsmSigner {
       HashMap<String, Object> body = new HashMap();
       body.put("transactions", Arrays.asList(template));
       body.put("xpubs", entry.getValue());
-      template = hsm.singletonBatchRequest("sign-transaction", body, Transaction.Template.class);
+      template = hsm.singletonBatchRequest("sign-transaction", body, Transaction.Template.class, APIException.class);
     }
     return template;
   }
@@ -95,7 +95,7 @@ public class HsmSigner {
       requestBody.put("transactions", tmpls);
       requestBody.put("xpubs", entry.getValue());
       BatchResponse<Transaction.Template> batch =
-          hsm.batchRequest("sign-transaction", requestBody, Transaction.Template.class);
+          hsm.batchRequest("sign-transaction", requestBody, Transaction.Template.class, APIException.class);
 
       // We need to work towards a single, final BatchResponse that uses the
       // original indexes. For the next cycle, we should retain only those


### PR DESCRIPTION
Unmarshal build errors into BuildException instead of APIException.
Clients will need to use instanceof and cast build errors to
BuildException if using the batch endpoint.