### PR TITLE
docker/testbot: use race detector

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -40,7 +40,7 @@ SDKTARGET=chain-test
 (
 	export DATABASE_URL="postgres:///it-core?sslmode=disable"
 	createdb it-core
-	go install chain/cmd/migratedb chain/cmd/cored chain/cmd/corectl
+	go install -race chain/cmd/migratedb chain/cmd/cored chain/cmd/corectl
 	migratedb -d $DATABASE_URL
 	corectl config-generator
 	cored | tee $initlog &

--- a/docker/testbot/startup.sh
+++ b/docker/testbot/startup.sh
@@ -12,6 +12,7 @@ git clone https://github.com/chain/chain.git $CHAIN
 cd $CHAIN/sdk/java && mvn package && rm -rf $CHAIN/sdk/java/target
 
 /usr/local/go/bin/go install\
+    -race\
     chain/cmd/testbot\
     chain/cmd/benchcore\
 

--- a/docker/testbot/tests.sh
+++ b/docker/testbot/tests.sh
@@ -46,10 +46,10 @@ psql core -f $CHAIN/core/schema.sql
 # TODO(boymanjor): generate credentials
 
 echo 'installing cored'
-go install -tags 'insecure_disable_https_redirect' chain/cmd/cored
+go install -race -tags 'insecure_disable_https_redirect' chain/cmd/cored
 
 echo 'installing corectl'
-go install chain/cmd/corectl
+go install -race chain/cmd/corectl
 
 echo 'running integration tests'
 $GOPATH/bin/corectl config-generator


### PR DESCRIPTION
When compiling cored for integration tests, compile with -race to enable
the race detector.