### PR TITLE
core/query: fix block processor race

### DIFF
--- a/core/query/index.go
+++ b/core/query/index.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lib/pq"
 
+	"chain/core/asset"
 	"chain/database/pg"
 	"chain/errors"
 	"chain/protocol/bc"
@@ -38,6 +39,8 @@ func (ind *Indexer) ProcessBlocks(ctx context.Context) {
 // IndexTransactions is registered as a block callback on the Chain. It
 // saves all annotated transactions to the database.
 func (ind *Indexer) IndexTransactions(ctx context.Context, b *bc.Block) error {
+	<-ind.pinStore.Pin(asset.PinName).WaitForHeight(b.Height)
+
 	err := ind.insertBlock(ctx, b)
 	if err != nil {
 		return err

--- a/core/query/index_test.go
+++ b/core/query/index_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"chain/core/pin"
 	"chain/database/pg/pgtest"
 	"chain/protocol"
 	"chain/protocol/bc"
@@ -13,7 +14,9 @@ func TestIndexBlock(t *testing.T) {
 	ctx := context.Background()
 	db := pgtest.NewTx(t)
 
-	indexer := NewIndexer(db, &protocol.Chain{}, nil)
+	pinStore := &pin.Store{DB: db}
+
+	indexer := NewIndexer(db, &protocol.Chain{}, pinStore)
 	b := &bc.Block{
 		Transactions: []*bc.Tx{},
 	}


### PR DESCRIPTION
Previously, if the transaction index processor completed before the
asset processor, the transaction index would be missing data. This
change introduces a wait that blocks until the asset processor has
finished the given block.

Closes #76 