### PR TITLE
perf: only wait for confirmation

### DIFF
--- a/perf/IouSettlement.java
+++ b/perf/IouSettlement.java
@@ -214,7 +214,7 @@ class Bank {
     List<Transaction.Template> templates = Transaction.buildBatch(client, builders).successes();
     List<Transaction.Template> signedTemplates = HsmSigner.signBatch(templates).successes();
     List<Transaction.SubmitResponse> txs =
-        Transaction.submitBatch(client, signedTemplates).successes();
+        Transaction.submitBatch(client, signedTemplates, "confirmed").successes();
   }
 }
 

--- a/perf/UtxoReservation.java
+++ b/perf/UtxoReservation.java
@@ -35,7 +35,7 @@ public class UtxoReservation {
     System.exit(0);
   }
 
-  static final int utxosPerDenomination = 5;
+  static final int utxosPerDenomination = 100;
   static final int utxoDenominations = 5;
 
   static long totalPerAccount() {
@@ -101,7 +101,7 @@ public class UtxoReservation {
     }
     Transaction.Template template = builder.build(client);
     Transaction.Template signedTemplate = HsmSigner.sign(template);
-    Transaction.SubmitResponse tx = Transaction.submit(client, signedTemplate);
+    Transaction.SubmitResponse tx = Transaction.submit(client, signedTemplate, "confirmed");
   }
 
   static void transact(Client client) throws Exception {
@@ -110,8 +110,8 @@ public class UtxoReservation {
     Account alice = getAccount(client, "alice");
     Account bob = getAccount(client, "bob");
 
-    final int iterations = 600; // 10 minutes
-    final int concurrentPayments = 80;
+    final int iterations = 300; // 5 minutes
+    final int concurrentPayments = 250;
     final int maxPerPayment = (int) totalPerAccount() / concurrentPayments;
 
     Random r = new Random();
@@ -164,7 +164,7 @@ public class UtxoReservation {
                     .setAccountId(to.id));
     Transaction.Template template = builder.build(client);
     Transaction.Template signedTemplate = HsmSigner.sign(template);
-    Transaction.SubmitResponse tx = Transaction.submit(client, signedTemplate);
+    Transaction.SubmitResponse tx = Transaction.submit(client, signedTemplate, "confirmed");
   }
 
   static Asset getAsset(Client client, String alias) throws Exception {


### PR DESCRIPTION
In perf tests, only wait until the tx is confirmed. Also, make
UtxoReservation.java a little more ambitious. I also reduced
its duration to make it a little easier to iterate quickly.