### PR TITLE
core: expose missing asset/account IDs in actions

### DIFF
--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -43,6 +43,14 @@ type spendAction struct {
 }
 
 func (a *spendAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.BuildResult, error) {
+	if a.AccountID == "" {
+		return nil, txbuilder.ErrActionMissingAccountID
+	}
+
+	if a.AssetID == (bc.AssetID{}) {
+		return nil, txbuilder.ErrActionMissingAssetID
+	}
+
 	acct, err := a.accounts.findByID(ctx, a.AccountID)
 	if err != nil {
 		return nil, errors.Wrap(err, "get account info")
@@ -191,6 +199,14 @@ type controlAction struct {
 }
 
 func (a *controlAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.BuildResult, error) {
+	if a.AccountID == "" {
+		return nil, txbuilder.ErrActionMissingAccountID
+	}
+
+	if a.AssetID == (bc.AssetID{}) {
+		return nil, txbuilder.ErrActionMissingAssetID
+	}
+
 	acp, err := a.accounts.CreateControlProgram(ctx, a.AccountID, false)
 	if err != nil {
 		return nil, err

--- a/core/asset/builder.go
+++ b/core/asset/builder.go
@@ -35,6 +35,10 @@ type issueAction struct {
 }
 
 func (a *issueAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.BuildResult, error) {
+	if a.AssetID == (bc.AssetID{}) {
+		return nil, txbuilder.ErrActionMissingAssetID
+	}
+
 	asset, err := a.assets.findByID(ctx, a.AssetID)
 	if errors.Root(err) == pg.ErrUserInputNotFound {
 		err = errors.WithDetailf(err, "missing asset with ID %q", a.AssetID)

--- a/core/errors.go
+++ b/core/errors.go
@@ -112,13 +112,15 @@ var (
 
 		// Transaction error namespace (7xx)
 		// Build error namespace (70x)
-		txbuilder.ErrBadRefData: errorInfo{400, "CH700", "Reference data does not match previous transaction's reference data"},
-		errBadActionType:        errorInfo{400, "CH701", "Invalid action type"},
-		errBadAlias:             errorInfo{400, "CH702", "Invalid alias on action"},
-		errBadAction:            errorInfo{400, "CH703", "Invalid action object"},
-		txbuilder.ErrBadAmount:  errorInfo{400, "CH704", "Invalid asset amount"},
-		txbuilder.ErrBlankCheck: errorInfo{400, "CH705", "Unsafe transaction: leaves assets to be taken without requiring payment"},
-		txbuilder.ErrAction:     errorInfo{400, "CH706", "One or more actions had an error: see attached data"},
+		txbuilder.ErrBadRefData:             errorInfo{400, "CH700", "Reference data does not match previous transaction's reference data"},
+		errBadActionType:                    errorInfo{400, "CH701", "Invalid action type"},
+		errBadAlias:                         errorInfo{400, "CH702", "Invalid alias on action"},
+		errBadAction:                        errorInfo{400, "CH703", "Invalid action object"},
+		txbuilder.ErrBadAmount:              errorInfo{400, "CH704", "Invalid asset amount"},
+		txbuilder.ErrBlankCheck:             errorInfo{400, "CH705", "Unsafe transaction: leaves assets to be taken without requiring payment"},
+		txbuilder.ErrAction:                 errorInfo{400, "CH706", "One or more actions had an error: see attached data"},
+		txbuilder.ErrActionMissingAssetID:   errorInfo{400, "CH707", "Action is missing asset information"},
+		txbuilder.ErrActionMissingAccountID: errorInfo{400, "CH708", "Action is missing account information"},
 
 		// Submit error namespace (73x)
 		txbuilder.ErrMissingRawTx:          errorInfo{400, "CH730", "Missing raw transaction"},

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -18,12 +18,14 @@ import (
 )
 
 var (
-	ErrBadRefData          = errors.New("transaction reference data does not match previous template's reference data")
-	ErrBadTxInputIdx       = errors.New("unsigned tx missing input")
-	ErrBadWitnessComponent = errors.New("invalid witness component")
-	ErrBadAmount           = errors.New("bad asset amount")
-	ErrBlankCheck          = errors.New("unsafe transaction: leaves assets free to control")
-	ErrAction              = errors.New("errors occurred in one or more actions")
+	ErrBadRefData             = errors.New("transaction reference data does not match previous template's reference data")
+	ErrBadTxInputIdx          = errors.New("unsigned tx missing input")
+	ErrBadWitnessComponent    = errors.New("invalid witness component")
+	ErrBadAmount              = errors.New("bad asset amount")
+	ErrBlankCheck             = errors.New("unsafe transaction: leaves assets free to control")
+	ErrAction                 = errors.New("errors occurred in one or more actions")
+	ErrActionMissingAssetID   = errors.New("asset ID is blank")
+	ErrActionMissingAccountID = errors.New("account ID is blank")
 )
 
 // Build builds or adds on to a transaction.


### PR DESCRIPTION
Replace "not found" errors for blank asset and account IDs with errors indicating
that enough information to locate an object was not provided.