### PR TITLE
metrics: save space with fewer significant figures

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -48,7 +48,7 @@ type Latency struct {
 // duration limit and with three significant figures of precision.
 func NewLatency(limit time.Duration) *Latency {
 	return &Latency{
-		hdr:   *hdrhistogram.New(0, int64(limit), 3),
+		hdr:   *hdrhistogram.New(0, int64(limit), 2),
 		limit: limit,
 	}
 }
@@ -148,7 +148,7 @@ func (r *RotatingLatency) rotate() {
 //              "Histogram": {
 //                  "LowestTrackableValue": 0,
 //                  "HighestTrackableValue": 1000000000,
-//                  "SignificantFigures": 3,
+//                  "SignificantFigures": 2,
 //                  "Counts": [2,0,15,...]
 //              }
 //          },


### PR DESCRIPTION
We care about the difference between 54ms and 55ms or
230ms and 240ms, but not really between 54ms and 54.1ms
or 230ms and 231ms. Storing only two significant figures
instead of three uses less space. In our case, it uses
about 15% as much space (860kB instead of 5.8MB). This
matters more for efficiency of sampling and storing
metrics than for the performance of cored itself.