### PR TITLE
cmd/testnet-reset: restrict execution time

### DIFF
--- a/cmd/testnet-reset/main.go
+++ b/cmd/testnet-reset/main.go
@@ -11,7 +11,10 @@ import (
 	"time"
 
 	"chain/core/rpc"
+	"chain/env"
 )
+
+var scheduled = env.Bool("SCHEDULED", true)
 
 type core struct {
 	netTok string
@@ -42,6 +45,15 @@ func coreEnv(prefix string) (*rpc.Client, core) {
 func main() {
 	log.SetFlags(0)
 	ctx := context.Background()
+	env.Parse()
+
+	cur := time.Now()
+	max := cur.Add(time.Hour).Weekday()
+	min := cur.Add(-1 * time.Hour).Weekday()
+	if *scheduled && (min != time.Saturday || max != time.Sunday) {
+		log.Println("only run Sunday at midnight +/- an hour")
+		os.Exit(0)
+	}
 
 	gen, genCore := coreEnv("GENERATOR")
 	sig1, sig1Core := coreEnv("SIGNER1")


### PR DESCRIPTION
The cmd is set up on a Heroku cron job with a max
interval of one day. This commit restricts execution
to when the cmd is initiated manually (SCHEDULED=false)
or the execution time is within an hour of Sunday at
midnight.