### PR TITLE
core: up max request size to 1mb

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -79,7 +79,7 @@ type RequestLimit struct {
 }
 
 func maxBytes(h http.Handler) http.Handler {
-	const maxReqSize = 1e5 // 100kB
+	const maxReqSize = 1e7 // 10mb
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// A block can easily be bigger than maxReqSize, but everything
 		// else should be pretty small.

--- a/core/api.go
+++ b/core/api.go
@@ -79,7 +79,7 @@ type RequestLimit struct {
 }
 
 func maxBytes(h http.Handler) http.Handler {
-	const maxReqSize = 1e6 // 1mb
+	const maxReqSize = 1e6 // 1MB
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// A block can easily be bigger than maxReqSize, but everything
 		// else should be pretty small.

--- a/core/api.go
+++ b/core/api.go
@@ -79,7 +79,7 @@ type RequestLimit struct {
 }
 
 func maxBytes(h http.Handler) http.Handler {
-	const maxReqSize = 1e7 // 10mb
+	const maxReqSize = 1e6 // 1mb
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// A block can easily be bigger than maxReqSize, but everything
 		// else should be pretty small.


### PR DESCRIPTION
If UTXOs are fragmented, sign transaction requests (and maybe submit requests too) can exceed the current 100kb request body limit.