### PR TITLE
installer/mac: remove unused dependencies and add sha256 checks

### DIFF
--- a/installer/mac/Chain Core.xcodeproj/project.pbxproj
+++ b/installer/mac/Chain Core.xcodeproj/project.pbxproj
@@ -21,10 +21,6 @@
 		208663E81D9C8AFD00D32EB2 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 208663E71D9C8AFD00D32EB2 /* WebKit.framework */; };
 		20889C761DA5AD8600C39E3D /* DashboardWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20889C751DA5AD8600C39E3D /* DashboardWindowController.swift */; };
 		208D132C1D99CD02006E68D0 /* ChainCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208D132B1D99CD02006E68D0 /* ChainCore.swift */; };
-		20BC08761DC9303A002A3C1E /* build_chain.sh in Resources */ = {isa = PBXBuildFile; fileRef = 20BC08721DC9303A002A3C1E /* build_chain.sh */; };
-		20BC08771DC9303A002A3C1E /* copy_postgres.sh in Resources */ = {isa = PBXBuildFile; fileRef = 20BC08731DC9303A002A3C1E /* copy_postgres.sh */; };
-		20BC08781DC9303A002A3C1E /* patch_loader_path.rb in Resources */ = {isa = PBXBuildFile; fileRef = 20BC08741DC9303A002A3C1E /* patch_loader_path.rb */; };
-		20BC08791DC9303A002A3C1E /* update_appcast.rb in Resources */ = {isa = PBXBuildFile; fileRef = 20BC08751DC9303A002A3C1E /* update_appcast.rb */; };
 		20BC087C1DC93051002A3C1E /* ClientLauncher.applescript in Sources */ = {isa = PBXBuildFile; fileRef = 20BC087A1DC93051002A3C1E /* ClientLauncher.applescript */; };
 		20BC087D1DC93051002A3C1E /* ClientLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BC087B1DC93051002A3C1E /* ClientLauncher.swift */; };
 		20C5E44F1DB0A28100C8CB2D /* TaskCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20C5E44E1DB0A28100C8CB2D /* TaskCleaner.swift */; };
@@ -79,6 +75,7 @@
 		20BC087B1DC93051002A3C1E /* ClientLauncher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ClientLauncher.swift; path = ChainCore/ClientLauncher.swift; sourceTree = "<group>"; };
 		20BC087E1DC93237002A3C1E /* makefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.make; name = makefile; path = pg/src/makefile; sourceTree = "<group>"; };
 		20C5E44E1DB0A28100C8CB2D /* TaskCleaner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TaskCleaner.swift; path = ChainCore/TaskCleaner.swift; sourceTree = "<group>"; };
+		20DED1391DD3DE9800B81D66 /* renamesha256.rb */ = {isa = PBXFileReference; lastKnownFileType = text.script.ruby; name = renamesha256.rb; path = tools/renamesha256.rb; sourceTree = "<group>"; };
 		830658E41D536F2E00BA1752 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = ChainCore/Extensions.swift; sourceTree = "<group>"; };
 		830B4B251D1C132300F16762 /* ServerManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ServerManager.swift; path = ChainCore/ServerManager.swift; sourceTree = "<group>"; };
 		831C84AC1D771B4800FA5F59 /* Sparkle.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sparkle.framework; path = ChainCore/Vendor/Sparkle.framework; sourceTree = "<group>"; };
@@ -144,6 +141,7 @@
 				20BC08731DC9303A002A3C1E /* copy_postgres.sh */,
 				20BC08741DC9303A002A3C1E /* patch_loader_path.rb */,
 				20BC08751DC9303A002A3C1E /* update_appcast.rb */,
+				20DED1391DD3DE9800B81D66 /* renamesha256.rb */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -268,14 +266,10 @@
 				20239A651DB14CE000DA27B3 /* Nitti Medium.otf in Resources */,
 				20239A681DB14CE000DA27B3 /* NittiGrotesk-Medium.otf in Resources */,
 				20239A641DB14CE000DA27B3 /* Nitti Light.otf in Resources */,
-				20BC08791DC9303A002A3C1E /* update_appcast.rb in Resources */,
-				20BC08781DC9303A002A3C1E /* patch_loader_path.rb in Resources */,
 				20239A691DB14CE000DA27B3 /* NittiGrotesk-Normal.otf in Resources */,
 				83FB57201D1B05F000A903A3 /* Assets.xcassets in Resources */,
-				20BC08771DC9303A002A3C1E /* copy_postgres.sh in Resources */,
 				83FB57231D1B05F000A903A3 /* Main.storyboard in Resources */,
 				20239A6A1DB14CE000DA27B3 /* NittiGrotesk-SemiLight.otf in Resources */,
-				20BC08761DC9303A002A3C1E /* build_chain.sh in Resources */,
 				20239A631DB14CE000DA27B3 /* Nitti Bold.otf in Resources */,
 				20239A671DB14CE000DA27B3 /* NittiGrotesk-Bold.otf in Resources */,
 			);

--- a/installer/mac/pg/src/makefile
+++ b/installer/mac/pg/src/makefile
@@ -6,23 +6,15 @@ PATH=$(PREFIX)/bin:/bin:/usr/bin:/opt/local/bin
 
 POSTGRES_VERSION=9.5.4
 POSTGRES_MAJOR_VERSION=9.5
-
-JPEG_VERSION=8d
-LIBEDIT_VERSION=20130611-3.1
-
-#http://download.osgeo.org/gdal/
-LIBJASPER_VERSION=1.900.1
+POSTGRES_SHA256=cf5e571164ad66028ecd7dd8819e3765470d45bcd440d258b686be7e69c76ed0
 
 # http://xmlsoft.org/news.html
 LIBXML2_VERSION=2.9.3
+LIBXML2_SHA256=4de9e31f46b44d34871c22f54bfc54398ef124d6f7cafb1f4a5958fbcd3ba12d
 
 # https://www.openssl.org
 OPENSSL_VERSION=1.0.1t
-
-# https://github.com/json-c/json-c/wiki
-# https://s3.amazonaws.com/json-c_releases/releases/index.html
-JSONC_VERSION=0.11
-
+OPENSSL_SHA256=4a6ee491a2fdb22e519c76fdc2a628bb3cec12762cd456861d207996c8a07088
 
 #compiler options
 MACOSX_DEPLOYMENT_TARGET=10.7
@@ -36,7 +28,7 @@ CURL=/usr/bin/curl -L10 --silent --show-error --remote-name
 TAR=/usr/bin/tar xzf
 
 all: postgresql
-clean: clean-postgresql clean-openssl clean-libxml2 clean-libjpeg clean-libjasper clean-json-c
+clean: clean-postgresql clean-openssl clean-libxml2
 
 #########################
 ###### PostgreSQL #######
@@ -58,15 +50,16 @@ postgresql-$(POSTGRES_VERSION)/GNUmakefile: $(SHAREDPREFIX)/lib/libssl.dylib $(S
 # patch makefile to fix python linker flags
 	cd postgresql-$(POSTGRES_VERSION)/src; mv Makefile.global Makefile.global.old; sed 's@^python_libspec.*@python_libspec = '"`python-config --ldflags`"'@' Makefile.global.old >Makefile.global
 
-postgresql-$(POSTGRES_VERSION)/configure: postgresql-$(POSTGRES_VERSION).tar.bz2
-	$(TAR) "postgresql-$(POSTGRES_VERSION).tar.bz2"
+postgresql-$(POSTGRES_VERSION)/configure: postgresql-$(POSTGRES_VERSION).tar.bz2-${POSTGRES_SHA256}
+	$(TAR) "postgresql-$(POSTGRES_VERSION).tar.bz2-${POSTGRES_SHA256}"
 	touch $@
 
-postgresql-$(POSTGRES_VERSION).tar.bz2:	
-	$(CURL) "https://ftp.postgresql.org/pub/source/v$(POSTGRES_VERSION)/postgresql-$(POSTGRES_VERSION).tar.bz2"
+postgresql-$(POSTGRES_VERSION).tar.bz2-${POSTGRES_SHA256}:
+	$(CURL) "https://ftp.postgresql.org/pub/source/v$(POSTGRES_VERSION)/postgresql-${POSTGRES_VERSION}.tar.bz2"
+	ruby ../../tools/renamesha256.rb postgresql-${POSTGRES_VERSION}.tar.bz2
 
 clean-postgresql:
-	rm -Rf postgresql-$(POSTGRES_VERSION)
+	rm -Rf postgresql-$(POSTGRES_VERSION)*
 	
 		
 #########################
@@ -82,15 +75,16 @@ $(SHAREDPREFIX)/lib/libssl.dylib: openssl-${OPENSSL_VERSION}/Makefile
 openssl-${OPENSSL_VERSION}/Makefile: openssl-${OPENSSL_VERSION}/Configure
 	cd openssl-${OPENSSL_VERSION} && ./Configure --prefix="${SHAREDPREFIX}" darwin64-x86_64-cc zlib no-asm no-krb5 shared
 
-openssl-${OPENSSL_VERSION}/Configure: openssl-${OPENSSL_VERSION}.tar.gz
-	$(TAR) openssl-${OPENSSL_VERSION}.tar.gz
+openssl-${OPENSSL_VERSION}/Configure: openssl-${OPENSSL_VERSION}.tar.gz-${OPENSSL_SHA256}
+	$(TAR) openssl-${OPENSSL_VERSION}.tar.gz-${OPENSSL_SHA256}
 	touch $@
 
-openssl-${OPENSSL_VERSION}.tar.gz:
+openssl-${OPENSSL_VERSION}.tar.gz-${OPENSSL_SHA256}:
 	$(CURL) "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
+	ruby ../../tools/renamesha256.rb openssl-${OPENSSL_VERSION}.tar.gz
 	
 clean-openssl:
-	rm -Rf "openssl-${OPENSSL_VERSION}"
+	rm -Rf openssl-${OPENSSL_VERSION}*
 
 #########################
 ######## LibXML2 ########
@@ -106,108 +100,15 @@ $(SHAREDPREFIX)/lib/libxml2.dylib: libxml2-${LIBXML2_VERSION}/Makefile
 libxml2-${LIBXML2_VERSION}/Makefile: libxml2-${LIBXML2_VERSION}/configure
 	cd libxml2-${LIBXML2_VERSION} && ./configure --prefix="$(SHAREDPREFIX)" --disable-dependency-tracking
 
-libxml2-${LIBXML2_VERSION}/configure: libxml2-${LIBXML2_VERSION}.tar.gz
-	$(TAR) libxml2-${LIBXML2_VERSION}.tar.gz
+libxml2-${LIBXML2_VERSION}/configure: libxml2-${LIBXML2_VERSION}.tar.gz-${LIBXML2_SHA256}
+	$(TAR) libxml2-${LIBXML2_VERSION}.tar.gz-${LIBXML2_SHA256}
 	touch $@
 	
-libxml2-${LIBXML2_VERSION}.tar.gz:
+libxml2-${LIBXML2_VERSION}.tar.gz-${LIBXML2_SHA256}:
 	$(CURL) "ftp://xmlsoft.org/libxml2/libxml2-${LIBXML2_VERSION}.tar.gz"
+	ruby ../../tools/renamesha256.rb libxml2-${LIBXML2_VERSION}.tar.gz
 	
 clean-libxml2:
-	rm -Rf "libxml2-$(LIBXML2_VERSION)"
-
-#########################
-####### LibEdit #########
-#########################
-
-libedit: $(SHAREDPREFIX)/lib/libedit.dylib
-
-$(SHAREDPREFIX)/lib/libedit.dylib: libedit-$(LIBEDIT_VERSION)/Makefile
-	make -C "libedit-$(LIBEDIT_VERSION)" install
-
-libedit-$(LIBEDIT_VERSION)/Makefile: libedit-$(LIBEDIT_VERSION)/configure
-	cd libedit-$(LIBEDIT_VERSION) && ./configure --prefix="$(SHAREDPREFIX)"
-
-libedit-$(LIBEDIT_VERSION)/configure: libedit-$(LIBEDIT_VERSION).tar.gz
-	$(TAR) "libedit-${LIBEDIT_VERSION}.tar.gz"
-	touch $@
-
-libedit-$(LIBEDIT_VERSION).tar.gz:
-	$(CURL) "http://www.thrysoee.dk/editline/libedit-$(LIBEDIT_VERSION).tar.gz"
-
-clean-libedit:
-	rm -Rf "libedit-$(LIBEDIT_VERSION)"
-
-
-#########################
-####### LibJasper #######
-#########################
-
-libjasper: $(SHAREDPREFIX)/lib/libjasper.dylib
-
-$(SHAREDPREFIX)/lib/libjasper.dylib: jasper-${LIBJASPER_VERSION}.uuid/Makefile
-	make -C jasper-${LIBJASPER_VERSION}.uuid install
-
-jasper-${LIBJASPER_VERSION}.uuid/Makefile: jasper-${LIBJASPER_VERSION}.uuid/configure
-	cd jasper-${LIBJASPER_VERSION}.uuid && ./configure --prefix="$(SHAREDPREFIX)" --disable-debug --disable-dependency-tracking --enable-shared --enable-dynamic
-
-
-jasper-${LIBJASPER_VERSION}.uuid/configure: jasper-$(LIBJASPER_VERSION).uuid.tar.gz
-	$(TAR) "jasper-$(LIBJASPER_VERSION).uuid.tar.gz"
-	touch $@
-
-jasper-$(LIBJASPER_VERSION).uuid.tar.gz:
-	$(CURL) "http://download.osgeo.org/gdal/jasper-$(LIBJASPER_VERSION).uuid.tar.gz"
-
-clean-libjasper:
-	rm -Rf jasper-${LIBJASPER_VERSION}.uuid
-
-
-#########################
-#######  libjpeg  #######
-#########################
-
-libjpeg: $(SHAREDPREFIX)/lib/libjpeg.dylib
-
-$(SHAREDPREFIX)/lib/libjpeg.dylib: jpeg-$(JPEG_VERSION)/Makefile
-	make -C jpeg-$(JPEG_VERSION) install
-
-jpeg-$(JPEG_VERSION)/Makefile: jpeg-$(JPEG_VERSION)/configure
-	cd jpeg-$(JPEG_VERSION) && ./configure --prefix="$(SHAREDPREFIX)" --disable-dependency-tracking
-
-jpeg-$(JPEG_VERSION)/configure: jpegsrc.v$(JPEG_VERSION).tar.gz
-	$(TAR) jpegsrc.v$(JPEG_VERSION).tar.gz
-	touch $@
-
-jpegsrc.v$(JPEG_VERSION).tar.gz:
-	$(CURL) "http://www.ijg.org/files/jpegsrc.v$(JPEG_VERSION).tar.gz"
-
-clean-libjpeg:
-	rm -Rf jpeg-$(JPEG_VERSION)
-
-
-
-#########################
-###### JSON-c ###########
-#########################
-
-$(SHAREDPREFIX)/include/json/json_object_iterator.h: json-c-$(JSONC_VERSION)/Makefile
-	make -C json-c-$(JSONC_VERSION) install
-	cp json-c-$(JSONC_VERSION)/json_object_iterator.h "$(SHAREDPREFIX)/include/json/json_object_iterator.h"
-
-
-json-c-$(JSONC_VERSION)/Makefile: json-c-$(JSONC_VERSION)/configure
-	cd json-c-$(JSONC_VERSION) && ./configure --prefix="$(SHAREDPREFIX)"
-
-json-c-$(JSONC_VERSION)/configure: json-c-$(JSONC_VERSION).tar.gz
-	$(TAR) json-c-$(JSONC_VERSION).tar.gz
-	touch $@
-
-json-c-$(JSONC_VERSION).tar.gz:
-	$(CURL) "https://s3.amazonaws.com/json-c_releases/releases/json-c-$(JSONC_VERSION).tar.gz"
-
-clean-json-c:
-	rm -Rf json-c-$(JSONC_VERSION)
-
+	rm -Rf libxml2-$(LIBXML2_VERSION)*
 
 

--- a/installer/mac/tools/renamesha256.rb
+++ b/installer/mac/tools/renamesha256.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# Renames `filename.tar.gz` into `filename.tar.gz-<sha256digest>`
+path = ARGV[0]
+if !File.exist?(path)
+    $stderr.puts "File not found: #{path}"
+    exit(1)
+end
+digest = `shasum -a 256 #{path}`[0,64]
+
+name = File.basename(path) + "-#{digest}"
+newpath = File.dirname(path) + "/" + name
+if system(%{mv "#{path}" "#{newpath}"})
+    exit(0)
+else
+    exit(1)
+end


### PR DESCRIPTION
This removes unused dependencies from the mac app and adds sha256 digest checks to the remaining ones.

SHA256 digests for Postgres, OpenSSL and libxml2 are hardcoded in the makefile. If the digests of the downloaded archives do not match, make cannot continue building the dependencies.

