### PR TITLE
dashboard: change confusing token language

### DIFF
--- a/dashboard/src/features/configuration/components/Index/Index.jsx
+++ b/dashboard/src/features/configuration/components/Index/Index.jsx
@@ -152,7 +152,7 @@ class Index extends React.Component {
                 placeholder='https://<block-generator-host>'
                 fieldProps={generator_url} />
               <TextField
-                title='Generator Access Token'
+                title='Network Access Token'
                 placeholder='token-id:9e5f139755366add8c76'
                 fieldProps={generator_access_token} />
               <TextField

--- a/dashboard/src/features/core/components/Index/Index.jsx
+++ b/dashboard/src/features/core/components/Index/Index.jsx
@@ -88,7 +88,7 @@ class Index extends React.Component {
                 </tr>}
               {!this.props.core.generator &&
                 <tr>
-                  <td className={styles.row_label}>Generator Access Token:</td>
+                  <td className={styles.row_label}>Network Access Token:</td>
                   <td><code>{this.props.core.generatorAccessToken}</code></td>
                 </tr>}
               <tr>

--- a/docs/core/get-started/configure.md
+++ b/docs/core/get-started/configure.md
@@ -21,8 +21,8 @@ For more information, see [operating a blockchain](../learn-more/blockchain-oper
 This connects to an existing blockchain whose block generator is already configured. You must supply the following information to join:
 
 * Block generator URL
+* Network access token
 * Blockchain ID
-* Network token
 
 Once configured, Chain Core will begin downloading blockchain data from the block generator. Once your Core is up to date with the network it will receive new blocks as they are created.
 


### PR DESCRIPTION
Instead of presenting the user with the phrase "Generator Access
Token", we'll use "Network Access Token", which is the object that
is actually created and shared to network participants.