### PR TITLE
errors: make WithData merge maps

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -30,9 +30,9 @@ type errorInfo struct {
 
 type detailedError struct {
 	errorInfo
-	Detail    string      `json:"detail,omitempty"`
-	Data      interface{} `json:"data,omitempty"`
-	Temporary bool        `json:"temporary"`
+	Detail    string                 `json:"detail,omitempty"`
+	Data      map[string]interface{} `json:"data,omitempty"`
+	Temporary bool                   `json:"temporary"`
 }
 
 func isTemporary(info errorInfo, err error) bool {
@@ -44,7 +44,7 @@ func isTemporary(info errorInfo, err error) bool {
 	case "CH761": // outputs currently reserved
 		return true
 	case "CH706": // 1 or more action errors
-		errs := errors.Data(err).([]detailedError)
+		errs := errors.Data(err)["actions"].([]detailedError)
 		temp := true
 		for _, actionErr := range errs {
 			temp = temp && isTemporary(actionErr.errorInfo, nil)

--- a/core/transact.go
+++ b/core/transact.go
@@ -55,7 +55,7 @@ func (h *Handler) buildSingle(ctx context.Context, req *buildRequest) (*txbuilde
 	maxTime := time.Now().Add(ttl)
 	tpl, err := txbuilder.Build(ctx, req.Tx, actions, maxTime)
 	if errors.Root(err) == txbuilder.ErrAction {
-		err = errors.WithData(err, errInfoBodyList(errors.Data(err).([]error)))
+		err = errors.WithData(err, "actions", errInfoBodyList(errors.Data(err)["actions"].([]error)))
 	}
 	if err != nil {
 		return nil, err

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -65,7 +65,7 @@ func Build(ctx context.Context, tx *bc.TxData, actions []Action, maxTime time.Ti
 result:
 	for i, v := range results {
 		if v.err != nil {
-			err := errors.WithDataKV(v.err, "action_index", i)
+			err := errors.WithData(v.err, "action_index", i)
 			errs = append(errs, err)
 			continue result
 		}
@@ -73,7 +73,7 @@ result:
 		for _, in := range buildResult.Inputs {
 			if in.Amount() > math.MaxInt64 {
 				err := errors.WithDetailf(ErrBadAmount, "amount %d exceeds maximum value 2^63", in.Amount())
-				err = errors.WithData(err, map[string]int{"action_index": i})
+				err = errors.WithData(err, "action_index", i)
 				errs = append(errs, err)
 				continue result
 			}
@@ -81,7 +81,7 @@ result:
 		for _, out := range buildResult.Outputs {
 			if out.Amount > math.MaxInt64 {
 				err := errors.WithDetailf(ErrBadAmount, "amount %d exceeds maximum value 2^63", out.Amount)
-				err = errors.WithData(err, map[string]int{"action_index": i})
+				err = errors.WithData(err, "action_index", i)
 				errs = append(errs, err)
 				continue result
 			}
@@ -90,7 +90,7 @@ result:
 		if len(buildResult.Inputs) != len(buildResult.SigningInstructions) {
 			// This would only happen from a bug in our system
 			err := errors.Wrap(fmt.Errorf("%T returned different number of inputs and signing instructions", actions[i]))
-			err = errors.WithData(err, map[string]int{"action_index": i})
+			err = errors.WithData(err, "action_index", i)
 			errs = append(errs, err)
 			continue result
 		}
@@ -130,7 +130,7 @@ result:
 
 	if len(errs) > 0 {
 		rollback(rollbacks)
-		return nil, errors.WithData(ErrAction, errs)
+		return nil, errors.WithData(ErrAction, "actions", errs)
 	}
 
 	err := checkBlankCheck(tx)

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -65,7 +65,7 @@ func Build(ctx context.Context, tx *bc.TxData, actions []Action, maxTime time.Ti
 result:
 	for i, v := range results {
 		if v.err != nil {
-			err := errors.WithData(v.err, map[string]int{"action_index": i})
+			err := errors.WithDataKV(v.err, "action_index", i)
 			errs = append(errs, err)
 			continue result
 		}

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -65,7 +65,7 @@ func Build(ctx context.Context, tx *bc.TxData, actions []Action, maxTime time.Ti
 result:
 	for i, v := range results {
 		if v.err != nil {
-			err := errors.WithData(v.err, "action_index", i)
+			err := errors.WithData(v.err, "index", i)
 			errs = append(errs, err)
 			continue result
 		}
@@ -73,7 +73,7 @@ result:
 		for _, in := range buildResult.Inputs {
 			if in.Amount() > math.MaxInt64 {
 				err := errors.WithDetailf(ErrBadAmount, "amount %d exceeds maximum value 2^63", in.Amount())
-				err = errors.WithData(err, "action_index", i)
+				err = errors.WithData(err, "index", i)
 				errs = append(errs, err)
 				continue result
 			}
@@ -81,7 +81,7 @@ result:
 		for _, out := range buildResult.Outputs {
 			if out.Amount > math.MaxInt64 {
 				err := errors.WithDetailf(ErrBadAmount, "amount %d exceeds maximum value 2^63", out.Amount)
-				err = errors.WithData(err, "action_index", i)
+				err = errors.WithData(err, "index", i)
 				errs = append(errs, err)
 				continue result
 			}
@@ -90,7 +90,7 @@ result:
 		if len(buildResult.Inputs) != len(buildResult.SigningInstructions) {
 			// This would only happen from a bug in our system
 			err := errors.Wrap(fmt.Errorf("%T returned different number of inputs and signing instructions", actions[i]))
-			err = errors.WithData(err, "action_index", i)
+			err = errors.WithData(err, "index", i)
 			errs = append(errs, err)
 			continue result
 		}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -138,7 +138,7 @@ func withData(err error, v map[string]interface{}) error {
 // Note that if err already has a data item of any other type,
 // it will not be accessible via the returned error value.
 func WithData(err error, keyval ...interface{}) error {
-	// TODO(kr): add vet check for odd-length keyval
+	// TODO(kr): add vet check for odd-length keyval and non-string keys
 	newkv := make(map[string]interface{})
 	for k, v := range Data(err) {
 		newkv[k] = v

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,7 +15,7 @@ func New(text string) error {
 type wrapperError struct {
 	msg    string
 	detail []string
-	data   interface{}
+	data   map[string]interface{}
 	stack  []StackFrame
 	root   error
 }
@@ -111,13 +111,13 @@ func Detail(err error) string {
 	return strings.Join(wrapper.detail, "; ")
 }
 
-// WithData returns a new error that wraps err
+// withData returns a new error that wraps err
 // as a chain error message containing v as
 // an extra data item.
 // Calling Data on the returned error yields v.
 // Note that if err already has a data item,
 // it will not be accessible via the returned error value.
-func WithData(err error, v interface{}) error {
+func withData(err error, v map[string]interface{}) error {
 	if err == nil {
 		return nil
 	}
@@ -126,7 +126,7 @@ func WithData(err error, v interface{}) error {
 	return e1
 }
 
-// WithDataKV returns a new error that wraps err
+// WithData returns a new error that wraps err
 // as a chain error message containing a value of type
 // map[string]interface{} as an extra data item.
 // The map contains the values in the map in err,
@@ -137,20 +137,20 @@ func WithData(err error, v interface{}) error {
 // Calling Data on the returned error yields the map.
 // Note that if err already has a data item of any other type,
 // it will not be accessible via the returned error value.
-func WithDataKV(err error, keyval ...interface{}) error {
+func WithData(err error, keyval ...interface{}) error {
+	// TODO(kr): add vet check for odd-length keyval
 	newkv := make(map[string]interface{})
-	oldkv, _ := Data(err).(map[string]interface{})
-	for k, v := range oldkv {
+	for k, v := range Data(err) {
 		newkv[k] = v
 	}
 	for i := 0; i < len(keyval); i += 2 {
 		newkv[keyval[i].(string)] = keyval[i+1]
 	}
-	return WithData(err, newkv)
+	return withData(err, newkv)
 }
 
 // Data returns the data item in err, if any.
-func Data(err error) interface{} {
+func Data(err error) map[string]interface{} {
 	wrapper, _ := err.(wrapperError)
 	return wrapper.data
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -126,6 +126,29 @@ func WithData(err error, v interface{}) error {
 	return e1
 }
 
+// WithDataKV returns a new error that wraps err
+// as a chain error message containing a value of type
+// map[string]interface{} as an extra data item.
+// The map contains the values in map in err, if any,
+// plus the items in keyval.
+// Keyval takes the form
+//   k1, v1, k2, v2, ...
+// Here kN must be strings.
+// Calling Data on the returned error yields the map.
+// Note that if err already has a data item of any other type,
+// it will not be accessible via the returned error value.
+func WithDataKV(err error, keyval ...interface{}) error {
+	newkv := make(map[string]interface{})
+	oldkv, _ := Data(err).(map[string]interface{})
+	for k, v := range oldkv {
+		newkv[k] = v
+	}
+	for i := 0; i < len(keyval); i += 2 {
+		newkv[keyval[i].(string)] = keyval[i+1]
+	}
+	return WithData(err, newkv)
+}
+
 // Data returns the data item in err, if any.
 func Data(err error) interface{} {
 	wrapper, _ := err.(wrapperError)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -133,7 +133,7 @@ func WithData(err error, v interface{}) error {
 // if any, plus the items in keyval.
 // Keyval takes the form
 //   k1, v1, k2, v2, ...
-// Here kN must be strings.
+// Values kN must be strings.
 // Calling Data on the returned error yields the map.
 // Note that if err already has a data item of any other type,
 // it will not be accessible via the returned error value.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -129,8 +129,8 @@ func WithData(err error, v interface{}) error {
 // WithDataKV returns a new error that wraps err
 // as a chain error message containing a value of type
 // map[string]interface{} as an extra data item.
-// The map contains the values in map in err, if any,
-// plus the items in keyval.
+// The map contains the values in the map in err,
+// if any, plus the items in keyval.
 // Keyval takes the form
 //   k1, v1, k2, v2, ...
 // Here kN must be strings.

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -97,7 +97,7 @@ func TestDetail(t *testing.T) {
 	}
 }
 
-func TestDataKV(t *testing.T) {
+func TestData(t *testing.T) {
 	root := errors.New("foo")
 	cases := []struct {
 		err  error

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -97,40 +97,15 @@ func TestDetail(t *testing.T) {
 	}
 }
 
-func TestData(t *testing.T) {
-	root := errors.New("foo")
-	cases := []struct {
-		err  error
-		data interface{}
-	}{
-		{root, nil},
-		{WithData(root, 1), 1},
-		{WithData(root, map[string]string{"a": "b"}), map[string]string{"a": "b"}},
-		{WithData(root, "bar"), "bar"},
-		{WithData(WithData(root, "bar"), "baz"), "baz"},
-		{Wrap(WithData(root, "bar"), "baz"), "bar"},
-	}
-
-	for _, test := range cases {
-		if got := Data(test.err); !reflect.DeepEqual(got, test.data) {
-			t.Errorf("Data(%#v) = %v want %v", test.err, got, test.data)
-		}
-		if got := Root(test.err); got != root {
-			t.Errorf("Root(%#v) = %v want %v", test.err, got, root)
-		}
-	}
-}
-
 func TestDataKV(t *testing.T) {
 	root := errors.New("foo")
 	cases := []struct {
 		err  error
 		data interface{}
 	}{
-		{WithDataKV(root, "a", "b"), map[string]interface{}{"a": "b"}},
-		{WithDataKV(WithDataKV(root, "a", "b"), "c", "d"), map[string]interface{}{"a": "b", "c": "d"}},
-		{Wrap(WithDataKV(root, "a", "b"), "baz"), map[string]interface{}{"a": "b"}},
-		{WithDataKV(WithData(root, "x"), "a", "b"), map[string]interface{}{"a": "b"}},
+		{WithData(root, "a", "b"), map[string]interface{}{"a": "b"}},
+		{WithData(WithData(root, "a", "b"), "c", "d"), map[string]interface{}{"a": "b", "c": "d"}},
+		{Wrap(WithData(root, "a", "b"), "baz"), map[string]interface{}{"a": "b"}},
 	}
 
 	for _, test := range cases {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -130,6 +130,7 @@ func TestDataKV(t *testing.T) {
 		{WithDataKV(root, "a", "b"), map[string]interface{}{"a": "b"}},
 		{WithDataKV(WithDataKV(root, "a", "b"), "c", "d"), map[string]interface{}{"a": "b", "c": "d"}},
 		{Wrap(WithDataKV(root, "a", "b"), "baz"), map[string]interface{}{"a": "b"}},
+		{WithDataKV(WithData(root, "x"), "a", "b"), map[string]interface{}{"a": "b"}},
 	}
 
 	for _, test := range cases {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -120,3 +120,24 @@ func TestData(t *testing.T) {
 		}
 	}
 }
+
+func TestDataKV(t *testing.T) {
+	root := errors.New("foo")
+	cases := []struct {
+		err  error
+		data interface{}
+	}{
+		{WithDataKV(root, "a", "b"), map[string]interface{}{"a": "b"}},
+		{WithDataKV(WithDataKV(root, "a", "b"), "c", "d"), map[string]interface{}{"a": "b", "c": "d"}},
+		{Wrap(WithDataKV(root, "a", "b"), "baz"), map[string]interface{}{"a": "b"}},
+	}
+
+	for _, test := range cases {
+		if got := Data(test.err); !reflect.DeepEqual(got, test.data) {
+			t.Errorf("Data(%#v) = %v want %v", test.err, got, test.data)
+		}
+		if got := Root(test.err); got != root {
+			t.Errorf("Root(%#v) = %v want %v", test.err, got, root)
+		}
+	}
+}

--- a/sdk/java/src/main/java/com/chain/exception/BuildException.java
+++ b/sdk/java/src/main/java/com/chain/exception/BuildException.java
@@ -18,7 +18,7 @@ public class BuildException extends APIException {
             /**
              * The index of the action that caused this error.
              */
-            @SerializedName("action_index")
+            @SerializedName("index")
             public Integer index;
         }
 
@@ -32,9 +32,17 @@ public class BuildException extends APIException {
         public Data data;
     }
 
+    public static class Data {
+        /**
+         * A list of errors resulting from building actions.
+         */
+        @SerializedName("actions")
+        public List<ActionError> actionErrors;
+    }
+
     /**
-     * A list of errors resulting from building actions.
+     * Extra data associated with this error, if any.
      */
     @SerializedName("data")
-    public List<ActionError> actionErrors;
+    public Data data;
 }


### PR DESCRIPTION
This lets us accumulate data in an error rather than
entirely replacing what was there before.

This is the first step in an alternate approach to #115.