### PR TITLE
core/config: new package

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -13,6 +13,7 @@ import (
 	"chain/core/accesstoken"
 	"chain/core/account"
 	"chain/core/asset"
+	"chain/core/config"
 	"chain/core/leader"
 	"chain/core/mockhsm"
 	"chain/core/pin"
@@ -59,7 +60,7 @@ type Handler struct {
 	Indexer       *query.Indexer
 	TxFeeds       *txfeed.Tracker
 	AccessTokens  *accesstoken.CredentialStore
-	Config        *Config
+	Config        *config.Config
 	DB            pg.DB
 	Addr          string
 	AltAuth       func(*http.Request) bool
@@ -189,27 +190,6 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.once.Do(h.init)
 
 	h.handler.ServeHTTP(w, r)
-}
-
-// Config encapsulates Core-level, persistent configuration options.
-type Config struct {
-	ID                   string  `json:"id"`
-	IsSigner             bool    `json:"is_signer"`
-	IsGenerator          bool    `json:"is_generator"`
-	BlockchainID         bc.Hash `json:"blockchain_id"`
-	GeneratorURL         string  `json:"generator_url"`
-	GeneratorAccessToken string  `json:"generator_access_token"`
-	ConfiguredAt         time.Time
-	BlockPub             string         `json:"block_pub"`
-	Signers              []ConfigSigner `json:"block_signer_urls"`
-	Quorum               int
-	MaxIssuanceWindow    time.Duration
-}
-
-type ConfigSigner struct {
-	AccessToken string        `json:"access_token"`
-	Pubkey      json.HexBytes `json:"pubkey"`
-	URL         string        `json:"url"`
 }
 
 // Used as a request object for api queries

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -9,6 +9,7 @@ import (
 
 	"chain/core/account"
 	"chain/core/asset"
+	"chain/core/config"
 	"chain/core/coretest"
 	"chain/core/pin"
 	"chain/core/query"
@@ -195,7 +196,7 @@ func TestMux(t *testing.T) {
 			t.Fatal("unexpected panic:", err)
 		}
 	}()
-	(&Handler{Config: &Config{}}).init()
+	(&Handler{Config: &config.Config{}}).init()
 }
 
 func TestTransfer(t *testing.T) {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -1,0 +1,249 @@
+// Package config manages persistent configuration data for
+// Chain Core.
+package config
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/url"
+	"time"
+
+	"chain/core/mockhsm"
+	"chain/core/rpc"
+	"chain/core/txdb"
+	"chain/crypto/ed25519"
+	"chain/database/pg"
+	"chain/database/sql"
+	chainjson "chain/encoding/json"
+	"chain/errors"
+	"chain/log"
+	"chain/protocol"
+	"chain/protocol/bc"
+	"chain/protocol/state"
+)
+
+const (
+	autoBlockKeyAlias = "_CHAIN_CORE_AUTO_BLOCK_KEY"
+)
+
+var (
+	ErrBadGenerator    = errors.New("generator returned an unsuccessful response")
+	ErrBadSignerURL    = errors.New("block signer URL is invalid")
+	ErrBadSignerPubkey = errors.New("block signer pubkey is invalid")
+	ErrBadQuorum       = errors.New("quorum must be greater than 0 if there are signers")
+)
+
+// Config encapsulates Core-level, persistent configuration options.
+type Config struct {
+	ID                   string  `json:"id"`
+	IsSigner             bool    `json:"is_signer"`
+	IsGenerator          bool    `json:"is_generator"`
+	BlockchainID         bc.Hash `json:"blockchain_id"`
+	GeneratorURL         string  `json:"generator_url"`
+	GeneratorAccessToken string  `json:"generator_access_token"`
+	ConfiguredAt         time.Time
+	BlockPub             string        `json:"block_pub"`
+	Signers              []BlockSigner `json:"block_signer_urls"`
+	Quorum               int
+	MaxIssuanceWindow    time.Duration
+}
+
+type BlockSigner struct {
+	AccessToken string             `json:"access_token"`
+	Pubkey      chainjson.HexBytes `json:"pubkey"`
+	URL         string             `json:"url"`
+}
+
+// Load loads the stored configuration, if any, from the database.
+func Load(ctx context.Context, db pg.DB) (*Config, error) {
+	const q = `
+			SELECT id, is_signer, is_generator,
+			blockchain_id, generator_url, generator_access_token, block_xpub,
+			remote_block_signers, max_issuance_window_ms, configured_at
+			FROM config
+		`
+
+	c := new(Config)
+	var (
+		blockSignerData []byte
+		miw             int64
+	)
+	err := db.QueryRow(ctx, q).Scan(
+		&c.ID,
+		&c.IsSigner,
+		&c.IsGenerator,
+		&c.BlockchainID,
+		&c.GeneratorURL,
+		&c.GeneratorAccessToken,
+		&c.BlockPub,
+		&blockSignerData,
+		&miw,
+		&c.ConfiguredAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Wrap(err, "fetching Core config")
+	}
+
+	if len(blockSignerData) > 0 {
+		err = json.Unmarshal(blockSignerData, &c.Signers)
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+	}
+
+	c.MaxIssuanceWindow = time.Duration(miw) * time.Millisecond
+	return c, nil
+}
+
+// Configure configures the core by writing to the database.
+// If running in a cored process,
+// the caller must ensure that the new configuration is properly reloaded,
+// for example by restarting the process.
+//
+// If c.IsSigner is true, Configure generates a new mockhsm keypair
+// for signing blocks, and assigns it to c.BlockPub.
+//
+// If c.IsGenerator is true, Configure creates an initial block,
+// saves it, and assigns its hash to c.BlockchainID.
+// Otherwise, c.IsGenerator is false, and Configure makes a test request
+// to GeneratorURL to detect simple configuration mistakes.
+func Configure(ctx context.Context, db pg.DB, c *Config) error {
+	var err error
+	if !c.IsGenerator {
+		err = tryGenerator(
+			ctx,
+			c.GeneratorURL,
+			c.GeneratorAccessToken,
+			c.BlockchainID.String(),
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	var signingKeys []ed25519.PublicKey
+	if c.IsSigner {
+		var blockPub ed25519.PublicKey
+		if c.BlockPub == "" {
+			hsm := mockhsm.New(db)
+			corePub, created, err := hsm.GetOrCreate(ctx, autoBlockKeyAlias)
+			if err != nil {
+				return err
+			}
+			blockPub = corePub.Pub
+			blockPubStr := hex.EncodeToString(blockPub)
+			if created {
+				log.Messagef(ctx, "Generated new block-signing key %s\n", blockPubStr)
+			} else {
+				log.Messagef(ctx, "Using block-signing key %s\n", blockPubStr)
+			}
+			c.BlockPub = blockPubStr
+		} else {
+			blockPub, err = hex.DecodeString(c.BlockPub)
+			if err != nil {
+				return err
+			}
+		}
+		signingKeys = append(signingKeys, blockPub)
+	}
+
+	if c.IsGenerator {
+		for _, signer := range c.Signers {
+			_, err = url.Parse(signer.URL)
+			if err != nil {
+				return errors.Wrap(ErrBadSignerURL, err.Error())
+			}
+			if len(signer.Pubkey) != ed25519.PublicKeySize {
+				return errors.Wrap(ErrBadSignerPubkey, err.Error())
+			}
+			signingKeys = append(signingKeys, ed25519.PublicKey(signer.Pubkey))
+		}
+
+		if c.Quorum == 0 && len(signingKeys) > 0 {
+			return errors.Wrap(ErrBadQuorum)
+		}
+
+		block, err := protocol.NewInitialBlock(signingKeys, c.Quorum, time.Now())
+		if err != nil {
+			return err
+		}
+
+		initialBlockHash := block.Hash()
+
+		store, pool := txdb.New(db.(*sql.DB))
+		chain, err := protocol.NewChain(ctx, initialBlockHash, store, pool, nil)
+		if err != nil {
+			return err
+		}
+
+		err = chain.CommitBlock(ctx, block, state.Empty())
+		if err != nil {
+			return err
+		}
+
+		c.BlockchainID = initialBlockHash
+		chain.MaxIssuanceWindow = c.MaxIssuanceWindow
+	}
+
+	var blockSignerData []byte
+	if len(c.Signers) > 0 {
+		blockSignerData, err = json.Marshal(c.Signers)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+	}
+
+	b := make([]byte, 10)
+	_, err = rand.Read(b)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	c.ID = hex.EncodeToString(b)
+
+	// TODO(tessr): rename block_xpub column
+	const q = `
+		INSERT INTO config (id, is_signer, block_xpub, is_generator,
+			blockchain_id, generator_url, generator_access_token,
+			remote_block_signers, max_issuance_window_ms, configured_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+	`
+	_, err = db.Exec(
+		ctx,
+		q,
+		c.ID,
+		c.IsSigner,
+		c.BlockPub,
+		c.IsGenerator,
+		c.BlockchainID,
+		c.GeneratorURL,
+		c.GeneratorAccessToken,
+		blockSignerData,
+		bc.DurationMillis(c.MaxIssuanceWindow),
+	)
+	return err
+}
+
+func tryGenerator(ctx context.Context, url, accessToken, blockchainID string) error {
+	client := &rpc.Client{
+		BaseURL:      url,
+		AccessToken:  accessToken,
+		BlockchainID: blockchainID,
+	}
+	var x struct {
+		BlockHeight uint64 `json:"block_height"`
+	}
+	err := client.Call(ctx, "/rpc/block-height", nil, &x)
+	if err != nil {
+		return errors.Wrap(ErrBadGenerator, err.Error())
+	}
+
+	if x.BlockHeight < 1 {
+		return ErrBadGenerator
+	}
+
+	return nil
+}

--- a/core/core.go
+++ b/core/core.go
@@ -2,40 +2,25 @@ package core
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"expvar"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
+	"chain/core/config"
 	"chain/core/fetch"
 	"chain/core/leader"
-	"chain/core/mockhsm"
-	"chain/core/rpc"
-	"chain/core/txdb"
-	"chain/crypto/ed25519"
-	"chain/database/pg"
-	"chain/database/sql"
 	"chain/errors"
 	"chain/log"
 	"chain/net/http/httpjson"
-	"chain/protocol"
-	"chain/protocol/bc"
-	"chain/protocol/state"
 )
 
 var (
 	errAlreadyConfigured = errors.New("core is already configured; must reset first")
 	errUnconfigured      = errors.New("core is not configured")
-	errBadGenerator      = errors.New("generator returned an unsuccessful response")
 	errBadBlockPub       = errors.New("supplied block pub key is invalid")
 	errNoClientTokens    = errors.New("cannot enable client auth without client access tokens")
-	errBadSignerURL      = errors.New("block signer URL is invalid")
-	errBadSignerPubkey   = errors.New("block signer pubkey is invalid")
-	errBadQuorum         = errors.New("quorum must be greater than 0 if there are signers")
 	// errProdReset is returned when reset is called on a
 	// production system.
 	errProdReset = errors.New("reset called on production system")
@@ -44,7 +29,6 @@ var (
 // reserved mockhsm key alias
 const (
 	networkRPCVersion = 1
-	autoBlockKeyAlias = "_CHAIN_CORE_AUTO_BLOCK_KEY"
 )
 
 func isProduction() bool {
@@ -148,135 +132,7 @@ func (h *Handler) leaderInfo(ctx context.Context) (map[string]interface{}, error
 	return m, nil
 }
 
-// Configure configures the core by writing to the database.
-// If running in a cored process,
-// the caller must ensure that the new configuration is properly reloaded,
-// for example by restarting the process.
-//
-// If c.IsSigner is true, Configure generates a new mockhsm keypair
-// for signing blocks, and assigns it to c.BlockPub.
-//
-// If c.IsGenerator is true, Configure creates an initial block,
-// saves it, and assigns its hash to c.BlockchainID.
-// Otherwise, c.IsGenerator is false, and Configure makes a test request
-// to GeneratorURL to detect simple configuration mistakes.
-func Configure(ctx context.Context, db pg.DB, c *Config) error {
-	var err error
-	if !c.IsGenerator {
-		err = tryGenerator(
-			ctx,
-			c.GeneratorURL,
-			c.GeneratorAccessToken,
-			c.BlockchainID.String(),
-		)
-		if err != nil {
-			return err
-		}
-	}
-
-	var signingKeys []ed25519.PublicKey
-	if c.IsSigner {
-		var blockPub ed25519.PublicKey
-		if c.BlockPub == "" {
-			hsm := mockhsm.New(db)
-			corePub, created, err := hsm.GetOrCreate(ctx, autoBlockKeyAlias)
-			if err != nil {
-				return err
-			}
-			blockPub = corePub.Pub
-			blockPubStr := hex.EncodeToString(blockPub)
-			if created {
-				log.Messagef(ctx, "Generated new block-signing key %s\n", blockPubStr)
-			} else {
-				log.Messagef(ctx, "Using block-signing key %s\n", blockPubStr)
-			}
-			c.BlockPub = blockPubStr
-		} else {
-			blockPub, err = hex.DecodeString(c.BlockPub)
-			if err != nil {
-				return err
-			}
-		}
-		signingKeys = append(signingKeys, blockPub)
-	}
-
-	if c.IsGenerator {
-		for _, signer := range c.Signers {
-			_, err = url.Parse(signer.URL)
-			if err != nil {
-				return errors.Wrap(errBadSignerURL, err.Error())
-			}
-			if len(signer.Pubkey) != ed25519.PublicKeySize {
-				return errors.Wrap(errBadSignerPubkey, err.Error())
-			}
-			signingKeys = append(signingKeys, ed25519.PublicKey(signer.Pubkey))
-		}
-
-		if c.Quorum == 0 && len(signingKeys) > 0 {
-			return errors.Wrap(errBadQuorum)
-		}
-
-		block, err := protocol.NewInitialBlock(signingKeys, c.Quorum, time.Now())
-		if err != nil {
-			return err
-		}
-
-		initialBlockHash := block.Hash()
-
-		store, pool := txdb.New(db.(*sql.DB))
-		chain, err := protocol.NewChain(ctx, initialBlockHash, store, pool, nil)
-		if err != nil {
-			return err
-		}
-
-		err = chain.CommitBlock(ctx, block, state.Empty())
-		if err != nil {
-			return err
-		}
-
-		c.BlockchainID = initialBlockHash
-		chain.MaxIssuanceWindow = c.MaxIssuanceWindow
-	}
-
-	var blockSignerData []byte
-	if len(c.Signers) > 0 {
-		blockSignerData, err = json.Marshal(c.Signers)
-		if err != nil {
-			return errors.Wrap(err)
-		}
-	}
-
-	b := make([]byte, 10)
-	_, err = rand.Read(b)
-	if err != nil {
-		return errors.Wrap(err)
-	}
-	c.ID = hex.EncodeToString(b)
-
-	// TODO(tessr): rename block_xpub column
-	const q = `
-		INSERT INTO config (id, is_signer, block_xpub, is_generator,
-			blockchain_id, generator_url, generator_access_token,
-			remote_block_signers, max_issuance_window_ms, configured_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
-	`
-	_, err = db.Exec(
-		ctx,
-		q,
-		c.ID,
-		c.IsSigner,
-		c.BlockPub,
-		c.IsGenerator,
-		c.BlockchainID,
-		c.GeneratorURL,
-		c.GeneratorAccessToken,
-		blockSignerData,
-		bc.DurationMillis(c.MaxIssuanceWindow),
-	)
-	return err
-}
-
-func (h *Handler) configure(ctx context.Context, x *Config) error {
+func (h *Handler) configure(ctx context.Context, x *config.Config) error {
 	if h.Config != nil {
 		return errAlreadyConfigured
 	}
@@ -285,7 +141,7 @@ func (h *Handler) configure(ctx context.Context, x *Config) error {
 		x.MaxIssuanceWindow = 24 * time.Hour
 	}
 
-	err := Configure(ctx, h.DB, x)
+	err := config.Configure(ctx, h.DB, x)
 	if err != nil {
 		return err
 	}
@@ -293,70 +149,6 @@ func (h *Handler) configure(ctx context.Context, x *Config) error {
 	closeConnOK(httpjson.ResponseWriter(ctx), httpjson.Request(ctx))
 	execSelf("")
 	panic("unreached")
-}
-
-// LoadConfig loads the stored configuration, if any, from the database.
-func LoadConfig(ctx context.Context, db pg.DB) (*Config, error) {
-	const q = `
-			SELECT id, is_signer, is_generator,
-			blockchain_id, generator_url, generator_access_token, block_xpub,
-			remote_block_signers, max_issuance_window_ms, configured_at
-			FROM config
-		`
-
-	c := new(Config)
-	var (
-		blockSignerData []byte
-		miw             int64
-	)
-	err := db.QueryRow(ctx, q).Scan(
-		&c.ID,
-		&c.IsSigner,
-		&c.IsGenerator,
-		&c.BlockchainID,
-		&c.GeneratorURL,
-		&c.GeneratorAccessToken,
-		&c.BlockPub,
-		&blockSignerData,
-		&miw,
-		&c.ConfiguredAt,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	} else if err != nil {
-		return nil, errors.Wrap(err, "fetching Core config")
-	}
-
-	if len(blockSignerData) > 0 {
-		err = json.Unmarshal(blockSignerData, &c.Signers)
-		if err != nil {
-			return nil, errors.Wrap(err)
-		}
-	}
-
-	c.MaxIssuanceWindow = time.Duration(miw) * time.Millisecond
-	return c, nil
-}
-
-func tryGenerator(ctx context.Context, url, accessToken, blockchainID string) error {
-	client := &rpc.Client{
-		BaseURL:      url,
-		AccessToken:  accessToken,
-		BlockchainID: blockchainID,
-	}
-	var x struct {
-		BlockHeight uint64 `json:"block_height"`
-	}
-	err := client.Call(ctx, "/rpc/block-height", nil, &x)
-	if err != nil {
-		return errors.Wrap(errBadGenerator, err.Error())
-	}
-
-	if x.BlockHeight < 1 {
-		return errBadGenerator
-	}
-
-	return nil
 }
 
 func closeConnOK(w http.ResponseWriter, req *http.Request) {

--- a/core/errors.go
+++ b/core/errors.go
@@ -8,6 +8,7 @@ import (
 	"chain/core/account/utxodb"
 	"chain/core/asset"
 	"chain/core/blocksigner"
+	"chain/core/config"
 	"chain/core/mockhsm"
 	"chain/core/query"
 	"chain/core/query/filter"
@@ -81,13 +82,13 @@ var (
 		// Core error namespace
 		errUnconfigured:                errorInfo{400, "CH100", "This core still needs to be configured"},
 		errAlreadyConfigured:           errorInfo{400, "CH101", "This core has already been configured"},
-		errBadGenerator:                errorInfo{400, "CH102", "Generator URL returned an invalid response"},
+		config.ErrBadGenerator:         errorInfo{400, "CH102", "Generator URL returned an invalid response"},
 		errBadBlockPub:                 errorInfo{400, "CH103", "Provided Block XPub is invalid"},
 		rpc.ErrWrongNetwork:            errorInfo{502, "CH104", "A peer core is operating on a different blockchain network"},
 		protocol.ErrTheDistantFuture:   errorInfo{400, "CH105", "Requested height is too far ahead"},
-		errBadSignerURL:                errorInfo{400, "CH106", "Block signer URL is invalid"},
-		errBadSignerPubkey:             errorInfo{400, "CH107", "Block signer pubkey is invalid"},
-		errBadQuorum:                   errorInfo{400, "CH108", "Quorum must be greater than 0 if there are signers"},
+		config.ErrBadSignerURL:         errorInfo{400, "CH106", "Block signer URL is invalid"},
+		config.ErrBadSignerPubkey:      errorInfo{400, "CH107", "Block signer pubkey is invalid"},
+		config.ErrBadQuorum:            errorInfo{400, "CH108", "Quorum must be greater than 0 if there are signers"},
 		errProdReset:                   errorInfo{400, "CH110", "Reset can only be called in a development system"},
 		errNoClientTokens:              errorInfo{400, "CH120", "Cannot enable client authentication with no client tokens"},
 		blocksigner.ErrConsensusChange: errorInfo{400, "CH150", "Refuse to sign block with consensus change"},


### PR DESCRIPTION
Move `core.Config` and related functions into a new package, `core/config`.
This allows corectl to not import `chain/core` and by extension the
dashboard & documentation.

The `corectl` binary size is reduced from 52M to 15M.