### PR TITLE
cmd/benchcore: make a filesystem

### DIFF
--- a/cmd/benchcore/main.go
+++ b/cmd/benchcore/main.go
@@ -699,6 +699,7 @@ sudo bash <<EOFSUDO
 set -eo pipefail
 apt-get update -qq
 mkdir -p /var/lib/postgresql
+mkfs -t ext4 /dev/xvdb
 mount /dev/xvdb /var/lib/postgresql/
 apt-get install -y -qq postgresql-9.5 postgresql-client-9.5
 


### PR DESCRIPTION
Apparently EBS volumes come "blank" with no filesystem.