### PR TITLE
core/pin: remove racy Listen test

### DIFF
--- a/core/pin/pin_test.go
+++ b/core/pin/pin_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"chain/database/pg/pgtest"
-	"chain/database/sql"
 )
 
 func TestWaitForHeight(t *testing.T) {
@@ -28,43 +27,6 @@ func TestWaitForHeight(t *testing.T) {
 	}(sctx)
 
 	err := p.RaiseTo(ctx, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = <-ch
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestListen(t *testing.T) {
-	ctx := context.Background()
-
-	dbURL := pgtest.DBURL
-	if dbURL == "" {
-		dbURL = pgtest.DefaultURL
-	}
-
-	db, err := sql.Open("postgres", dbURL)
-
-	p := newPin(db, "test", 0)
-
-	sctx, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
-	ch := make(chan error)
-
-	go p.Listen(sctx, dbURL)
-	go func(ctx context.Context) {
-		select {
-		case <-ctx.Done():
-			ch <- ctx.Err()
-		case <-p.WaitForHeight(1):
-			ch <- nil
-		}
-	}(sctx)
-
-	_, err = db.Exec(ctx, `SELECT pg_notify('pin-test'::text, '1')`)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
There is no way to guarantee that this test will pass, since notify may
be called before Listen is ready.