### PR TITLE
protocol, core/pin: WaitForX -> XWaiter

### DIFF
--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -42,7 +42,7 @@ func TestAccountSourceReserve(t *testing.T) {
 	accounts.IndexAccounts(indexer, pinStore)
 	go accounts.ProcessBlocks(ctx)
 	prottest.MakeBlock(t, c)
-	<-pinStore.WaitForPin(account.PinName, c.Height())
+	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	assetAmount1 := bc.AssetAmount{
 		AssetID: asset,
@@ -96,7 +96,7 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 	accounts.IndexAccounts(indexer, pinStore)
 	go accounts.ProcessBlocks(ctx)
 	prottest.MakeBlock(t, c)
-	<-pinStore.WaitForPin(account.PinName, c.Height())
+	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	source := accounts.NewSpendUTXOAction(out.Outpoint)
 	buildResult, err := source.Build(ctx, time.Now().Add(time.Minute))
@@ -145,7 +145,7 @@ func TestAccountSourceReserveIdempotency(t *testing.T) {
 	accounts.IndexAccounts(indexer, pinStore)
 	go accounts.ProcessBlocks(ctx)
 	prottest.MakeBlock(t, c)
-	<-pinStore.WaitForPin(account.PinName, c.Height())
+	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	reserveFunc := func(source txbuilder.Action) []*bc.TxInput {
 		buildResult, err := source.Build(ctx, time.Now().Add(time.Minute))

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -61,7 +61,7 @@ func TestBuildFinal(t *testing.T) {
 
 	// Make a block so that UTXOs from the above tx are available to spend.
 	prottest.MakeBlock(t, c)
-	<-pinStore.WaitForPin(account.PinName, c.Height())
+	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	sources = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil)
 	tmpl, err = txbuilder.Build(ctx, nil, []txbuilder.Action{sources, dests}, time.Now().Add(time.Minute))
@@ -170,7 +170,7 @@ func TestAccountTransfer(t *testing.T) {
 
 	// Make a block so that UTXOs from the above tx are available to spend.
 	prottest.MakeBlock(t, c)
-	<-pinStore.WaitForPin(account.PinName, c.Height())
+	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	// new source
 	sources = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil)
@@ -253,7 +253,7 @@ func TestTransfer(t *testing.T) {
 
 	// Make a block so that UTXOs from the above tx are available to spend.
 	prottest.MakeBlock(t, c)
-	<-pinStore.WaitForPin(account.PinName, c.Height())
+	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	// Now transfer
 	buildReqFmt := `

--- a/core/blocksigner/blocksigner.go
+++ b/core/blocksigner/blocksigner.go
@@ -65,7 +65,7 @@ func (s *Signer) String() string {
 // This function fails if this node has ever signed a different block at the
 // same height as b.
 func (s *Signer) ValidateAndSignBlock(ctx context.Context, b *bc.Block) ([]byte, error) {
-	err := <-s.c.WaitForBlockSoon(ctx, b.Height-1)
+	err := <-s.c.BlockSoonWaiter(ctx, b.Height-1)
 	if err != nil {
 		return nil, errors.Wrapf(err, "waiting for block at height %d", b.Height-1)
 	}

--- a/core/generator/generator_test.go
+++ b/core/generator/generator_test.go
@@ -40,7 +40,7 @@ func TestGeneratorRecovery(t *testing.T) {
 
 	// Wait for the block to land, and then make sure it's the same block
 	// that was pending before we ran Generate.
-	<-c.WaitForBlock(pendingBlock.Height)
+	<-c.BlockWaiter(pendingBlock.Height)
 	confirmedBlock, err := c.GetBlock(ctx, pendingBlock.Height)
 	if err != nil {
 		testutil.FatalErr(t, err)

--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -71,7 +71,7 @@ func TestMockHSM(t *testing.T) {
 
 	// Make a block so that UTXOs from the above tx are available to spend.
 	prottest.MakeBlock(t, c)
-	<-pinStore.WaitForPin(account.PinName, c.Height())
+	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	xferSrc1 := accounts.NewSpendAction(bc.AssetAmount{AssetID: asset1ID, Amount: 10}, acct1.ID, nil, nil)
 	xferSrc2 := accounts.NewSpendAction(bc.AssetAmount{AssetID: asset2ID, Amount: 20}, acct2.ID, nil, nil)

--- a/core/pin/pin.go
+++ b/core/pin/pin.go
@@ -37,7 +37,7 @@ func (s *Store) ProcessBlocks(ctx context.Context, c *protocol.Chain, pinName st
 		case <-ctx.Done(): // leader deposed
 			log.Error(ctx, ctx.Err())
 			return
-		case <-c.WaitForBlock(height + 1):
+		case <-c.BlockWaiter(height + 1):
 			block, err := c.GetBlock(ctx, height+1)
 			if err != nil {
 				log.Error(ctx, err)
@@ -99,7 +99,7 @@ func (s *Store) pin(name string) <-chan *pin {
 	return ch
 }
 
-func (s *Store) WaitForPin(pinName string, height uint64) <-chan struct{} {
+func (s *Store) PinWaiter(pinName string, height uint64) <-chan struct{} {
 	ch := make(chan struct{}, 1)
 	p := <-s.pin(pinName)
 	go func() {
@@ -113,7 +113,7 @@ func (s *Store) WaitForPin(pinName string, height uint64) <-chan struct{} {
 	return ch
 }
 
-func (s *Store) WaitForAll(height uint64) <-chan struct{} {
+func (s *Store) AllWaiter(height uint64) <-chan struct{} {
 	ch := make(chan struct{}, 1)
 	go func() {
 		var pins []string
@@ -123,7 +123,7 @@ func (s *Store) WaitForAll(height uint64) <-chan struct{} {
 		}
 		s.mu.Unlock()
 		for _, name := range pins {
-			<-s.WaitForPin(name, height)
+			<-s.PinWaiter(name, height)
 		}
 		ch <- struct{}{}
 	}()

--- a/core/pin/pin_test.go
+++ b/core/pin/pin_test.go
@@ -22,7 +22,7 @@ func TestWaitForPin(t *testing.T) {
 		select {
 		case <-ctx.Done():
 			ch <- ctx.Err()
-		case <-s.WaitForPin("test", 1):
+		case <-s.PinWaiter("test", 1):
 			ch <- nil
 		}
 	}(sctx)

--- a/core/query/index.go
+++ b/core/query/index.go
@@ -39,7 +39,7 @@ func (ind *Indexer) ProcessBlocks(ctx context.Context) {
 // IndexTransactions is registered as a block callback on the Chain. It
 // saves all annotated transactions to the database.
 func (ind *Indexer) IndexTransactions(ctx context.Context, b *bc.Block) error {
-	<-ind.pinStore.WaitForPin(asset.PinName, b.Height)
+	<-ind.pinStore.PinWaiter(asset.PinName, b.Height)
 
 	err := ind.insertBlock(ctx, b)
 	if err != nil {

--- a/core/query/query_test.go
+++ b/core/query/query_test.go
@@ -56,7 +56,7 @@ func setupQueryTest(t *testing.T) (context.Context, *Indexer, time.Time, time.Ti
 	coretest.IssueAssets(ctx, t, c, assets, accounts, asset2.AssetID, 100, acct1.ID)
 
 	prottest.MakeBlock(t, c)
-	<-pinStore.WaitForPin(TxPinName, c.Height())
+	<-pinStore.PinWaiter(TxPinName, c.Height())
 
 	time2 := time.Now()
 

--- a/core/query/transactions.go
+++ b/core/query/transactions.go
@@ -164,7 +164,7 @@ func (ind *Indexer) waitForAndFetchTransactions(ctx context.Context, queryStr st
 		)
 
 		for h := ind.c.Height(); len(txs) == 0; h++ {
-			<-ind.pinStore.WaitForPin(TxPinName, h)
+			<-ind.pinStore.PinWaiter(TxPinName, h)
 			if err != nil {
 				resp <- fetchResp{nil, nil, err}
 				return

--- a/core/rpc.go
+++ b/core/rpc.go
@@ -16,7 +16,7 @@ import (
 // waiting if necessary until one is created.
 // It is an error to request blocks very far in the future.
 func (h *Handler) getBlockRPC(ctx context.Context, height uint64) (chainjson.HexBytes, error) {
-	err := <-h.Chain.WaitForBlockSoon(ctx, height)
+	err := <-h.Chain.BlockSoonWaiter(ctx, height)
 	if err != nil {
 		return nil, errors.Wrapf(err, "waiting for block at height %d", height)
 	}

--- a/core/transact.go
+++ b/core/transact.go
@@ -226,7 +226,7 @@ func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Temp
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-h.PinStore.WaitForAll(height):
+	case <-h.PinStore.AllWaiter(height):
 	}
 
 	return nil
@@ -239,7 +239,7 @@ func waitForTxInBlock(ctx context.Context, c *protocol.Chain, tx *bc.Tx, height 
 		case <-ctx.Done():
 			return 0, ctx.Err()
 
-		case <-c.WaitForBlock(height):
+		case <-c.BlockWaiter(height):
 			b, err := c.GetBlock(ctx, height)
 			if err != nil {
 				return 0, errors.Wrap(err, "getting block that just landed")

--- a/core/txbuilder/finalize.go
+++ b/core/txbuilder/finalize.go
@@ -48,7 +48,7 @@ func publishTx(ctx context.Context, c *protocol.Chain, msg *bc.Tx) error {
 
 	// Make sure there is at least one block in case client is trying to
 	// finalize a tx before the initial block has landed
-	<-c.WaitForBlock(1)
+	<-c.BlockWaiter(1)
 
 	if Generator != nil {
 		// If this transaction is valid, ValidateTxCached will store it in the cache.

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -43,7 +43,7 @@ func TestSighashCheck(t *testing.T) {
 	}
 
 	prottest.MakeBlock(t, info.Chain)
-	<-info.pinStore.WaitForPin(account.PinName, info.Chain.Height())
+	<-info.pinStore.PinWaiter(account.PinName, info.Chain.Height())
 
 	assetAmount := bc.AssetAmount{
 		AssetID: info.asset.AssetID,
@@ -111,7 +111,7 @@ func TestConflictingTxsInPool(t *testing.T) {
 	dumpState(ctx, t, db)
 	prottest.MakeBlock(t, info.Chain)
 	dumpState(ctx, t, db)
-	<-info.pinStore.WaitForPin(account.PinName, info.Chain.Height())
+	<-info.pinStore.PinWaiter(account.PinName, info.Chain.Height())
 
 	assetAmount := bc.AssetAmount{
 		AssetID: info.asset.AssetID,
@@ -153,7 +153,7 @@ func TestConflictingTxsInPool(t *testing.T) {
 	// Make a block, which should reject one of the txs.
 	dumpState(ctx, t, db)
 	b := prottest.MakeBlock(t, info.Chain)
-	<-info.pinStore.WaitForPin(account.PinName, info.Chain.Height())
+	<-info.pinStore.PinWaiter(account.PinName, info.Chain.Height())
 
 	dumpState(ctx, t, db)
 	if len(b.Transactions) != 1 {
@@ -179,7 +179,7 @@ func TestTransferConfirmed(t *testing.T) {
 	prottest.MakeBlock(t, info.Chain)
 	dumpState(ctx, t, db)
 
-	<-info.pinStore.WaitForPin(account.PinName, info.Chain.Height())
+	<-info.pinStore.PinWaiter(account.PinName, info.Chain.Height())
 
 	_, err = transfer(ctx, t, info, info.acctA.ID, info.acctB.ID, 10)
 	if err != nil {

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -70,7 +70,7 @@ func TestWaitForBlockSoonAlreadyExists(t *testing.T) {
 	makeEmptyBlock(t, c) // height=2
 	makeEmptyBlock(t, c) // height=3
 
-	err := <-c.WaitForBlockSoon(context.Background(), 2)
+	err := <-c.BlockSoonWaiter(context.Background(), 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,10 +79,10 @@ func TestWaitForBlockSoonAlreadyExists(t *testing.T) {
 func TestWaitForBlockSoonDistantFuture(t *testing.T) {
 	c, _ := newTestChain(t, time.Now())
 
-	got := <-c.WaitForBlockSoon(context.Background(), 100) // distant future
+	got := <-c.BlockSoonWaiter(context.Background(), 100) // distant future
 	want := ErrTheDistantFuture
 	if got != want {
-		t.Errorf("WaitForBlockSoon(100) = %+v want %+v", got, want)
+		t.Errorf("BlockSoonWaiter(100) = %+v want %+v", got, want)
 	}
 }
 
@@ -103,7 +103,7 @@ func TestWaitForBlockSoonWaits(t *testing.T) {
 		makeEmptyBlock(t, c)              // height=3
 	}()
 
-	err := <-c.WaitForBlockSoon(context.Background(), 3)
+	err := <-c.BlockSoonWaiter(context.Background(), 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestWaitForBlockSoonTimesout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
-	err := <-c.WaitForBlockSoon(ctx, 3)
+	err := <-c.BlockSoonWaiter(ctx, 3)
 	if err != ctx.Err() {
 		t.Fatalf("expected timeout err, got %v", err)
 	}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -33,7 +33,7 @@ and compose transactions.
 To publish a new transaction, prepare your transaction
 (select outputs, and compose and sign the tx) and send the
 transaction to the network's generator. To wait for
-confirmation, call WaitForBlock on successive block heights
+confirmation, call BlockWaiter on successive block heights
 and inspect the blockchain state until you find that the
 transaction has been either confirmed or rejected. Note
 that transactions may be malleable if there's no commitment
@@ -215,7 +215,7 @@ func (c *Chain) setState(b *bc.Block, s *state.Snapshot) {
 // but it is an error to wait for a block far in the future.
 // WaitForBlockSoon will timeout if the context times out.
 // To wait unconditionally, the caller should use WaitForBlock.
-func (c *Chain) WaitForBlockSoon(ctx context.Context, height uint64) <-chan error {
+func (c *Chain) BlockSoonWaiter(ctx context.Context, height uint64) <-chan error {
 	ch := make(chan error, 1)
 
 	go func() {
@@ -226,7 +226,7 @@ func (c *Chain) WaitForBlockSoon(ctx context.Context, height uint64) <-chan erro
 		}
 
 		select {
-		case <-c.WaitForBlock(height):
+		case <-c.BlockWaiter(height):
 			ch <- nil
 		case <-ctx.Done():
 			ch <- ctx.Err()
@@ -238,7 +238,7 @@ func (c *Chain) WaitForBlockSoon(ctx context.Context, height uint64) <-chan erro
 
 // WaitForBlock returns a channel that
 // waits for the block at the given height.
-func (c *Chain) WaitForBlock(height uint64) <-chan struct{} {
+func (c *Chain) BlockWaiter(height uint64) <-chan struct{} {
 	ch := make(chan struct{}, 1)
 	go func() {
 		c.state.cond.L.Lock()

--- a/protocol/tx.go
+++ b/protocol/tx.go
@@ -24,7 +24,7 @@ import (
 // resolved when a block lands.
 //
 // It is an error to call AddTx before the initial block has landed.
-// Use WaitForBlock to guarantee this.
+// Use BlockWaiter to guarantee this.
 func (c *Chain) AddTx(ctx context.Context, tx *bc.Tx) error {
 	err := c.ValidateTxCached(tx)
 	if err != nil {


### PR DESCRIPTION
The functions `WaitForBlock`, `WaitForBlockSoon`, `WaitForPin`, and `WaitForAll` did not do any actual waiting, so rename them to indicate that waiting can be done with the values they return.