### PR TITLE
core: wait until transaction block is processed

### DIFF
--- a/core/transact.go
+++ b/core/transact.go
@@ -94,9 +94,9 @@ func (h *Handler) build(ctx context.Context, buildReqs []*buildRequest) (interfa
 }
 
 type submitSingleArg struct {
-	tpl     *txbuilder.Template
-	wait    chainjson.Duration
-	waitFor string
+	tpl       *txbuilder.Template
+	wait      chainjson.Duration
+	waitUntil string
 }
 
 func (h *Handler) submitSingle(ctx context.Context, x submitSingleArg) (interface{}, error) {
@@ -111,7 +111,7 @@ func (h *Handler) submitSingle(ctx context.Context, x submitSingleArg) (interfac
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	err := h.finalizeTxWait(ctx, x.tpl, x.waitFor)
+	err := h.finalizeTxWait(ctx, x.tpl, x.waitUntil)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func CleanupSubmittedTxs(ctx context.Context, db pg.DB) {
 // confirmed on the blockchain.  ErrRejected means a conflicting tx is
 // on the blockchain.  context.DeadlineExceeded means ctx is an
 // expiring context that timed out.
-func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Template, waitFor string) error {
+func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Template, waitUntil string) error {
 	if txTemplate.Transaction == nil {
 		return errors.Wrap(txbuilder.ErrMissingRawTx)
 	}
@@ -210,7 +210,7 @@ func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Temp
 		}
 	}
 
-	if waitFor == "none" {
+	if waitUntil == "none" {
 		return nil
 	}
 
@@ -219,7 +219,7 @@ func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Temp
 		return err
 	}
 
-	if waitFor == "confirmed" {
+	if waitUntil == "confirmed" {
 		return nil
 	}
 
@@ -273,7 +273,7 @@ func waitForTxInBlock(ctx context.Context, c *protocol.Chain, tx *bc.Tx, height 
 type submitArg struct {
 	Transactions []*txbuilder.Template
 	wait         chainjson.Duration
-	WaitFor      string `json:"wait_for"` // values none, confirmed, processed. default: processed
+	WaitUntil    string `json:"wait_until"` // values none, confirmed, processed. default: processed
 }
 
 // POST /v3/transact/submit
@@ -289,9 +289,9 @@ func (h *Handler) submit(ctx context.Context, x submitArg) interface{} {
 			defer batchRecover(subctx, &responses[i])
 
 			tx, err := h.submitSingle(subctx, submitSingleArg{
-				tpl:     x.Transactions[i],
-				wait:    x.wait,
-				waitFor: x.WaitFor,
+				tpl:       x.Transactions[i],
+				wait:      x.wait,
+				waitUntil: x.WaitUntil,
 			})
 			if err != nil {
 				responses[i] = err

--- a/core/transact.go
+++ b/core/transact.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"chain/core/fetch"
-	"chain/core/query"
 	"chain/core/txbuilder"
 	"chain/database/pg"
 	chainjson "chain/encoding/json"
@@ -95,8 +94,9 @@ func (h *Handler) build(ctx context.Context, buildReqs []*buildRequest) (interfa
 }
 
 type submitSingleArg struct {
-	tpl  *txbuilder.Template
-	wait chainjson.Duration
+	tpl     *txbuilder.Template
+	wait    chainjson.Duration
+	waitFor string
 }
 
 func (h *Handler) submitSingle(ctx context.Context, x submitSingleArg) (interface{}, error) {
@@ -111,7 +111,7 @@ func (h *Handler) submitSingle(ctx context.Context, x submitSingleArg) (interfac
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	err := h.finalizeTxWait(ctx, x.tpl)
+	err := h.finalizeTxWait(ctx, x.tpl, x.waitFor)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func CleanupSubmittedTxs(ctx context.Context, db pg.DB) {
 // confirmed on the blockchain.  ErrRejected means a conflicting tx is
 // on the blockchain.  context.DeadlineExceeded means ctx is an
 // expiring context that timed out.
-func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Template) error {
+func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Template, waitFor string) error {
 	if txTemplate.Transaction == nil {
 		return errors.Wrap(txbuilder.ErrMissingRawTx)
 	}
@@ -210,15 +210,23 @@ func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Temp
 		}
 	}
 
+	if waitFor == "none" {
+		return nil
+	}
+
 	height, err = waitForTxInBlock(ctx, h.Chain, tx, height)
 	if err != nil {
 		return err
 	}
 
+	if waitFor == "confirmed" {
+		return nil
+	}
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-h.PinStore.Pin(query.TxPinName).WaitForHeight(height):
+	case <-h.PinStore.WaitForAll(height):
 	}
 
 	return nil
@@ -265,6 +273,7 @@ func waitForTxInBlock(ctx context.Context, c *protocol.Chain, tx *bc.Tx, height 
 type submitArg struct {
 	Transactions []*txbuilder.Template
 	wait         chainjson.Duration
+	WaitFor      string `json:"wait_for"` // values none, confirmed, processed. default: processed
 }
 
 // POST /v3/transact/submit
@@ -280,8 +289,9 @@ func (h *Handler) submit(ctx context.Context, x submitArg) interface{} {
 			defer batchRecover(subctx, &responses[i])
 
 			tx, err := h.submitSingle(subctx, submitSingleArg{
-				tpl:  x.Transactions[i],
-				wait: x.wait,
+				tpl:     x.Transactions[i],
+				wait:    x.wait,
+				waitFor: x.WaitFor,
 			})
 			if err != nil {
 				responses[i] = err

--- a/sdk/java/src/main/java/com/chain/api/Transaction.java
+++ b/sdk/java/src/main/java/com/chain/api/Transaction.java
@@ -515,6 +515,26 @@ public class Transaction {
   }
 
   /**
+   * Submits a batch of signed transaction templates for inclusion into a block.
+   * @param client client object which makes server requests
+   * @param templates list of transaction templates
+   * @param waitUntil when the server should wait until responding - none, confirmed, processed
+   * @return a list of submit responses (individual objects can hold transaction ids or error info)
+   * @throws APIException This exception is raised if the api returns errors while submitting transactions.
+   * @throws BadURLException This exception wraps java.net.MalformedURLException.
+   * @throws ConnectivityException This exception is raised if there are connectivity issues with the server.
+   * @throws HTTPException This exception is raised when errors occur making http requests.
+   * @throws JSONException This exception is raised due to malformed json requests or responses.
+   */
+  public static BatchResponse<SubmitResponse> submitBatch(Client client, List<Template> templates, String waitUntil)
+      throws ChainException {
+    HashMap<String, Object> body = new HashMap<>();
+    body.put("transactions", templates);
+    body.put("wait_until", waitUntil);
+    return client.batchRequest("submit-transaction", body, SubmitResponse.class, APIException.class);
+  }
+
+  /**
    * Submits signed transaction template for inclusion into a block.
    * @param client client object which makes server requests
    * @param template transaction template
@@ -528,6 +548,25 @@ public class Transaction {
   public static SubmitResponse submit(Client client, Template template) throws ChainException {
     HashMap<String, Object> body = new HashMap<>();
     body.put("transactions", Arrays.asList(template));
+    return client.singletonBatchRequest("submit-transaction", body, SubmitResponse.class, APIException.class);
+  }
+
+  /**
+   * Submits signed transaction template for inclusion into a block.
+   * @param client client object which makes server requests
+   * @param template transaction template
+   * @param waitUntil when the server should wait until responding - none, confirmed, processed
+   * @return submit responses
+   * @throws APIException This exception is raised if the api returns errors while submitting a transaction.
+   * @throws BadURLException This exception wraps java.net.MalformedURLException.
+   * @throws ConnectivityException This exception is raised if there are connectivity issues with the server.
+   * @throws HTTPException This exception is raised when errors occur making http requests.
+   * @throws JSONException This exception is raised due to malformed json requests or responses.
+   */
+  public static SubmitResponse submit(Client client, Template template, String waitUntil) throws ChainException {
+    HashMap<String, Object> body = new HashMap<>();
+    body.put("transactions", Arrays.asList(template));
+    body.put("wait_until", waitUntil);
     return client.singletonBatchRequest("submit-transaction", body, SubmitResponse.class, APIException.class);
   }
 


### PR DESCRIPTION
After introducing block processors, the submit call would return before
the block that contained the transaction had been processed by all
processors. Since this was a change of behavior and since it could cause
confusion when other requests are made before processing, it has been
changed to wait for processing by default. Since finer grain control is
possible, an additional field "WaitFor" has been introduced that will
determine when the submit call returns.