### PR TITLE
core/account: remove utxo from SpendAction

### DIFF
--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -14,12 +14,10 @@ import (
 	"chain/protocol/bc"
 )
 
-func (m *Manager) NewSpendAction(amt bc.AssetAmount, accountID string, txHash *bc.Hash, txOut *uint32, refData chainjson.Map, clientToken *string) txbuilder.Action {
+func (m *Manager) NewSpendAction(amt bc.AssetAmount, accountID string, refData chainjson.Map, clientToken *string) txbuilder.Action {
 	return &spendAction{
 		accounts:      m,
 		AssetAmount:   amt,
-		TxHash:        txHash,
-		TxOut:         txOut,
 		AccountID:     accountID,
 		ReferenceData: refData,
 		ClientToken:   clientToken,
@@ -36,8 +34,6 @@ type spendAction struct {
 	accounts *Manager
 	bc.AssetAmount
 	AccountID     string        `json:"account_id"`
-	TxHash        *bc.Hash      `json:"transaction_id"`
-	TxOut         *uint32       `json:"position"`
 	ReferenceData chainjson.Map `json:"reference_data"`
 	ClientToken   *string       `json:"client_token"`
 }
@@ -63,8 +59,6 @@ func (a *spendAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.
 		AssetID:     a.AssetID,
 		Amount:      a.Amount,
 		AccountID:   a.AccountID,
-		TxHash:      a.TxHash,
-		OutputIndex: a.TxOut,
 		ClientToken: a.ClientToken,
 	}
 	rid, reserved, change, err := a.accounts.utxoDB.Reserve(ctx, src, maxTime)

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -63,7 +63,7 @@ func TestBuildFinal(t *testing.T) {
 	accountPin := pinStore.Pin(account.PinName)
 	<-accountPin.WaitForHeight(c.Height())
 
-	sources = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil, nil, nil)
+	sources = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil)
 	tmpl, err = txbuilder.Build(ctx, nil, []txbuilder.Action{sources, dests}, time.Now().Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)
@@ -173,7 +173,7 @@ func TestAccountTransfer(t *testing.T) {
 	<-accountPin.WaitForHeight(c.Height())
 
 	// new source
-	sources = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil, nil, nil)
+	sources = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil)
 	tmpl, err = txbuilder.Build(ctx, nil, []txbuilder.Action{sources, dests}, time.Now().Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)

--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -73,8 +73,8 @@ func TestMockHSM(t *testing.T) {
 	accountPin := pinStore.Pin(account.PinName)
 	<-accountPin.WaitForHeight(c.Height())
 
-	xferSrc1 := accounts.NewSpendAction(bc.AssetAmount{AssetID: asset1ID, Amount: 10}, acct1.ID, nil, nil, nil, nil)
-	xferSrc2 := accounts.NewSpendAction(bc.AssetAmount{AssetID: asset2ID, Amount: 20}, acct2.ID, nil, nil, nil, nil)
+	xferSrc1 := accounts.NewSpendAction(bc.AssetAmount{AssetID: asset1ID, Amount: 10}, acct1.ID, nil, nil)
+	xferSrc2 := accounts.NewSpendAction(bc.AssetAmount{AssetID: asset2ID, Amount: 20}, acct2.ID, nil, nil)
 	xferDest1 := accounts.NewControlAction(bc.AssetAmount{AssetID: asset2ID, Amount: 20}, acct1.ID, nil)
 	xferDest2 := accounts.NewControlAction(bc.AssetAmount{AssetID: asset1ID, Amount: 10}, acct2.ID, nil)
 	tmpl, err = txbuilder.Build(ctx, nil, []txbuilder.Action{xferSrc1, xferSrc2, xferDest1, xferDest2}, time.Now().Add(time.Minute))

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -68,8 +68,8 @@ func TestRecovery(t *testing.T) {
 	coretest.Transfer(ctx, t, c, []txbuilder.Action{
 		accounts.NewControlAction(bc.AssetAmount{AssetID: usd, Amount: 1}, alice, nil),
 		accounts.NewControlAction(bc.AssetAmount{AssetID: apple, Amount: 1}, bob, nil),
-		accounts.NewSpendAction(bc.AssetAmount{AssetID: usd, Amount: 1}, bob, nil, nil, nil, nil),
-		accounts.NewSpendAction(bc.AssetAmount{AssetID: apple, Amount: 1}, alice, nil, nil, nil, nil),
+		accounts.NewSpendAction(bc.AssetAmount{AssetID: usd, Amount: 1}, bob, nil, nil),
+		accounts.NewSpendAction(bc.AssetAmount{AssetID: apple, Amount: 1}, alice, nil, nil),
 	})
 
 	// Save a copy of the pool txs

--- a/core/transact_test.go
+++ b/core/transact_test.go
@@ -50,7 +50,7 @@ func TestLocalAccountTransfer(t *testing.T) {
 	_, _ = h.submitSingle(ctx, submitSingleArg{tpl: tmpl, wait: chainjson.Duration{Duration: time.Millisecond}})
 
 	// Add a new source, spending the change output produced above.
-	sources = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil, nil, nil)
+	sources = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil)
 	tmpl, err = txbuilder.Build(ctx, nil, []txbuilder.Action{sources, dests}, time.Now().Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -55,7 +55,7 @@ func TestConflictingTxsInPool(t *testing.T) {
 		AssetID: info.asset.AssetID,
 		Amount:  10,
 	}
-	spendAction := info.NewSpendAction(assetAmount, info.acctA.ID, nil, nil, nil, nil)
+	spendAction := info.NewSpendAction(assetAmount, info.acctA.ID, nil, nil)
 	dest1 := info.NewControlAction(assetAmount, info.acctB.ID, nil)
 
 	// Build the first tx
@@ -324,7 +324,7 @@ func transfer(ctx context.Context, t testing.TB, info *testInfo, srcAcctID, dest
 		AssetID: info.asset.AssetID,
 		Amount:  amount,
 	}
-	source := info.NewSpendAction(assetAmount, srcAcctID, nil, nil, nil, nil)
+	source := info.NewSpendAction(assetAmount, srcAcctID, nil, nil)
 	dest := info.NewControlAction(assetAmount, destAcctID, nil)
 
 	xferTx, err := Build(ctx, nil, []Action{source, dest}, time.Now().Add(time.Minute))


### PR DESCRIPTION
Remove the transaction hash and index parameters from the account spend
action. Now that we have the SpendUTXOAction, we no longer need to be
able to filter account UTXOs by transaction hash.