### PR TITLE
core/leader: encapsulate leadership state

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -315,10 +315,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 		}
 	}()
 
-	// Note, it's important for any services that will install blockchain
-	// callbacks to be initialized before leader.Run() and the http server,
-	// otherwise there's a data race within protocol.Chain.
-	go leader.Run(db, *listenAddr, func(ctx context.Context) {
+	h.Leadership = leader.Run(db, *listenAddr, func(ctx context.Context) {
 		go h.Accounts.ExpireReservations(ctx, expireReservationsPeriod)
 		if conf.IsGenerator {
 			go generator.Generate(ctx, c, generatorSigners, db, blockPeriod, genhealth)

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -315,7 +315,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 		}
 	}()
 
-	h.Leadership = leader.Run(db, *listenAddr, func(ctx context.Context) {
+	h.Leader = leader.Run(db, *listenAddr, func(ctx context.Context) {
 		go h.Accounts.ExpireReservations(ctx, expireReservationsPeriod)
 		if conf.IsGenerator {
 			go generator.Generate(ctx, c, generatorSigners, db, blockPeriod, genhealth)

--- a/core/api.go
+++ b/core/api.go
@@ -14,7 +14,6 @@ import (
 	"chain/core/account"
 	"chain/core/asset"
 	"chain/core/config"
-	"chain/core/leader"
 	"chain/core/mockhsm"
 	"chain/core/pin"
 	"chain/core/query"
@@ -49,6 +48,11 @@ var (
 	errLeaderElection = errors.New("no leader; pending election")
 )
 
+type Leader interface {
+	IsLeading() bool
+	Address(ctx context.Context) (string, error)
+}
+
 // Handler serves the Chain HTTP API
 type Handler struct {
 	Chain         *protocol.Chain
@@ -60,7 +64,7 @@ type Handler struct {
 	Indexer       *query.Indexer
 	TxFeeds       *txfeed.Tracker
 	AccessTokens  *accesstoken.CredentialStore
-	Leadership    leader.Leadership
+	Leader        Leader
 	Config        *config.Config
 	DB            pg.DB
 	Addr          string
@@ -277,7 +281,7 @@ func (h *Handler) leaderSignHandler(f func(context.Context, *bc.Block) ([]byte, 
 		if f == nil {
 			return nil, errNotFound // TODO(kr): is this really the right error here?
 		}
-		if h.Leadership.IsLeading() {
+		if h.Leader.IsLeading() {
 			return f(ctx, b)
 		}
 		var resp []byte
@@ -291,7 +295,7 @@ func (h *Handler) leaderSignHandler(f func(context.Context, *bc.Block) ([]byte, 
 // request. For that reason, it cannot be used outside of a request-
 // handling context.
 func (h *Handler) forwardToLeader(ctx context.Context, path string, body interface{}, resp interface{}) error {
-	addr, err := h.Leadership.Address(ctx)
+	addr, err := h.Leader.Address(ctx)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/core/api.go
+++ b/core/api.go
@@ -60,6 +60,7 @@ type Handler struct {
 	Indexer       *query.Indexer
 	TxFeeds       *txfeed.Tracker
 	AccessTokens  *accesstoken.CredentialStore
+	Leadership    leader.Leadership
 	Config        *config.Config
 	DB            pg.DB
 	Addr          string
@@ -276,7 +277,7 @@ func (h *Handler) leaderSignHandler(f func(context.Context, *bc.Block) ([]byte, 
 		if f == nil {
 			return nil, errNotFound // TODO(kr): is this really the right error here?
 		}
-		if leader.IsLeading() {
+		if h.Leadership.IsLeading() {
 			return f(ctx, b)
 		}
 		var resp []byte
@@ -290,7 +291,7 @@ func (h *Handler) leaderSignHandler(f func(context.Context, *bc.Block) ([]byte, 
 // request. For that reason, it cannot be used outside of a request-
 // handling context.
 func (h *Handler) forwardToLeader(ctx context.Context, path string, body interface{}, resp interface{}) error {
-	addr, err := leader.Address(ctx, h.DB)
+	addr, err := h.Leadership.Address(ctx)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -59,7 +59,7 @@ func (h *Handler) info(ctx context.Context) (map[string]interface{}, error) {
 			"is_configured": false,
 		}, nil
 	}
-	if h.Leadership.IsLeading() {
+	if h.Leader.IsLeading() {
 		return h.leaderInfo(ctx)
 	} else {
 		var resp map[string]interface{}

--- a/core/core.go
+++ b/core/core.go
@@ -10,7 +10,6 @@ import (
 
 	"chain/core/config"
 	"chain/core/fetch"
-	"chain/core/leader"
 	"chain/errors"
 	"chain/log"
 	"chain/net/http/httpjson"
@@ -60,7 +59,7 @@ func (h *Handler) info(ctx context.Context) (map[string]interface{}, error) {
 			"is_configured": false,
 		}, nil
 	}
-	if leader.IsLeading() {
+	if h.Leadership.IsLeading() {
 		return h.leaderInfo(ctx)
 	} else {
 		var resp map[string]interface{}

--- a/core/leader/leader.go
+++ b/core/leader/leader.go
@@ -13,18 +13,29 @@ import (
 	"chain/log"
 )
 
-var (
-	isLeading bool
-	lock      sync.Mutex
-)
+type Leadership interface {
+	IsLeading() bool
+	Address(ctx context.Context) (string, error)
+}
 
-// IsLeading returns true if this process is
-// the core leader.
-func IsLeading() bool {
-	lock.Lock()
-	l := isLeading
-	lock.Unlock()
-	return l
+type leadership struct {
+	db      pg.DB
+	key     string
+	lead    func(context.Context)
+	address string
+
+	// state
+	mu      sync.Mutex
+	leading bool
+	cancel  func()
+}
+
+// IsLeading returns true if this process is the core leader.
+func (l *leadership) IsLeading() bool {
+	l.mu.Lock()
+	leading := l.leading
+	l.mu.Unlock()
+	return leading
 }
 
 // Run runs as a goroutine, trying once every five seconds to become
@@ -37,12 +48,12 @@ func IsLeading() bool {
 //
 // The Chain Core has up to a 10-second refractory period after
 // shutdown, during which no process can become the new leader.
-func Run(db *sql.DB, addr string, lead func(context.Context)) {
+func Run(db *sql.DB, addr string, lead func(context.Context)) Leadership {
 	ctx := context.Background()
 	// We use our process's address as the key, because it's unique
 	// among all processes within a Core and it allows a restarted
 	// leader to immediately return to its leadership.
-	l := &leader{
+	l := &leadership{
 		db:      db,
 		key:     addr,
 		lead:    lead,
@@ -50,25 +61,16 @@ func Run(db *sql.DB, addr string, lead func(context.Context)) {
 	}
 	log.Messagef(ctx, "Using leaderKey: %q", l.key)
 
-	update(ctx, l)
-	for range time.Tick(5 * time.Second) {
-		update(ctx, l)
-	}
+	l.update(ctx)
+	go func() {
+		for range time.Tick(5 * time.Second) {
+			l.update(ctx)
+		}
+	}()
+	return l
 }
 
-type leader struct {
-	// config
-	db      *sql.DB
-	key     string
-	lead    func(context.Context)
-	address string
-
-	// state
-	leading bool
-	cancel  func()
-}
-
-func update(ctx context.Context, l *leader) {
+func (l *leadership) update(ctx context.Context) {
 	const (
 		insertQ = `
 			INSERT INTO leader (leader_key, address, expiry) VALUES ($1, $2, CURRENT_TIMESTAMP + INTERVAL '10 seconds')
@@ -81,7 +83,7 @@ func update(ctx context.Context, l *leader) {
 		`
 	)
 
-	if l.leading {
+	if l.IsLeading() {
 		res, err := l.db.Exec(ctx, updateQ, l.key)
 		if err == nil {
 			rowsAffected, err := res.RowsAffected()
@@ -98,14 +100,11 @@ func update(ctx context.Context, l *leader) {
 			log.Error(ctx, err)
 		}
 		log.Messagef(ctx, "No longer core leader")
+		l.mu.Lock()
 		l.cancel()
 		l.leading = false
-
-		lock.Lock()
-		isLeading = false
-		lock.Unlock()
-
 		l.cancel = nil
+		l.mu.Unlock()
 	} else {
 		// Try to put this process's key into the leader table.  It
 		// succeeds if the table's empty or the existing row (there can be
@@ -131,24 +130,23 @@ func update(ctx context.Context, l *leader) {
 
 		log.Messagef(ctx, "I am the core leader")
 
-		l.leading = true
-
-		lock.Lock()
-		isLeading = true
-		lock.Unlock()
-
-		ctx, l.cancel = context.WithCancel(ctx)
+		ctx, cancel := context.WithCancel(ctx)
 		go l.lead(ctx)
+
+		l.mu.Lock()
+		l.leading = true
+		l.cancel = cancel
+		l.mu.Unlock()
 	}
 }
 
 // Address retrieves the IP address of the current
 // core leader.
-func Address(ctx context.Context, db pg.DB) (string, error) {
+func (l *leadership) Address(ctx context.Context) (string, error) {
 	const q = `SELECT address FROM leader`
 
 	var addr string
-	err := db.QueryRow(ctx, q).Scan(&addr)
+	err := l.db.QueryRow(ctx, q).Scan(&addr)
 	if err != nil {
 		return "", errors.Wrap(err, "could not fetch leader address")
 	}

--- a/core/transact.go
+++ b/core/transact.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"chain/core/fetch"
-	"chain/core/leader"
 	"chain/core/txbuilder"
 	"chain/database/pg"
 	chainjson "chain/encoding/json"
@@ -74,7 +73,7 @@ func (h *Handler) build(ctx context.Context, buildReqs []*buildRequest) (interfa
 	// If we're not the leader, we don't have access to the current
 	// reservations. Forward the build call to the leader process.
 	// TODO(jackson): Distribute reservations across cored processes.
-	if !leader.IsLeading() {
+	if !h.Leader.IsLeading() {
 		var resp map[string]interface{}
 		err := h.forwardToLeader(ctx, "/build-transaction", buildReqs, &resp)
 		return resp, err


### PR DESCRIPTION
Return a leadership struct from `leader.Run`. This prevents the need for
callers to pass in a pg.DB to `leader.Address`. Also, it will allow
tests to write mock Leadership implementations if they need to test code
that is only run on the leader (like the in-memory reserver).