### PR TITLE
installer/mac: add DevRelease configuration

### DIFF
--- a/installer/mac/Chain Core.xcodeproj/project.pbxproj
+++ b/installer/mac/Chain Core.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		20BC087B1DC93051002A3C1E /* ClientLauncher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ClientLauncher.swift; path = ChainCore/ClientLauncher.swift; sourceTree = "<group>"; };
 		20BC087E1DC93237002A3C1E /* makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; name = makefile; path = pg/src/makefile; sourceTree = "<group>"; };
 		20C5E44E1DB0A28100C8CB2D /* TaskCleaner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TaskCleaner.swift; path = ChainCore/TaskCleaner.swift; sourceTree = "<group>"; };
+		20DED1371DD3C04900B81D66 /* updates-dev.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "updates-dev.xml"; sourceTree = "<group>"; };
 		830658E41D536F2E00BA1752 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = ChainCore/Extensions.swift; sourceTree = "<group>"; };
 		830B4B251D1C132300F16762 /* ServerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ServerManager.swift; path = ChainCore/ServerManager.swift; sourceTree = "<group>"; };
 		831C84AC1D771B4800FA5F59 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = ChainCore/Vendor/Sparkle.framework; sourceTree = "<group>"; };
@@ -131,6 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				20A50E541DA586D900F36C00 /* updates.xml */,
+				20DED1371DD3C04900B81D66 /* updates-dev.xml */,
 			);
 			name = Updates;
 			path = updates;

--- a/installer/mac/Chain Core.xcodeproj/project.pbxproj
+++ b/installer/mac/Chain Core.xcodeproj/project.pbxproj
@@ -350,6 +350,71 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		20DED1351DD3BDA600B81D66 /* DevRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "$(PROJECT_DIR)/pg/build/include";
+				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/pg/build/lib";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-lpq";
+				SDKROOT = macosx;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+			};
+			name = DevRelease;
+		};
+		20DED1361DD3BDA600B81D66 /* DevRelease */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APP_VERSION = 1.0.dev2;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DB_VERSION = v1.0;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/ChainCore/Vendor",
+				);
+				INFOPLIST_FILE = ChainCore/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.chain.ChainCoreApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "ChainCore/ChainCore-Bridging-Header.h";
+				SWIFT_VERSION = 3.0.1;
+				UPDATES_PATH = "updates-dev.xml";
+			};
+			name = DevRelease;
+		};
 		83FB57251D1B05F000A903A3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -443,7 +508,7 @@
 		83FB57281D1B05F000A903A3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_VERSION = 1.0.20161101;
+				APP_VERSION = 1.0.dev2;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -463,13 +528,14 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "ChainCore/ChainCore-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0.1;
+				UPDATES_PATH = "updates-dev.xml";
 			};
 			name = Debug;
 		};
 		83FB57291D1B05F000A903A3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_VERSION = 1.0.20161101;
+				APP_VERSION = 1.0.1;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -486,6 +552,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "ChainCore/ChainCore-Bridging-Header.h";
 				SWIFT_VERSION = 3.0.1;
+				UPDATES_PATH = updates.xml;
 			};
 			name = Release;
 		};
@@ -497,6 +564,7 @@
 			buildConfigurations = (
 				83FB57251D1B05F000A903A3 /* Debug */,
 				83FB57261D1B05F000A903A3 /* Release */,
+				20DED1351DD3BDA600B81D66 /* DevRelease */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -506,6 +574,7 @@
 			buildConfigurations = (
 				83FB57281D1B05F000A903A3 /* Debug */,
 				83FB57291D1B05F000A903A3 /* Release */,
+				20DED1361DD3BDA600B81D66 /* DevRelease */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/installer/mac/ChainCore/Info.plist
+++ b/installer/mac/ChainCore/Info.plist
@@ -49,6 +49,6 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>SUFeedURL</key>
-	<string>https://download.chain.com/mac/updates.xml</string>
+	<string>https://download.chain.com/mac/$(UPDATES_PATH)</string>
 </dict>
 </plist>

--- a/installer/mac/README.md
+++ b/installer/mac/README.md
@@ -28,14 +28,14 @@ Make sure you do `make clean` before re-build. Later we will improve this by pat
 
 ## Release process
 
-1. Bump the APP_VERSION in project settings.
-2. Bump the DB_VERSION in project settings if necessary (this will make the app create separate database and ignore all previous data).
-3. Build and Archive the app.
+1. Bump the `APP_VERSION` in project settings.
+2. Bump the `DB_VERSION` in project settings if necessary (this will make the app create separate database and ignore all previous data).
+3. Build and Archive the app. Duplicate the default scheme and change configuration from `Release` to `DevRelease` if you want to make a development release without affecting existing users of the stable version of the app.
 4. Export with Developer ID signature to the `updates` folder.
 5. Place `Chain Core.app` in the `updates` folder directly, without extra stuff.
 6. Run `tools/update_appcast.rb`. 
-7. Edit `updates/updates.xml` to specify relevant release notes.
-8. Upload the latest `Chain_Core_X.Y.zip`, `Chain_Core.zip`, and `updates.xml` to the server specified in the `tools/update_appcast.rb`. 
+7. Edit `updates/updates(-dev).xml` to specify relevant release notes.
+8. Upload the latest `Chain_Core_X.Y.zip`, `Chain_Core.zip`, and `updates(-dev).xml` to the server specified in the Info.plist (SUFeedURL). 
 
 
 ## License

--- a/installer/mac/tools/update_appcast.rb
+++ b/installer/mac/tools/update_appcast.rb
@@ -2,26 +2,42 @@
 # This script takes the Chain Core.app file in its folder, zips it, versions it and updates the update file.
 
 require 'json'
+require 'fileutils'
 
-base_url = "https://download.chain.com/mac"
-dirpath = File.expand_path("../updates", File.dirname(__FILE__))
-filename = "Chain Core.app"
-version = JSON.load(`plutil -convert json -o - "#{dirpath}/#{filename}/Contents/Info.plist"`)["CFBundleVersion"]
-zipname = "Chain_Core_#{version}.zip"
-latestname = "Chain_Core.zip"
+TIME_REGEXP = /\d\d\d\d-\d\d-\d\d \d\d-\d\d-\d\d/
+dirpath     = File.expand_path("../updates", File.dirname(__FILE__))
+filename    = "Chain Core.app"
+app_paths = Dir["#{dirpath}/**/Chain Core.app"].to_a.sort_by{|path| path[TIME_REGEXP] || "9999-99-99 99-99-99" }
+app_path = app_paths.last # use the latest build
+(app_paths - [app_path]).each do |path|
+  if x = path[TIME_REGEXP]
+    puts "path has time: #{path}: #{x} // #{File.dirname(path)}"
+    FileUtils.rm_r(File.dirname(path))
+  else
+    FileUtils.rm_r(path)
+  end
+end
+info        = JSON.load(`plutil -convert json -o - "#{app_path}/Contents/Info.plist"`)
+updates_url = info["SUFeedURL"]
+base_url = File.dirname(updates_url)
+version     = info["CFBundleVersion"]
+zipname     = "Chain_Core_#{version}.zip"
+latestzipname  = "Chain_Core.zip"
+
+updates_filename = updates_url[/updates.*\.xml$/]
 
 system(%{rm -rf #{dirpath}/#{zipname}})
-system(%{ditto -ck --keepParent --rsrc "#{dirpath}/#{filename}" "#{dirpath}/#{zipname}"})
+system(%{ditto -ck --keepParent --rsrc "#{app_path}" "#{dirpath}/#{zipname}"})
 
-system("rm #{dirpath}/#{latestname}")
-system("cp #{dirpath}/#{zipname} #{dirpath}/#{latestname}")
+system("rm #{dirpath}/#{latestzipname}")
+system("cp #{dirpath}/#{zipname} #{dirpath}/#{latestzipname}")
 
 bytesize = `stat -f %z "#{dirpath}/#{zipname}"`.strip
 pubdate  = `LC_TIME=en_US date +"%a, %d %b %G %T %z"`.strip
 
-appcast_path = dirpath + "/updates.xml"
+appcast_path = dirpath + "/" + updates_filename
 appcast = File.read(appcast_path)
-appcast.gsub!(%r{<link>.*?</link>}, %{<link>#{base_url}/updates.xml</link>})
+appcast.gsub!(%r{<link>.*?</link>}, %{<link>#{updates_url}</link>})
 appcast.gsub!(%r{<title>.*?\d+\.\d+</title>}, %{<title>Chain Core Developer Edition #{version}</title>})
 appcast.gsub!(%r{<pubDate>.*?</pubDate>}, %{<pubDate>#{pubdate}</pubDate>})
 appcast.gsub!(%r{sparkle:version=".*?"}, %{sparkle:version="#{version}"})

--- a/installer/mac/updates/updates-dev.xml
+++ b/installer/mac/updates/updates-dev.xml
@@ -14,11 +14,11 @@
             </ul>
           ]]>
         </description>
-        <pubDate>Mon, 24 Oct 2016 05:46:26 -0700</pubDate>
+        <pubDate>Wed, 09 Nov 2016 13:31:49 -0800</pubDate>
         <enclosure 
-        	url="https://download.chain.com/mac/Chain_Core_1.0.1.zip"
+        	url="https://download.chain.com/mac/Chain_Core_1.0.dev2.zip"
         	sparkle:version="1.0.dev2"
-        	length="78582133"
+        	length="53544295"
         	type="application/octet-stream"
         	sparkle:dsaSignature=""
         	/>

--- a/installer/mac/updates/updates-dev.xml
+++ b/installer/mac/updates/updates-dev.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Chain Core Developer Edition Updates</title>
+    <link>https://download.chain.com/mac/updates-dev.xml</link>
+    <description>Most recent changes with links to updates.</description>
+    <language>en</language>
+      <item>
+        <title>Chain Core Developer Edition 1.0.dev2</title>
+        <description>
+          <![CDATA[
+            <ul>
+              <li>Public release.</li>
+            </ul>
+          ]]>
+        </description>
+        <pubDate>Mon, 24 Oct 2016 05:46:26 -0700</pubDate>
+        <enclosure 
+        	url="https://download.chain.com/mac/Chain_Core_1.0.1.zip"
+        	sparkle:version="1.0.dev2"
+        	length="78582133"
+        	type="application/octet-stream"
+        	sparkle:dsaSignature=""
+        	/>
+      </item>
+  </channel>
+</rss>


### PR DESCRIPTION
This adds `DevRelease` in addition to `Release` configuration with a separate version number and a separate `updates-dev.xml` URL. The `update_appcase.rb` script is updated to package latest archive and announce it in a correct appcast file (`updates.xml` for `Release` and `updates-dev.xml` for `DevRelease`).

