### PR TITLE
core/txbuilder: report missing field names

### DIFF
--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -46,7 +46,8 @@ func (a *spendAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.
 	var missing []string
 	if a.AccountID == "" {
 		missing = append(missing, "account_id")
-	} else if a.AssetID == (bc.AssetID{}) {
+	}
+	if a.AssetID == (bc.AssetID{}) {
 		missing = append(missing, "asset_id")
 	}
 	if len(missing) > 0 {
@@ -204,7 +205,8 @@ func (a *controlAction) Build(ctx context.Context, maxTime time.Time) (*txbuilde
 	var missing []string
 	if a.AccountID == "" {
 		missing = append(missing, "account_id")
-	} else if a.AssetID == (bc.AssetID{}) {
+	}
+	if a.AssetID == (bc.AssetID{}) {
 		missing = append(missing, "asset_id")
 	}
 	if len(missing) > 0 {

--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -43,6 +43,16 @@ type spendAction struct {
 }
 
 func (a *spendAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.BuildResult, error) {
+	var missing []string
+	if a.AccountID == "" {
+		missing = append(missing, "account_id")
+	} else if a.AssetID == (bc.AssetID{}) {
+		missing = append(missing, "asset_id")
+	}
+	if len(missing) > 0 {
+		return nil, txbuilder.MissingFieldsError(missing...)
+	}
+
 	acct, err := a.accounts.findByID(ctx, a.AccountID)
 	if err != nil {
 		return nil, errors.Wrap(err, "get account info")
@@ -191,6 +201,16 @@ type controlAction struct {
 }
 
 func (a *controlAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.BuildResult, error) {
+	var missing []string
+	if a.AccountID == "" {
+		missing = append(missing, "account_id")
+	} else if a.AssetID == (bc.AssetID{}) {
+		missing = append(missing, "asset_id")
+	}
+	if len(missing) > 0 {
+		return nil, txbuilder.MissingFieldsError(missing...)
+	}
+
 	acp, err := a.accounts.CreateControlProgram(ctx, a.AccountID, false)
 	if err != nil {
 		return nil, err

--- a/core/asset/builder.go
+++ b/core/asset/builder.go
@@ -35,6 +35,10 @@ type issueAction struct {
 }
 
 func (a *issueAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.BuildResult, error) {
+	if a.AssetID == (bc.AssetID{}) {
+		return nil, txbuilder.MissingFieldsError("asset_id")
+	}
+
 	asset, err := a.assets.findByID(ctx, a.AssetID)
 	if errors.Root(err) == pg.ErrUserInputNotFound {
 		err = errors.WithDetailf(err, "missing asset with ID %q", a.AssetID)

--- a/core/errors.go
+++ b/core/errors.go
@@ -74,6 +74,7 @@ var (
 		errRateLimited:               errorInfo{429, "CH007", "Request limit exceeded"},
 		errLeaderElection:            errorInfo{503, "CH008", "Electing a new leader for the core; try again soon"},
 		errNotAuthenticated:          errorInfo{401, "CH009", "Request could not be authenticated"},
+		txbuilder.ErrMissingFields:   errorInfo{400, "CH010", "One or more fields are missing"},
 		asset.ErrDuplicateAlias:      errorInfo{400, "CH050", "Alias already exists"},
 		account.ErrDuplicateAlias:    errorInfo{400, "CH050", "Alias already exists"},
 		txfeed.ErrDuplicateAlias:     errorInfo{400, "CH050", "Alias already exists"},

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -233,5 +233,5 @@ func checkBlankCheck(tx *bc.TxData) error {
 // MissingFieldsError returns a wrapped error ErrMissingFields
 // with a data item containing the given field names.
 func MissingFieldsError(name ...string) error {
-	return errors.WithData(ErrMissingFields, "missing_field_names", name)
+	return errors.WithData(ErrMissingFields, "missing_fields", name)
 }

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -24,6 +24,7 @@ var (
 	ErrBadAmount           = errors.New("bad asset amount")
 	ErrBlankCheck          = errors.New("unsafe transaction: leaves assets free to control")
 	ErrAction              = errors.New("errors occurred in one or more actions")
+	ErrMissingFields       = errors.New("required field is missing")
 )
 
 // Build builds or adds on to a transaction.
@@ -227,4 +228,10 @@ func checkBlankCheck(tx *bc.TxData) error {
 	}
 
 	return nil
+}
+
+// MissingFieldsError returns a wrapped error ErrMissingFields
+// with a data item containing the given field names.
+func MissingFieldsError(name ...string) error {
+	return errors.WithData(ErrMissingFields, "missing_field_names", name)
 }


### PR DESCRIPTION
This adds a new txbuilder error ErrMissingFields, and
updates account and asset builders to return that error
along with a list of missing field names.

Depends on #125.