### PR TITLE
protocol: WaitForBlock funcs return chans

### DIFF
--- a/core/blocksigner/blocksigner.go
+++ b/core/blocksigner/blocksigner.go
@@ -65,7 +65,12 @@ func (s *Signer) String() string {
 // This function fails if this node has ever signed a different block at the
 // same height as b.
 func (s *Signer) ValidateAndSignBlock(ctx context.Context, b *bc.Block) ([]byte, error) {
-	err := s.c.WaitForBlockSoon(ctx, b.Height-1)
+	var err error
+	select {
+	case err = <-s.c.WaitForBlockSoon(b.Height - 1):
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "waiting for block at height %d", b.Height-1)
 	}

--- a/core/blocksigner/blocksigner.go
+++ b/core/blocksigner/blocksigner.go
@@ -65,12 +65,7 @@ func (s *Signer) String() string {
 // This function fails if this node has ever signed a different block at the
 // same height as b.
 func (s *Signer) ValidateAndSignBlock(ctx context.Context, b *bc.Block) ([]byte, error) {
-	var err error
-	select {
-	case err = <-s.c.WaitForBlockSoon(b.Height - 1):
-	case <-ctx.Done():
-		err = ctx.Err()
-	}
+	err := <-s.c.WaitForBlockSoon(ctx, b.Height-1)
 	if err != nil {
 		return nil, errors.Wrapf(err, "waiting for block at height %d", b.Height-1)
 	}

--- a/core/generator/generator_test.go
+++ b/core/generator/generator_test.go
@@ -40,7 +40,7 @@ func TestGeneratorRecovery(t *testing.T) {
 
 	// Wait for the block to land, and then make sure it's the same block
 	// that was pending before we ran Generate.
-	c.WaitForBlock(pendingBlock.Height)
+	<-c.WaitForBlock(pendingBlock.Height)
 	confirmedBlock, err := c.GetBlock(ctx, pendingBlock.Height)
 	if err != nil {
 		testutil.FatalErr(t, err)

--- a/core/query/transactions.go
+++ b/core/query/transactions.go
@@ -164,7 +164,11 @@ func (ind *Indexer) waitForAndFetchTransactions(ctx context.Context, queryStr st
 		)
 
 		for h := ind.c.Height(); len(txs) == 0; h++ {
-			err = ind.c.WaitForBlockSoon(ctx, h)
+			select {
+			case err = <-ind.c.WaitForBlockSoon(h):
+			case <-ctx.Done():
+				err = ctx.Err()
+			}
 			if err != nil {
 				resp <- fetchResp{nil, nil, err}
 				return

--- a/core/query/transactions.go
+++ b/core/query/transactions.go
@@ -164,11 +164,7 @@ func (ind *Indexer) waitForAndFetchTransactions(ctx context.Context, queryStr st
 		)
 
 		for h := ind.c.Height(); len(txs) == 0; h++ {
-			select {
-			case err = <-ind.c.WaitForBlockSoon(h):
-			case <-ctx.Done():
-				err = ctx.Err()
-			}
+			err = <-ind.c.WaitForBlockSoon(ctx, h)
 			if err != nil {
 				resp <- fetchResp{nil, nil, err}
 				return

--- a/core/rpc.go
+++ b/core/rpc.go
@@ -16,12 +16,7 @@ import (
 // waiting if necessary until one is created.
 // It is an error to request blocks very far in the future.
 func (h *Handler) getBlockRPC(ctx context.Context, height uint64) (chainjson.HexBytes, error) {
-	var err error
-	select {
-	case err = <-h.Chain.WaitForBlockSoon(height):
-	case <-ctx.Done():
-		err = ctx.Err()
-	}
+	err := <-h.Chain.WaitForBlockSoon(ctx, height)
 	if err != nil {
 		return nil, errors.Wrapf(err, "waiting for block at height %d", height)
 	}

--- a/core/rpc.go
+++ b/core/rpc.go
@@ -16,7 +16,12 @@ import (
 // waiting if necessary until one is created.
 // It is an error to request blocks very far in the future.
 func (h *Handler) getBlockRPC(ctx context.Context, height uint64) (chainjson.HexBytes, error) {
-	err := h.Chain.WaitForBlockSoon(ctx, height)
+	var err error
+	select {
+	case err = <-h.Chain.WaitForBlockSoon(height):
+	case <-ctx.Done():
+		err = ctx.Err()
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "waiting for block at height %d", height)
 	}

--- a/core/transact.go
+++ b/core/transact.go
@@ -214,7 +214,7 @@ func (h *Handler) finalizeTxWait(ctx context.Context, c *protocol.Chain, txTempl
 		case <-ctx.Done():
 			return ctx.Err()
 
-		case <-waitBlock(ctx, c, height):
+		case <-c.WaitForBlock(height):
 			b, err := c.GetBlock(ctx, height)
 			if err != nil {
 				return errors.Wrap(err, "getting block that just landed")
@@ -243,15 +243,6 @@ func (h *Handler) finalizeTxWait(ctx context.Context, c *protocol.Chain, txTempl
 			// the tx's blockchain prevouts still exist in the state tree.
 		}
 	}
-}
-
-func waitBlock(ctx context.Context, c *protocol.Chain, height uint64) <-chan struct{} {
-	done := make(chan struct{}, 1)
-	go func() {
-		c.WaitForBlock(height)
-		done <- struct{}{}
-	}()
-	return done
 }
 
 type submitArg struct {

--- a/core/txbuilder/finalize.go
+++ b/core/txbuilder/finalize.go
@@ -48,7 +48,7 @@ func publishTx(ctx context.Context, c *protocol.Chain, msg *bc.Tx) error {
 
 	// Make sure there is at least one block in case client is trying to
 	// finalize a tx before the initial block has landed
-	c.WaitForBlock(1)
+	<-c.WaitForBlock(1)
 
 	if Generator != nil {
 		// If this transaction is valid, ValidateTxCached will store it in the cache.

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -70,7 +70,7 @@ func TestWaitForBlockSoonAlreadyExists(t *testing.T) {
 	makeEmptyBlock(t, c) // height=2
 	makeEmptyBlock(t, c) // height=3
 
-	err := c.WaitForBlockSoon(context.Background(), 2)
+	err := <-c.WaitForBlockSoon(2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestWaitForBlockSoonAlreadyExists(t *testing.T) {
 func TestWaitForBlockSoonDistantFuture(t *testing.T) {
 	c, _ := newTestChain(t, time.Now())
 
-	got := c.WaitForBlockSoon(context.Background(), 100) // distant future
+	got := <-c.WaitForBlockSoon(100) // distant future
 	want := ErrTheDistantFuture
 	if got != want {
 		t.Errorf("WaitForBlockSoon(100) = %+v want %+v", got, want)
@@ -103,27 +103,12 @@ func TestWaitForBlockSoonWaits(t *testing.T) {
 		makeEmptyBlock(t, c)              // height=3
 	}()
 
-	err := c.WaitForBlockSoon(context.Background(), 3)
+	err := <-c.WaitForBlockSoon(3)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if g := c.Height(); g != 3 {
 		t.Errorf("height after waiting = %d want 3", g)
-	}
-}
-
-func TestWaitForBlockSoonTimesout(t *testing.T) {
-	c, _ := newTestChain(t, time.Now())
-	go func() {
-		makeEmptyBlock(t, c) // height=2
-	}()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
-
-	err := c.WaitForBlockSoon(ctx, 3)
-	if err != ctx.Err() {
-		t.Fatalf("expected timeout err, got %v", err)
 	}
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -213,8 +213,8 @@ func (c *Chain) AddBlockCallback(f BlockCallback) {
 // but it is an error to wait for a block far in the future.
 // WaitForBlockSoon will timeout if the context times out.
 // To wait unconditionally, the caller should use WaitForBlock.
-func (c *Chain) WaitForBlockSoon(ctx context.Context, height uint64) chan error {
-	ch := make(chan error)
+func (c *Chain) WaitForBlockSoon(ctx context.Context, height uint64) <-chan error {
+	ch := make(chan error, 1)
 
 	go func() {
 		const slop = 3
@@ -236,8 +236,8 @@ func (c *Chain) WaitForBlockSoon(ctx context.Context, height uint64) chan error 
 
 // WaitForBlock returns a channel that
 // waits for the block at the given height.
-func (c *Chain) WaitForBlock(height uint64) chan struct{} {
-	ch := make(chan struct{})
+func (c *Chain) WaitForBlock(height uint64) <-chan struct{} {
+	ch := make(chan struct{}, 1)
 	go func() {
 		c.state.cond.L.Lock()
 		defer c.state.cond.L.Unlock()


### PR DESCRIPTION
This allows callers to select over the call without needing to introduce
a helper function.