### PR TITLE
encoding/json: treat null as zero-value duration

### DIFF
--- a/encoding/json/duration.go
+++ b/encoding/json/duration.go
@@ -1,6 +1,7 @@
 package json
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"strconv"
@@ -19,6 +20,10 @@ type Duration struct {
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h").
 // If there is no time unit, UnmarshalJSON defaults to ms.
 func (d *Duration) UnmarshalJSON(b []byte) error {
+	if bytes.Equal(b, []byte("null")) {
+		return nil
+	}
+
 	dMS, err := strconv.ParseInt(string(b), 10, 64)
 	if err != nil {
 		// Assume this is a string instead, in which case we need to unmarshal it as a string

--- a/encoding/json/duration_test.go
+++ b/encoding/json/duration_test.go
@@ -41,6 +41,17 @@ func TestUnmarshalDuration(t *testing.T) {
 			t.Errorf("wanted error %s, got %s", wantErr, err)
 		}
 	}
+
+	// Null case
+	var dur Duration
+	err := json.Unmarshal([]byte("null"), &dur)
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if dur.Duration != 0 {
+		t.Errorf(`Duration.UnmarshalJSON("null") = %v want 0`, dur.Duration)
+	}
 }
 
 func TestMarshalDuration(t *testing.T) {


### PR DESCRIPTION
When deserializing API request objects, it's useful to treat null
the same as undefined. This is especially convenient for
high-level languages, where it is common to assign values to
key-value objects that may or may not be null.