### PR TITLE
core/txbuilder: roll back builder side-effects

### DIFF
--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -57,10 +57,12 @@ func (a *spendAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.
 		ClientToken: a.ClientToken,
 	}
 	utxodbSources := []utxodb.Source{utxodbSource}
-	reserved, change, err := a.accounts.utxoDB.Reserve(ctx, utxodbSources, maxTime)
+	// TODO(kr): make utxodb.Reserve tkae a single Source not a slice
+	rids, reserved, change, err := a.accounts.utxoDB.Reserve(ctx, utxodbSources, maxTime)
 	if err != nil {
 		return nil, errors.Wrap(err, "reserving utxos")
 	}
+	rid := rids[0] // len(rids)==len(utxodbSources)
 
 	var (
 		txins      []*bc.TxInput
@@ -89,7 +91,7 @@ func (a *spendAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.
 		Inputs:              txins,
 		Outputs:             changeOuts,
 		SigningInstructions: tplInsts,
-		Rollback:            canceler(ctx, a.accounts, reserved...),
+		Rollback:            canceler(ctx, a.accounts, rid),
 	}
 	return br, nil
 }
@@ -118,7 +120,7 @@ type spendUTXOAction struct {
 }
 
 func (a *spendUTXOAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.BuildResult, error) {
-	r, err := a.accounts.utxoDB.ReserveUTXO(ctx, a.TxHash, a.TxOut, a.ClientToken, maxTime)
+	rid, r, err := a.accounts.utxoDB.ReserveUTXO(ctx, a.TxHash, a.TxOut, a.ClientToken, maxTime)
 	if err != nil {
 		return nil, err
 	}
@@ -136,19 +138,14 @@ func (a *spendUTXOAction) Build(ctx context.Context, maxTime time.Time) (*txbuil
 	return &txbuilder.BuildResult{
 		Inputs:              []*bc.TxInput{txInput},
 		SigningInstructions: []*txbuilder.SigningInstruction{sigInst},
-		Rollback:            canceler(ctx, a.accounts, r),
+		Rollback:            canceler(ctx, a.accounts, rid),
 	}, nil
 }
 
 // Best-effort cancellation attempt to put in txbuilder.BuildResult.Rollback.
-func canceler(ctx context.Context, m *Manager, utxos ...*utxodb.UTXO) func() {
+func canceler(ctx context.Context, m *Manager, rid int32) func() {
 	return func() {
-		var o []bc.Outpoint
-		for _, utxo := range utxos {
-			o = append(o, utxo.Outpoint)
-		}
-
-		err := m.utxoDB.Cancel(ctx, o)
+		err := m.utxoDB.Cancel(ctx, rid)
 		if err != nil {
 			log.Error(ctx, err)
 		}

--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -57,7 +57,7 @@ func (a *spendAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.
 		ClientToken: a.ClientToken,
 	}
 	utxodbSources := []utxodb.Source{utxodbSource}
-	// TODO(kr): make utxodb.Reserve tkae a single Source not a slice
+	// TODO(kr): make utxodb.Reserve take a single Source not a slice
 	rids, reserved, change, err := a.accounts.utxoDB.Reserve(ctx, utxodbSources, maxTime)
 	if err != nil {
 		return nil, errors.Wrap(err, "reserving utxos")

--- a/core/account/utxodb/reserve.go
+++ b/core/account/utxodb/reserve.go
@@ -261,6 +261,29 @@ func (res *Reserver) Reserve(ctx context.Context, sources []Source, exp time.Tim
 	return reserved, change, err
 }
 
+// Cancel cancels the given reservations, if they still exist.
+// If any do not exist (if they've already been consumed
+// or canceled), it silently ignores them.
+func (res *Reserver) Cancel(ctx context.Context, outpoints []bc.Outpoint) error {
+	txHashes := make([]string, 0, len(outpoints))
+	indexes := make([]uint32, 0, len(outpoints))
+	for _, outpoint := range outpoints {
+		txHashes = append(txHashes, outpoint.Hash.String())
+		indexes = append(indexes, outpoint.Index)
+	}
+
+	const query = `
+		WITH reservation_ids AS (
+		    SELECT DISTINCT reservation_id FROM account_utxos
+		        WHERE (tx_hash, index) IN (SELECT unnest($1::text[]), unnest($2::bigint[]))
+		)
+		SELECT cancel_reservation(reservation_id) FROM reservation_ids
+	`
+
+	_, err := res.DB.Exec(ctx, query, pq.StringArray(txHashes), pg.Uint32s(indexes))
+	return err
+}
+
 // ExpireReservations is meant to be run as a goroutine. It loops,
 // calling the expire_reservations() pl/pgsql function to
 // remove expired reservations from the reservations table.

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -77,6 +77,14 @@ type (
 		SigningInstructions []*SigningInstruction
 		MinTimeMS           uint64
 		ReferenceData       []byte
+
+		// If set, Rollback attempts to undo any side effects
+		// of building the action. For example, it might cancel
+		// any reservations that were made on UTXOs in a spend
+		// action. Rollback is a "best-effort" operation and not
+		// guaranteed to succeed. Each action's side effects,
+		// if any, must be designed with this in mind.
+		Rollback func()
 	}
 
 	Action interface {


### PR DESCRIPTION
If one action succeeds with some side effects (most
notably, reserving some UTXOs) and another action fails,
we should roll back the side effects if possible so that
the overall operation has no effect.

Note that this is not a guaranteed operation, so any
side effects need to be designed to be safe not to roll
back. Reservations are: they will eventually expire on
their own. Meanwhile, it helps performance to eagerly
cancel them upon failure rather than waiting for the
deadline to pass.