### PR TITLE
core/coreunsafe: truncate block_processors on reset

### DIFF
--- a/core/coreunsafe/reset.go
+++ b/core/coreunsafe/reset.go
@@ -39,6 +39,7 @@ func ResetBlockchain(ctx context.Context, db pg.DB) error {
 			annotated_txs,
 			asset_tags,
 			assets,
+			block_processors,
 			blocks,
 			config,
 			generator_pending_block,


### PR DESCRIPTION
This prevents block processors from ignoring blocks after a reset.