### PR TITLE
bin/build-centos-rpm: new command

### DIFF
--- a/bin/build-centos-rpm
+++ b/bin/build-centos-rpm
@@ -1,0 +1,47 @@
+#!/bin/sh
+# This command packages an rpm compatible with
+# CentOS versions 5.11 and 6.8. The package will
+# include cored, corectl and a SysVinit script.
+#
+# The command takes a version number as its only
+# argument. Currently, we use YYYYMMDD datestamps
+# as versions for developer edition packages.
+# The command will default to this convention.
+#
+# usage: build-centos-rpm [VERSION]
+
+set -xue
+
+# Disable cgo entirely.
+# We have seen one too many problems with cgo,
+# including an occasional (rare) malloc failure.
+# See https://github.com/lib/pq/issues/395.
+export CGO_ENABLED=0
+
+version=${1:-`date +%Y%m%d`}
+out=`mktemp -d /tmp/build-centos-rpm.XXXXXXXX`
+commit=`git rev-parse HEAD`
+date=`date +%s`
+ldflags="-X main.buildTag=dev -X main.buildCommit=$commit -X main.buildDate=$date"
+
+cleanup() {
+  rm -f $CHAIN/docker/centos-rpm/cored
+  rm -f $CHAIN/docker/centos-rpm/corectl
+  rm -rf $out
+}
+trap "cleanup" EXIT
+
+GOOS=linux GOARCH=amd64 go build\
+  -tags 'insecure_disable_https_redirect'\
+  -ldflags "$ldflags"\
+  -o $CHAIN/docker/centos-rpm/cored\
+  chain/cmd/cored
+
+GOOS=linux GOARCH=amd64 go build\
+  -o $CHAIN/docker/centos-rpm/corectl\
+  chain/cmd/corectl
+
+docker build --tag centos-rpm $CHAIN/docker/centos-rpm/
+docker run -it --rm -v "$out":/output -e VERSION="$version" centos-rpm
+aws s3 cp $out/cored-$version-1.x86_64.rpm s3://chain-core/centos/$version/cored-$version-1.x86_64.rpm --acl public-read
+aws s3 cp $out/cored-$version-1.x86_64.rpm s3://chain-core/centos/latest/cored-latest-1.x86_64.rpm --acl public-read

--- a/docker/centos-rpm/.gitignore
+++ b/docker/centos-rpm/.gitignore
@@ -1,0 +1,3 @@
+/cored
+/corectl
+/schema.sql

--- a/docker/centos-rpm/Dockerfile
+++ b/docker/centos-rpm/Dockerfile
@@ -1,0 +1,13 @@
+FROM centos:7
+
+RUN yum install -y gcc make rpm-build ruby-devel \
+    && gem install fpm
+
+COPY corectl /usr/bin/corectl
+COPY cored /usr/bin/cored
+COPY init /etc/init.d/cored
+COPY before-install /before-install
+COPY after-install /after-install
+COPY after-remove /after-remove
+COPY startup.sh /startup.sh
+ENTRYPOINT /startup.sh

--- a/docker/centos-rpm/Readme.md
+++ b/docker/centos-rpm/Readme.md
@@ -1,0 +1,29 @@
+#Chain Core Developer Edition - CentOS RPM builder
+##Introduction
+This image is used to build an rpm compatible with CentOS versions 5.11 and 6.8
+The resulting rpm includes:
+- the `cored` binary
+- the `corectl` binary
+- a SysVinit script
+
+A configuration file `/etc/cored.env` must be added to the intended
+host. It should contain relevant export commands for env setup.
+
+For example:
+```
+export DATABASE_URL=...
+export LISTEN=:<port>
+```
+
+##Build image
+```
+$ docker build --tag centos-rpm $CHAIN/docker/centos-rpm/
+```
+
+##Build rpm
+Upon running the container, a host directory must be mounted to the
+container's `/output` directory. The rpm will be generated there. The
+rpm will also need a version number passed as the VERSION env var.
+```
+$ docker run -it --rm -v /path/to/output/dir:/output -e VERSION=XXXXXXXX centos-rpm
+```

--- a/docker/centos-rpm/after-install
+++ b/docker/centos-rpm/after-install
@@ -1,0 +1,1 @@
+chkconfig --add cored

--- a/docker/centos-rpm/after-remove
+++ b/docker/centos-rpm/after-remove
@@ -1,0 +1,1 @@
+userdel cored

--- a/docker/centos-rpm/before-install
+++ b/docker/centos-rpm/before-install
@@ -1,0 +1,1 @@
+/usr/sbin/adduser -r --shell /bin/bash cored

--- a/docker/centos-rpm/init
+++ b/docker/centos-rpm/init
@@ -1,0 +1,66 @@
+#!/bin/sh
+#
+# /etc/init.d/cored
+# Subsystem file for Chain Core api server
+#
+# chkconfig: 2345 95 05
+# description: Chain Core api server daemon
+# processname: cored
+
+
+# Set variables
+RETVAL=0
+cfg="/etc/cored.env"
+cmd="/usr/bin/cored"
+pname="cored"
+lockfile=/var/lock/subsys/$pname
+
+# Source function library and config vars
+. /etc/init.d/functions
+[ -f $cfg ] && . $cfg
+
+start() {
+    echo -n "Starting $pname: "
+    if [ -f $lockfile ]; then
+      echo "$pname already running..."
+      return 1
+    fi
+    if [ ! -f $cfg ]; then
+      echo "configuration file does not exist: $cfg"
+      return 1
+    fi
+    echo
+    daemon --check cored nohup ${cmd} > /dev/null 2>&1 &
+    RETVAL=$?
+    [ "$RETVAL" = 0 ] && touch $lockfile
+}
+
+stop() {
+    echo -n "Stopping $pname:"
+    killproc $pname -TERM
+    RETVAL=$?
+    echo
+    [ "$RETVAL" = 0 ] && rm -f $lockfile
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status $pname
+        ;;
+    restart)
+        printf "Restarting $pname:\n"
+        stop
+        start
+        ;;
+    *)
+        echo "Usage: $pname {start|stop|status|restart}"
+        exit 1
+        ;;
+esac
+exit $?

--- a/docker/centos-rpm/startup.sh
+++ b/docker/centos-rpm/startup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+fpm -n cored -v $VERSION \
+  -s dir -t rpm \
+  -p /output \
+  --before-install /before-install \
+  --after-install /after-install \
+  --after-remove /after-remove \
+  /usr/bin/cored /usr/bin/corectl /etc/init.d/cored


### PR DESCRIPTION
build-centos-rpm utilizes a docker container to build
an rpm compatible with centos 5.11 and 6.8. It takes
an optional version number as an argument and uploads
the resulting rpm to the chain-core s3 bucket. 

The upload takes place from the caller's filesystem so
the aws-cli tool is required.