### PR TITLE
core/account: always lock the account_utxos table

### DIFF
--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -36,7 +36,7 @@ func NewManager(db *sql.DB, chain *protocol.Chain) *Manager {
 
 // Manager stores accounts and their associated control programs.
 type Manager struct {
-	db      pg.DB
+	db      *sql.DB
 	chain   *protocol.Chain
 	utxoDB  *utxodb.DBReserver
 	indexer Saver


### PR DESCRIPTION
We were writing to the `account_utxos` table during indexing without locking it, but that table requires locking. It probably led to deadlock in a recent test run.