### PR TITLE
docs: add Ruby documentation to bundled docs

### DIFF
--- a/bin/generate-docs
+++ b/bin/generate-docs
@@ -23,6 +23,18 @@ cp target/chain-sdk-java*[[:digit:]].jar $java_dest_path/chain-sdk-latest.jar
 mkdir -p $javadoc_dest_path
 cp -R target/apidocs/* $javadoc_dest_path
 
+ruby_dest_path=$compile_dest_path/ruby
+ruby_yardoc_dest_path=$ruby_dest_path/doc
+
+echo
+echo "Building Ruby SDK documentation..."
+
+cd $CHAIN/sdk/ruby
+bundle
+bundle exec yardoc 'lib/**/*.rb'
+mkdir -p $ruby_yardoc_dest_path
+cp -R doc/* $ruby_yardoc_dest_path
+
 echo
 echo "Documentation generated. Output directory:"
 echo $compile_dest_path

--- a/sdk/ruby/.gitignore
+++ b/sdk/ruby/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 .yardoc
 *.gem
+doc/

--- a/sdk/ruby/chain-sdk.gemspec
+++ b/sdk/ruby/chain-sdk.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.5.0', '>= 3.5.0'
+  s.add_development_dependency 'yard', '~> 0.9.5', '>= 0.9.5'
 end

--- a/sdk/ruby/lib/chain/access_token.rb
+++ b/sdk/ruby/lib/chain/access_token.rb
@@ -35,7 +35,7 @@ module Chain
         ))
       end
 
-      # @param [Hash] query
+      # @param [Hash] opts
       # @return [Query]
       def query(opts = {})
         Query.new(client, opts)

--- a/sdk/ruby/lib/chain/transaction.rb
+++ b/sdk/ruby/lib/chain/transaction.rb
@@ -68,7 +68,7 @@ module Chain
         ) { |item| Template.new(item) }
       end
 
-      # @param [Array<Builder>] builder
+      # @param [Array<Builder>] builders
       # @return [Array<Template>]
       def build_batch(builders)
         client.conn.batch_request(
@@ -86,7 +86,7 @@ module Chain
         ) { |item| SubmitResponse.new(item) }
       end
 
-      # @param [Array<Template>] template
+      # @param [Array<Template>] templates
       # @return [Array<SubmitResponse>]
       def submit_batch(templates)
         client.conn.batch_request(

--- a/sdk/ruby/lib/chain/version.rb
+++ b/sdk/ruby/lib/chain/version.rb
@@ -1,3 +1,3 @@
 module Chain
-  VERSION = '1.0.20161104'
+  VERSION = '1.0.0.pre'
 end


### PR DESCRIPTION
Adds generation of Ruby docs to generate-docs command, and bundles
the results into the cored executable.

Also:
- fixes some YARD annotation bugs that was breaking generate-docs
- re-bundles the documentation

This does not add a link to the Ruby YARD documentation, which
will happen when we officially release the Ruby SDK. For now, you
can navigate to http://localhost:1999/docs/ruby/doc/index.html .