### PR TITLE
core: handle panics in batch endpoints

### DIFF
--- a/core/accounts.go
+++ b/core/accounts.go
@@ -44,7 +44,7 @@ func (h *Handler) createAccount(ctx context.Context, ins []struct {
 		go func(i int) {
 			defer wg.Done()
 			subctx := reqid.NewSubContext(ctx, reqid.New())
-			resp := handleInnerRequest(subctx, func() (interface{}, error) {
+			responses[i] = handleInnerRequest(subctx, func() (interface{}, error) {
 				acc, err := h.Accounts.Create(subctx, ins[i].RootXPubs, ins[i].Quorum, ins[i].Alias, ins[i].Tags, ins[i].ClientToken)
 				if err != nil {
 					return nil, err
@@ -66,7 +66,6 @@ func (h *Handler) createAccount(ctx context.Context, ins []struct {
 					Tags:   acc.Tags,
 				}, nil
 			})
-			responses[i] = resp
 		}(i)
 	}
 

--- a/core/assets.go
+++ b/core/assets.go
@@ -51,7 +51,7 @@ func (h *Handler) createAsset(ctx context.Context, ins []struct {
 		go func(i int) {
 			defer wg.Done()
 			subctx := reqid.NewSubContext(ctx, reqid.New())
-			resp := handleInnerRequest(subctx, func() (interface{}, error) {
+			responses[i] = handleInnerRequest(subctx, func() (interface{}, error) {
 				asset, err := h.Assets.Define(
 					subctx,
 					ins[i].RootXPubs,
@@ -85,7 +85,6 @@ func (h *Handler) createAsset(ctx context.Context, ins []struct {
 					IsLocal:         "yes",
 				}, nil
 			})
-			responses[i] = resp
 		}(i)
 	}
 

--- a/core/http.go
+++ b/core/http.go
@@ -67,8 +67,8 @@ func handleInnerRequest(ctx context.Context, innerHandler func() (interface{}, e
 				err = fmt.Errorf("panic with %T", r)
 			}
 		}
-		// Convert errors into errorInfo responses (including errors from recovered
-		// panics above).
+		// Convert errors into errorInfo responses (including errors from
+		// recovered panics above).
 		if err != nil {
 			logHTTPError(ctx, err)
 			result, _ = errInfo(err)
@@ -76,6 +76,6 @@ func handleInnerRequest(ctx context.Context, innerHandler func() (interface{}, e
 	}()
 
 	resp, err = innerHandler()
-	// err is checked by the above defer().
+	// err is checked by the above defer.
 	return resp
 }

--- a/core/transact.go
+++ b/core/transact.go
@@ -77,12 +77,16 @@ func (h *Handler) build(ctx context.Context, buildReqs []*buildRequest) (interfa
 
 	for i := 0; i < len(responses); i++ {
 		go func(i int) {
-			defer wg.Done()
-
 			subctx := reqid.NewSubContext(ctx, reqid.New())
-			responses[i] = handleInnerRequest(subctx, func() (interface{}, error) {
-				return h.buildSingle(subctx, buildReqs[i])
-			})
+			defer wg.Done()
+			defer batchRecover(subctx, &responses[i])
+
+			tmpl, err := h.buildSingle(subctx, buildReqs[i])
+			if err != nil {
+				responses[i] = err
+			} else {
+				responses[i] = tmpl
+			}
 		}(i)
 	}
 
@@ -271,14 +275,19 @@ func (h *Handler) submit(ctx context.Context, x submitArg) interface{} {
 	wg.Add(len(responses))
 	for i := range responses {
 		go func(i int) {
-			defer wg.Done()
 			subctx := reqid.NewSubContext(ctx, reqid.New())
-			responses[i] = handleInnerRequest(subctx, func() (interface{}, error) {
-				return h.submitSingle(subctx, submitSingleArg{
-					tpl:  x.Transactions[i],
-					wait: x.wait,
-				})
+			defer wg.Done()
+			defer batchRecover(subctx, &responses[i])
+
+			tx, err := h.submitSingle(subctx, submitSingleArg{
+				tpl:  x.Transactions[i],
+				wait: x.wait,
 			})
+			if err != nil {
+				responses[i] = err
+			} else {
+				responses[i] = tx
+			}
 		}(i)
 	}
 

--- a/core/transact.go
+++ b/core/transact.go
@@ -80,10 +80,9 @@ func (h *Handler) build(ctx context.Context, buildReqs []*buildRequest) (interfa
 			defer wg.Done()
 
 			subctx := reqid.NewSubContext(ctx, reqid.New())
-			resp := handleInnerRequest(subctx, func() (interface{}, error) {
+			responses[i] = handleInnerRequest(subctx, func() (interface{}, error) {
 				return h.buildSingle(subctx, buildReqs[i])
 			})
-			responses[i] = resp
 		}(i)
 	}
 
@@ -274,13 +273,12 @@ func (h *Handler) submit(ctx context.Context, x submitArg) interface{} {
 		go func(i int) {
 			defer wg.Done()
 			subctx := reqid.NewSubContext(ctx, reqid.New())
-			resp := handleInnerRequest(subctx, func() (interface{}, error) {
+			responses[i] = handleInnerRequest(subctx, func() (interface{}, error) {
 				return h.submitSingle(subctx, submitSingleArg{
 					tpl:  x.Transactions[i],
 					wait: x.wait,
 				})
 			})
-			responses[i] = resp
 		}(i)
 	}
 


### PR DESCRIPTION
Previously, panics in batch endpoints were never recovered and would crash the process. This adds a `batchRecover` function that for recovering panics and converting errors into errorInfo structs.