### PR TITLE
core/pin: enable multi-process block processing

### DIFF
--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestMockHSM(t *testing.T) {
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	dbURL, db := pgtest.NewDB(t, pgtest.SchemaPath)
 	ctx := context.Background()
 	c := prottest.NewChain(t)
 	assets := asset.NewRegistry(db, c)
@@ -28,7 +28,8 @@ func TestMockHSM(t *testing.T) {
 	pinStore := pin.NewStore(db)
 	coretest.CreatePins(ctx, t, pinStore)
 	accounts.IndexAccounts(query.NewIndexer(db, c, pinStore), pinStore)
-	go accounts.ProcessBlocks(ctx)
+	go pinStore.QueueBlocks(ctx, c, account.PinName)
+	go accounts.ProcessBlocks(ctx, "testhost", dbURL)
 	mockhsm := mockhsm.New(db)
 
 	xpub1, err := mockhsm.XCreate(ctx, "")

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -30,4 +30,14 @@ var migrations = []migration{
 			height bigint DEFAULT 0 NOT NULL
 		);
 	`},
+	{Name: "2016-11-07.0.core.add-block-processor-queue.sql", SQL: `
+		CREATE TABLE block_processor_queue (
+			name text NOT NULL,
+			height bigint NOT NULL,
+			held_by text,
+			held_at timestamptz,
+			PRIMARY KEY (name, height)
+		);
+		ALTER TABLE block_processors ADD COLUMN queued_height bigint DEFAULT 0 NOT NULL;
+	`},
 }

--- a/core/pin/pin.go
+++ b/core/pin/pin.go
@@ -14,10 +14,7 @@ import (
 	"chain/protocol/bc"
 )
 
-const (
-	queueTimeout = time.Second * 5
-	queueCheck   = time.Millisecond * 500
-)
+const queueTimeout = time.Second * 5
 
 type Store struct {
 	db pg.DB

--- a/core/pin/pin.go
+++ b/core/pin/pin.go
@@ -38,16 +38,13 @@ func (s *Store) ProcessBlock(ctx context.Context, c *protocol.Chain, processID, 
 	if err != nil {
 		return err
 	}
+	defer s.Release(ctx, processID, name, height)
 	block, err := c.GetBlock(ctx, height)
 	if err != nil {
 		return err
 	}
 	err = f(ctx, block)
 	if err != nil {
-		releaseErr := s.Release(ctx, processID, name, height)
-		if err != nil {
-			log.Error(ctx, releaseErr)
-		}
 		return err
 	}
 	return s.Complete(ctx, processID, name, height)

--- a/core/pin/pin.go
+++ b/core/pin/pin.go
@@ -2,14 +2,21 @@ package pin
 
 import (
 	"context"
+	"database/sql"
 	"strconv"
 	"sync"
+	"time"
 
 	"chain/database/pg"
 	"chain/errors"
 	"chain/log"
 	"chain/protocol"
 	"chain/protocol/bc"
+)
+
+const (
+	queueTimeout = time.Second * 5
+	queueCheck   = time.Millisecond * 500
 )
 
 type Store struct {
@@ -29,31 +36,135 @@ func NewStore(db pg.DB) *Store {
 	return s
 }
 
-func (s *Store) ProcessBlocks(ctx context.Context, c *protocol.Chain, pinName string, cb func(context.Context, *bc.Block) error) {
-	p := <-s.pin(pinName)
+func (s *Store) ProcessBlock(ctx context.Context, c *protocol.Chain, processID, name string, f func(context.Context, *bc.Block) error) error {
+	height, err := s.HeightToProcess(ctx, processID, name)
+	if err != nil {
+		return err
+	}
+	block, err := c.GetBlock(ctx, height)
+	if err != nil {
+		return err
+	}
+	err = f(ctx, block)
+	if err != nil {
+		releaseErr := s.Release(ctx, processID, name, height)
+		if err != nil {
+			log.Error(ctx, releaseErr)
+		}
+		return err
+	}
+	return s.Complete(ctx, processID, name, height)
+}
+
+func (s *Store) HeightToProcess(ctx context.Context, processID, name string) (uint64, error) {
+	p := <-s.pin(name)
+	<-p.waitForQueue()
 	for {
-		height := p.getHeight()
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-p.queueListener:
+		}
+		const q = `
+			WITH block AS (
+				SELECT name, height FROM block_processor_queue
+				WHERE name=$1 AND (held_by IS NULL OR held_at<$2)
+				FOR UPDATE SKIP LOCKED
+				LIMIT 1
+			)
+			UPDATE block_processor_queue bpq
+			SET held_by=$3, held_at=$4
+			FROM block
+			WHERE (bpq.name, bpq.height) = (block.name, block.height)
+			RETURNING bpq.height
+		`
+		var height uint64
+		err := s.db.QueryRow(ctx, q, name, time.Now().Add(-queueTimeout), processID, time.Now()).Scan(&height)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return 0, errors.Wrap(err)
+		}
+		return height, nil
+	}
+}
+
+func (s *Store) Complete(ctx context.Context, processID, name string, height uint64) error {
+	p := <-s.pin(name)
+	const deleteQ = `
+		DELETE FROM block_processor_queue WHERE (name, height) = ($1, $2) AND held_by=$3
+	`
+	_, err := s.db.Exec(ctx, deleteQ, name, height, processID)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	const heightQ = `
+		SELECT
+			COALESCE((SELECT MIN(height) FROM block_processor_queue WHERE name=$1), 0) AS min_queued,
+			queued_height FROM block_processors WHERE name=$1
+	`
+	var minQueued, maxQueued uint64
+	err = s.db.QueryRow(ctx, heightQ, name).Scan(&minQueued, &maxQueued)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	var processedHeight uint64
+	if minQueued == 0 { // no queued items
+		processedHeight = maxQueued
+	} else {
+		processedHeight = minQueued - 1
+	}
+
+	return p.raiseTo(ctx, processedHeight)
+}
+
+// Release frees a held processor job in the queue.
+// It can
+func (s *Store) Release(ctx context.Context, processID, name string, height uint64) error {
+	const q = `
+		WITH updated AS (
+			UPDATE block_processor_queue
+			SET held_by=NULL, held_at=NULL
+			WHERE (name, height)=($1, $2) AND held_by=$3
+			RETURNING name, height
+		)
+		SELECT pg_notify(name, height) FROM updated;
+	`
+	_, err := s.db.Exec(ctx, q, name, height)
+	return errors.Wrap(err)
+}
+
+func (s *Store) QueueBlocks(ctx context.Context, c *protocol.Chain, name string) {
+	p := <-s.pin(name)
+	for {
+		height := p.getQueuedHeight()
 		select {
 		case <-ctx.Done(): // leader deposed
 			log.Error(ctx, ctx.Err())
 			return
 		case <-c.WaitForBlock(height + 1):
-			block, err := c.GetBlock(ctx, height+1)
+			err := s.addToQueue(ctx, name, height+1)
 			if err != nil {
 				log.Error(ctx, err)
 				continue
-			}
-			err = cb(ctx, block)
-			if err != nil {
-				log.Error(ctx, err)
-				continue
-			}
-			err = p.raiseTo(ctx, block.Height)
-			if err != nil {
-				log.Error(ctx, err)
 			}
 		}
 	}
+}
+
+func (s *Store) addToQueue(ctx context.Context, name string, height uint64) error {
+	const insertQ = `
+		INSERT INTO block_processor_queue (name, height) VALUES($1, $2)
+		ON CONFLICT(name, height) DO NOTHING;
+	`
+	_, err := s.db.Exec(ctx, insertQ, name, height)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	p := <-s.pin(name)
+	return p.raiseQueuedHeight(ctx, height)
 }
 
 func (s *Store) CreatePin(ctx context.Context, name string, height uint64) error {
@@ -63,10 +174,10 @@ func (s *Store) CreatePin(ctx context.Context, name string, height uint64) error
 		return nil
 	}
 	const q = `
-		INSERT INTO block_processors (name, height) VALUES($1, $2)
+		INSERT INTO block_processors (name, height, queued_height) VALUES($1, $2, $3)
 		ON CONFLICT(name) DO NOTHING;
 	`
-	_, err := s.db.Exec(ctx, q, name, height)
+	_, err := s.db.Exec(ctx, q, name, height, height)
 	if err != nil {
 		return errors.Wrap(err)
 	}
@@ -99,9 +210,9 @@ func (s *Store) pin(name string) <-chan *pin {
 	return ch
 }
 
-func (s *Store) WaitForPin(pinName string, height uint64) <-chan struct{} {
+func (s *Store) WaitForPin(name string, height uint64) <-chan struct{} {
 	ch := make(chan struct{}, 1)
-	p := <-s.pin(pinName)
+	p := <-s.pin(name)
 	go func() {
 		p.mu.Lock()
 		defer p.mu.Unlock()
@@ -130,73 +241,139 @@ func (s *Store) WaitForAll(height uint64) <-chan struct{} {
 	return ch
 }
 
-func (s *Store) Listen(ctx context.Context, pinName, dbURL string) {
-	listener, err := pg.NewListener(ctx, dbURL, "pin-"+pinName)
+func (s *Store) Listen(ctx context.Context, name, dbURL string) {
+	listener, err := pg.NewListener(ctx, dbURL, "pin-"+name)
 	if err != nil {
 		log.Error(ctx, err)
 		return
 	}
-	go func() {
-		defer listener.Close()
+	defer listener.Close()
 
-		var p *pin
+	var p *pin
 
-		for {
-			select {
-			case <-ctx.Done():
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case n := <-listener.Notify:
+			height, err := strconv.ParseUint(n.Extra, 10, 64)
+			if err != nil {
+				log.Error(ctx, errors.Wrap(err, "parsing db notification payload"))
 				return
-
-			case n := <-listener.Notify:
-				height, err := strconv.ParseUint(n.Extra, 10, 64)
-				if err != nil {
-					log.Error(ctx, errors.Wrap(err, "parsing db notification payload"))
-					return
-				}
-
-				if p == nil {
-					s.mu.Lock()
-					var ok bool
-					p, ok = s.pins[pinName]
-					if !ok {
-						p = newPin(s.db, pinName, height)
-						s.pins[pinName] = p
-						s.cond.Broadcast()
-					}
-					s.mu.Unlock()
-				}
-
-				p.mu.Lock()
-				if p.height < height {
-					p.height = height
-					p.cond.Broadcast()
-				}
-				p.mu.Unlock()
 			}
-		}
-	}()
 
-	return
+			if p == nil {
+				s.mu.Lock()
+				var ok bool
+				p, ok = s.pins[name]
+				if !ok {
+					p = newPin(s.db, name, height)
+					s.pins[name] = p
+					s.cond.Broadcast()
+				}
+				s.mu.Unlock()
+			}
+
+			p.mu.Lock()
+			if p.height < height {
+				p.height = height
+				p.cond.Broadcast()
+			}
+			p.mu.Unlock()
+		}
+	}
+}
+
+func (s *Store) ListenQueue(ctx context.Context, name, dbURL string) {
+	p := <-s.pin(name)
+	listener, err := pg.NewListener(ctx, dbURL, "pinqueue-"+p.name)
+	if err != nil {
+		log.Error(ctx, err)
+		return
+	}
+	p.mu.Lock()
+	p.queueListener = make(chan struct{}, 1)
+	p.cond.Broadcast()
+	p.mu.Unlock()
+	defer listener.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-listener.Notify:
+			p.queueListener <- struct{}{}
+		}
+	}
 }
 
 type pin struct {
-	mu     sync.Mutex
-	cond   sync.Cond
-	height uint64
+	mu            sync.Mutex
+	cond          sync.Cond
+	height        uint64
+	queuedHeight  uint64
+	queueListener chan struct{}
 
 	db   pg.DB
 	name string
 }
 
 func newPin(db pg.DB, name string, height uint64) *pin {
-	p := &pin{db: db, name: name, height: height}
+	p := &pin{db: db, name: name, height: height, queuedHeight: height}
 	p.cond.L = &p.mu
 	return p
+}
+
+func (p *pin) waitForQueue() <-chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		for p.queueListener == nil {
+			p.cond.Wait()
+		}
+		ch <- struct{}{}
+	}()
+	return ch
 }
 
 func (p *pin) getHeight() uint64 {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.height
+}
+
+func (p *pin) getQueuedHeight() uint64 {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.queuedHeight
+}
+
+func (p *pin) raiseQueuedHeight(ctx context.Context, height uint64) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	const q = `UPDATE block_processors SET queued_height=$1 WHERE queued_height<$1 AND name=$2`
+	_, err := p.db.Exec(ctx, q, height, p.name)
+	if err != nil {
+		return err
+	}
+
+	const notifyQ = `SELECT pg_notify($1, $2)`
+	_, err = p.db.Exec(ctx, notifyQ, "pinqueue-"+p.name, height)
+	if err != nil {
+		return err
+	}
+
+	if height > p.queuedHeight {
+		p.queuedHeight = height
+		go func() {
+			<-p.waitForQueue()
+			p.queueListener <- struct{}{}
+		}()
+	}
+	return nil
 }
 
 func (p *pin) raiseTo(ctx context.Context, height uint64) error {

--- a/core/pin/pin_test.go
+++ b/core/pin/pin_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"chain/database/pg/pgtest"
+	"chain/testutil"
 )
 
 func TestWaitForPin(t *testing.T) {
@@ -35,5 +36,69 @@ func TestWaitForPin(t *testing.T) {
 	err = <-ch
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestComplete(t *testing.T) {
+	dbURL, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	ctx := context.Background()
+
+	store := NewStore(db)
+	err := store.CreatePin(ctx, "x", 1)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+	go store.ListenQueue(ctx, "x", dbURL)
+
+	err = store.addToQueue(ctx, "x", 2)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+
+	height, err := store.HeightToProcess(ctx, "testprocess", "x")
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+
+	err = store.Complete(ctx, "testprocess", "x", height)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+
+	p := <-store.pin("x")
+	if p.getHeight() != 2 {
+		t.Errorf("got height = %d want %d", p.getHeight(), 2)
+	}
+}
+
+func TestRelease(t *testing.T) {
+	dbURL, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	ctx := context.Background()
+
+	store := NewStore(db)
+	err := store.CreatePin(ctx, "x", 1)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+	go store.ListenQueue(ctx, "x", dbURL)
+
+	err = store.addToQueue(ctx, "x", 2)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+
+	height, err := store.HeightToProcess(ctx, "testprocess", "x")
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+
+	err = store.Release(ctx, "testprocess", "x", height)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+
+	p := <-store.pin("x")
+	if p.getHeight() != 1 {
+		t.Errorf("got height = %d want %d", p.getHeight(), 1)
 	}
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -459,12 +459,25 @@ CREATE SEQUENCE assets_key_index_seq
 
 
 --
+-- Name: block_processor_queue; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE block_processor_queue (
+    name text NOT NULL,
+    height bigint NOT NULL,
+    held_by text,
+    held_at timestamp with time zone
+);
+
+
+--
 -- Name: block_processors; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE block_processors (
     name text NOT NULL,
-    height bigint DEFAULT 0 NOT NULL
+    height bigint DEFAULT 0 NOT NULL,
+    queued_height bigint DEFAULT 0 NOT NULL
 );
 
 
@@ -812,6 +825,14 @@ ALTER TABLE ONLY assets
 
 
 --
+-- Name: block_processor_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY block_processor_queue
+    ADD CONSTRAINT block_processor_queue_pkey PRIMARY KEY (name, height);
+
+
+--
 -- Name: block_processors_name_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1128,3 +1149,4 @@ ALTER TABLE ONLY account_utxos
 insert into migrations (filename, hash) values ('2016-10-17.0.core.schema-snapshot.sql', 'cff5210e2d6af410719c223a76443f73c5c12fe875f0efecb9a0a5937cf029cd');
 insert into migrations (filename, hash) values ('2016-10-19.0.core.add-core-id.sql', '9353da072a571d7a633140f2a44b6ac73ffe9e27223f7c653ccdef8df3e8139e');
 insert into migrations (filename, hash) values ('2016-10-31.0.core.add-block-processors.sql', '9e9488e0039337967ef810b09a8f7822e23b3918a49a6308f02db24ddf3e490f');
+insert into migrations (filename, hash) values ('2016-11-4.0.core.add-block-processor-queue.sql', 'b77d84a4423562cd7f1d7a5c1d91829e078758db55d2553edccdfe52e6d710a5');

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -1149,4 +1149,4 @@ ALTER TABLE ONLY account_utxos
 insert into migrations (filename, hash) values ('2016-10-17.0.core.schema-snapshot.sql', 'cff5210e2d6af410719c223a76443f73c5c12fe875f0efecb9a0a5937cf029cd');
 insert into migrations (filename, hash) values ('2016-10-19.0.core.add-core-id.sql', '9353da072a571d7a633140f2a44b6ac73ffe9e27223f7c653ccdef8df3e8139e');
 insert into migrations (filename, hash) values ('2016-10-31.0.core.add-block-processors.sql', '9e9488e0039337967ef810b09a8f7822e23b3918a49a6308f02db24ddf3e490f');
-insert into migrations (filename, hash) values ('2016-11-4.0.core.add-block-processor-queue.sql', 'b77d84a4423562cd7f1d7a5c1d91829e078758db55d2553edccdfe52e6d710a5');
+insert into migrations (filename, hash) values ('2016-11-07.0.core.add-block-processor-queue.sql', 'b77d84a4423562cd7f1d7a5c1d91829e078758db55d2553edccdfe52e6d710a5');

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 func TestSighashCheck(t *testing.T) {
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	dbURL, db := pgtest.NewDB(t, pgtest.SchemaPath)
 	ctx := context.Background()
-	info, err := bootdb(ctx, db, t)
+	info, err := bootdb(ctx, db, dbURL, t)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
None of the block processors need to be processed in sequence, or by
only the leader. This introduces a queue with jobs that allows any
process to perform the block processing work.