### PR TITLE
cmd/sha3: remove redundant info in help output

### DIFF
--- a/cmd/sha3/sha3.go
+++ b/cmd/sha3/sha3.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	size := flag.Int("n", 256, "size in bits of the desired hash: 224, 256 (default), 384, or 512")
+	size := flag.Int("n", 256, "output size in `bits`: 224, 256, 384, or 512")
 	flag.Parse()
 
 	var h hash.Hash


### PR DESCRIPTION
Package flag prints the default value on the end of the
line, so we don't need to say it again. This also makes
the other wording a bit more consise.