### PR TITLE
core/account: split utxo/reservation mapping into its own db table

### DIFF
--- a/core/account/indexer.go
+++ b/core/account/indexer.go
@@ -7,7 +7,6 @@ import (
 
 	"chain/core/signers"
 	"chain/database/pg"
-	"chain/database/sql"
 	"chain/encoding/json"
 	"chain/errors"
 	"chain/protocol/bc"
@@ -112,20 +111,7 @@ func (m *Manager) indexAccountUTXOs(ctx context.Context, b *bc.Block) error {
 		return errors.Wrap(err, "loading account info from control programs")
 	}
 
-	dbtx, err := m.db.Begin(ctx)
-	if err != nil {
-		return errors.Wrap(err, "begin transaction for canceling utxo reservation")
-	}
-	defer dbtx.Rollback(ctx)
-
-	// Use EXCLUSIVE locking here because the rows affected may overlap
-	// with rows affected by writes in other threads.
-	_, err = dbtx.Exec(ctx, `LOCK TABLE account_utxos IN EXCLUSIVE MODE`)
-	if err != nil {
-		return errors.Wrap(err, "locking utxo table")
-	}
-
-	err = m.upsertConfirmedAccountOutputs(ctx, dbtx, accOuts, blockPositions, b)
+	err = m.upsertConfirmedAccountOutputs(ctx, accOuts, blockPositions, b)
 	if err != nil {
 		return errors.Wrap(err, "upserting confirmed account utxos")
 	}
@@ -136,7 +122,7 @@ func (m *Manager) indexAccountUTXOs(ctx context.Context, b *bc.Block) error {
 		DELETE FROM account_utxos
 		WHERE (tx_hash, index) IN (SELECT unnest($1::text[]), unnest($2::integer[]))
 	`
-	_, err = dbtx.Exec(ctx, delQ, deltxhash, delindex)
+	_, err = m.db.Exec(ctx, delQ, deltxhash, delindex)
 	if err != nil {
 		return errors.Wrap(err, "deleting spent account utxos")
 	}
@@ -146,14 +132,8 @@ func (m *Manager) indexAccountUTXOs(ctx context.Context, b *bc.Block) error {
 	const expiryQ = `
 		DELETE FROM account_utxos WHERE expiry_height <= $1 AND confirmed_in IS NULL
 	`
-	_, err = dbtx.Exec(ctx, expiryQ, b.Height)
-
-	if err != nil {
-		return errors.Wrap(err, "deleting expired account utxos")
-	}
-
-	err = dbtx.Commit(ctx)
-	return errors.Wrap(err, "committing db transaction")
+	_, err = m.db.Exec(ctx, expiryQ, b.Height)
+	return errors.Wrap(err, "deleting expired account utxos")
 }
 
 func prevoutDBKeys(txs ...*bc.Tx) (txhash pq.StringArray, index pg.Uint32s) {
@@ -233,21 +213,6 @@ func (m *Manager) upsertUnconfirmedAccountOutputs(ctx context.Context, outs []*o
 		metadata = append(metadata, out.ReferenceData)
 	}
 
-	dbtx, err := m.db.Begin(ctx)
-	if err != nil {
-		return errors.Wrap(err, "begin transaction for canceling utxo reservation")
-	}
-	defer dbtx.Rollback(ctx)
-
-	// Use ROW EXCLUSIVE locking here because the rows affected are
-	// distinct from rows affected by writes in other threads. (This
-	// assumes that ON CONFLICT ... DO NOTHING avoids a deadlock when an
-	// actual conflict occurs.)
-	_, err = dbtx.Exec(ctx, `LOCK TABLE account_utxos IN ROW EXCLUSIVE MODE`)
-	if err != nil {
-		return errors.Wrap(err, "locking utxo table")
-	}
-
 	const q = `
 		INSERT INTO account_utxos (tx_hash, index, asset_id, amount, account_id, control_program_index,
 			control_program, metadata, expiry_height)
@@ -255,7 +220,7 @@ func (m *Manager) upsertUnconfirmedAccountOutputs(ctx context.Context, outs []*o
 			   unnest($5::text[]), unnest($6::bigint[]), unnest($7::bytea[]), unnest($8::bytea[]), $9
 		ON CONFLICT (tx_hash, index) DO NOTHING;
 	`
-	_, err = dbtx.Exec(ctx, q,
+	_, err := m.db.Exec(ctx, q,
 		txHash,
 		index,
 		assetID,
@@ -266,17 +231,13 @@ func (m *Manager) upsertUnconfirmedAccountOutputs(ctx context.Context, outs []*o
 		metadata,
 		expiryHeight,
 	)
-	if err != nil {
-		return errors.Wrap(err, "inserting utxos")
-	}
-	err = dbtx.Commit(ctx)
-	return errors.Wrap(err, "committing db transaction")
+	return errors.Wrap(err, "inserting utxos")
 }
 
 // upsertConfirmedAccountOutputs records the account data for confirmed utxos.
 // If the account utxo already exists (because it's from a local tx), the
 // block confirmation data will in the row will be updated.
-func (m *Manager) upsertConfirmedAccountOutputs(ctx context.Context, dbtx *sql.Tx, outs []*output, pos map[bc.Hash]uint32, block *bc.Block) error {
+func (m *Manager) upsertConfirmedAccountOutputs(ctx context.Context, outs []*output, pos map[bc.Hash]uint32, block *bc.Block) error {
 	var (
 		txHash    pq.StringArray
 		index     pg.Uint32s
@@ -312,7 +273,7 @@ func (m *Manager) upsertConfirmedAccountOutputs(ctx context.Context, dbtx *sql.T
 			block_timestamp = excluded.block_timestamp,
 			expiry_height   = excluded.expiry_height;
 	`
-	_, err := dbtx.Exec(ctx, q,
+	_, err := m.db.Exec(ctx, q,
 		txHash,
 		index,
 		assetID,

--- a/core/account/utxodb/db.go
+++ b/core/account/utxodb/db.go
@@ -50,31 +50,17 @@ type Source struct {
 }
 
 func (res *DBReserver) ReserveUTXO(ctx context.Context, txHash bc.Hash, pos uint32, clientToken *string, exp time.Time) (int32, *UTXO, error) {
-	dbtx, err := res.DB.Begin(ctx)
-	if err != nil {
-		return 0, nil, errors.Wrap(err, "begin transaction for reserving utxo")
-	}
-	defer dbtx.Rollback(ctx)
-
-	// Lock in ROW EXCLUSIVE mode because we believe the row affected
-	// here can't be affected by other threads concurrently. (That may
-	// be too optimistic. If it's just been spent [by another Core,
-	// presumably] it might get deleted during utxo indexing while we're
-	// trying to reserve it.)
-	_, err = dbtx.Exec(ctx, `LOCK TABLE account_utxos IN ROW EXCLUSIVE MODE`)
-	if err != nil {
-		return 0, nil, errors.Wrap(err, "acquire lock for reserving utxos")
-	}
-
 	const (
 		reserveQ = `
 			SELECT * FROM reserve_utxo($1, $2, $3, $4)
 				AS (reservation_id INT, already_existed BOOLEAN, utxo_exists BOOLEAN)
 		`
 		utxoQ = `
-			SELECT account_id, asset_id, amount, control_program_index, control_program
-			FROM account_utxos
-			WHERE reservation_id = $1 LIMIT 1
+			SELECT a.account_id, a.asset_id, a.amount, a.control_program_index, a.control_program
+			FROM account_utxos a, reservation_utxos r
+			WHERE r.reservation_id = $1
+				AND (a.tx_hash, a.index) = (r.tx_hash, r.index)
+			LIMIT 1
 		`
 	)
 
@@ -83,7 +69,7 @@ func (res *DBReserver) ReserveUTXO(ctx context.Context, txHash bc.Hash, pos uint
 		alreadyExisted bool
 		utxoExists     bool
 	)
-	err = dbtx.QueryRow(ctx, reserveQ, txHash, pos, exp, clientToken).Scan(
+	err := res.DB.QueryRow(ctx, reserveQ, txHash, pos, exp, clientToken).Scan(
 		&reservationID,
 		&alreadyExisted,
 		&utxoExists,
@@ -106,17 +92,12 @@ func (res *DBReserver) ReserveUTXO(ctx context.Context, txHash bc.Hash, pos uint
 		controlProg  []byte
 	)
 
-	err = dbtx.QueryRow(ctx, utxoQ, reservationID).Scan(&accountID, &assetID, &amount, &programIndex, &controlProg)
+	err = res.DB.QueryRow(ctx, utxoQ, reservationID).Scan(&accountID, &assetID, &amount, &programIndex, &controlProg)
 	if err == stdsql.ErrNoRows {
 		return 0, nil, pg.ErrUserInputNotFound
 	}
 	if err != nil {
 		return 0, nil, errors.Wrap(err, "query reservation member")
-	}
-
-	err = dbtx.Commit(ctx)
-	if err != nil {
-		return 0, nil, errors.Wrap(err, "commit transaction for reserving utxo")
 	}
 
 	utxo := &UTXO{
@@ -136,26 +117,10 @@ func (res *DBReserver) ReserveUTXO(ctx context.Context, txHash bc.Hash, pos uint
 	return reservationID, utxo, nil
 }
 
-// Reserve reserves account UTXOs to cover the provided sources. If
+// Reserve reserves account UTXOs to cover the provided source. If
 // UTXOs are successfully reserved, it's the responsbility of the
 // caller to cancel them if an error occurs.
 func (res *DBReserver) Reserve(ctx context.Context, source Source, exp time.Time) (reservationID int32, reserved []*UTXO, change uint64, err error) {
-	dbtx, err := res.DB.Begin(ctx)
-	if err != nil {
-		return 0, nil, 0, errors.Wrap(err, "begin transaction for reserving utxos")
-	}
-	defer dbtx.Rollback(ctx)
-
-	// Lock in ROW EXCLUSIVE mode because we believe the rows affected
-	// here can't be affected by other threads concurrently. (That may
-	// be too optimistic. If they've just been spent [by another Core,
-	// presumably] they might get deleted during utxo indexing while
-	// we're trying to reserve them.)
-	_, err = dbtx.Exec(ctx, `LOCK TABLE account_utxos IN ROW EXCLUSIVE MODE`)
-	if err != nil {
-		return 0, nil, 0, errors.Wrap(err, "acquire lock for reserving utxos")
-	}
-
 	const (
 		reserveQ = `
 		SELECT * FROM reserve_utxos($1, $2, $3, $4, $5, $6, $7)
@@ -163,8 +128,9 @@ func (res *DBReserver) Reserve(ctx context.Context, source Source, exp time.Time
 		`
 		utxosQ = `
 			SELECT a.tx_hash, a.index, a.amount, a.control_program_index, a.control_program
-			FROM account_utxos a
-			WHERE reservation_id = $1
+			FROM account_utxos a, reservation_utxos r
+			WHERE r.reservation_id = $1
+				AND (a.tx_hash, a.index) = (r.tx_hash, r.index)
 		`
 	)
 
@@ -196,7 +162,7 @@ func (res *DBReserver) Reserve(ctx context.Context, source Source, exp time.Time
 	//  * already_existed will be TRUE
 	//  * existing_change will be the change value for the existing
 	//    reservation row.
-	err = dbtx.QueryRow(ctx, reserveQ, source.AssetID, source.AccountID, txHash, outIndex, source.Amount, exp, source.ClientToken).Scan(
+	err := res.DB.QueryRow(ctx, reserveQ, source.AssetID, source.AccountID, txHash, outIndex, source.Amount, exp, source.ClientToken).Scan(
 		&reservationID,
 		&alreadyExisted,
 		&existingChange,
@@ -213,6 +179,7 @@ func (res *DBReserver) Reserve(ctx context.Context, source Source, exp time.Time
 		return 0, nil, 0, ErrReserved
 	}
 
+	var change uint64
 	if alreadyExisted && existingChange > 0 {
 		// This reservation already exists from a previous request
 		change = existingChange
@@ -220,7 +187,13 @@ func (res *DBReserver) Reserve(ctx context.Context, source Source, exp time.Time
 		change = reservedAmount - source.Amount
 	}
 
-	err = pg.ForQueryRows(ctx, dbtx, utxosQ, reservationID,
+	// Due to a race condition, another thread might have reserved some
+	// of our utxos out from under us. Double check the amount we get
+	// back.
+	var utxoTotal uint64
+
+	var reserved []*UTXO
+	err = pg.ForQueryRows(ctx, res.DB, utxosQ, reservationID,
 		func(hash bc.Hash, index uint32, amount uint64, programIndex uint64, script []byte) {
 			utxo := UTXO{
 				Outpoint:            bc.Outpoint{Hash: hash, Index: index},
@@ -230,63 +203,31 @@ func (res *DBReserver) Reserve(ctx context.Context, source Source, exp time.Time
 				ControlProgramIndex: programIndex,
 			}
 			reserved = append(reserved, &utxo)
+			utxoTotal += amount
 		},
 	)
 	if err != nil {
 		return reservationID, nil, 0, errors.Wrap(err, "query reservation members")
 	}
-	err = dbtx.Commit(ctx)
-	if err != nil {
-		return reservationID, nil, 0, errors.Wrap(err, "commit transaction for reserving utxos")
+
+	if source.Amount+change != utxoTotal {
+		// Lost a reservation race with another thread somewhere. Reuse
+		// ErrReserved to encourage callers to retry.
+		return reservationID, nil, change, ErrReserved
 	}
-	return reservationID, reserved, change, err
+
+	return reservationID, reserved, change, nil
 }
 
 // Cancel cancels the given reservation if possible.
 // If it doesn't exist (if it's already been consumed
 // or canceled), it is silently ignored.
 func (res *DBReserver) Cancel(ctx context.Context, rid int32) error {
-	dbtx, err := res.DB.Begin(ctx)
-	if err != nil {
-		return errors.Wrap(err, "begin transaction for canceling utxo reservation")
-	}
-	defer dbtx.Rollback(ctx)
-
-	// Lock in ROW EXCLUSIVE mode because we believe the row affected
-	// here can't be affected by other threads concurrently. (That may
-	// be too optimistic. If an underlying utxo has just been spent [by
-	// another Core, presumably] it might get deleted at the same time
-	// we're trying to null out its reservation_id as a result of
-	// canceling the reservation.)
-	_, err = dbtx.Exec(ctx, `LOCK TABLE account_utxos IN ROW EXCLUSIVE MODE`)
-	if err != nil {
-		return errors.Wrap(err, "locking table for canceling utxo reservation")
-	}
-
-	_, err = dbtx.Exec(ctx, "SELECT cancel_reservation($1)", rid)
-	if err != nil {
-		return errors.Wrap(err, "canceling utxo reservation")
-	}
-
-	return dbtx.Commit(ctx)
+	_, err := res.DB.Exec(ctx, "SELECT cancel_reservation($1)", rid)
+	return errors.Wrap(err, "canceling utxo reservation")
 }
 
 func (res *DBReserver) ExpireReservations(ctx context.Context) error {
-	dbtx, err := res.DB.Begin(ctx)
-	if err != nil {
-		return err
-	}
-	defer dbtx.Rollback(ctx)
-
-	_, err = dbtx.Exec(ctx, `LOCK TABLE account_utxos IN EXCLUSIVE MODE`)
-	if err != nil {
-		return err
-	}
-
-	_, err = dbtx.Exec(ctx, `SELECT expire_reservations()`)
-	if err != nil {
-		return err
-	}
-
-	return dbtx.Commit(ctx)
+	_, err := res.DB.Exec(ctx, `SELECT expire_reservations()`)
+	return err
 }

--- a/core/account/utxodb/db.go
+++ b/core/account/utxodb/db.go
@@ -162,7 +162,7 @@ func (res *DBReserver) Reserve(ctx context.Context, source Source, exp time.Time
 	//  * already_existed will be TRUE
 	//  * existing_change will be the change value for the existing
 	//    reservation row.
-	err := res.DB.QueryRow(ctx, reserveQ, source.AssetID, source.AccountID, txHash, outIndex, source.Amount, exp, source.ClientToken).Scan(
+	err = res.DB.QueryRow(ctx, reserveQ, source.AssetID, source.AccountID, txHash, outIndex, source.Amount, exp, source.ClientToken).Scan(
 		&reservationID,
 		&alreadyExisted,
 		&existingChange,
@@ -179,7 +179,6 @@ func (res *DBReserver) Reserve(ctx context.Context, source Source, exp time.Time
 		return 0, nil, 0, ErrReserved
 	}
 
-	var change uint64
 	if alreadyExisted && existingChange > 0 {
 		// This reservation already exists from a previous request
 		change = existingChange
@@ -192,7 +191,6 @@ func (res *DBReserver) Reserve(ctx context.Context, source Source, exp time.Time
 	// back.
 	var utxoTotal uint64
 
-	var reserved []*UTXO
 	err = pg.ForQueryRows(ctx, res.DB, utxosQ, reservationID,
 		func(hash bc.Hash, index uint32, amount uint64, programIndex uint64, script []byte) {
 			utxo := UTXO{

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -351,7 +351,7 @@ func cancel(ctx context.Context, db pg.DB, outpoints []bc.Outpoint) error {
 
 	const query = `
 		WITH reservation_ids AS (
-		    SELECT DISTINCT reservation_id FROM account_utxos
+		    SELECT DISTINCT reservation_id FROM reservation_utxos
 		        WHERE (tx_hash, index) IN (SELECT unnest($1::text[]), unnest($2::bigint[]))
 		)
 		SELECT cancel_reservation(reservation_id) FROM reservation_ids


### PR DESCRIPTION
Explicit locking is for the birds.