### PR TITLE
dashboard: allow Safari to submit balances form with sum_by parameter

### DIFF
--- a/dashboard/src/features/shared/components/SearchBar/SearchBar.jsx
+++ b/dashboard/src/features/shared/components/SearchBar/SearchBar.jsx
@@ -148,7 +148,7 @@ class SearchBar extends React.Component {
             </span>}
 
             {/* This is required for form submission */}
-            <input type='submit' className={styles.submit} />
+            <input type='submit' className={styles.submit} tabIndex='-1' />
         </form>
 
         <span className={styles.queryTime}>

--- a/dashboard/src/features/shared/components/SearchBar/SearchBar.scss
+++ b/dashboard/src/features/shared/components/SearchBar/SearchBar.scss
@@ -65,7 +65,8 @@
 }
 
 .submit {
-  display: none;
+  position: absolute;
+  left: -9999px;
 }
 
 .clearSearch {


### PR DESCRIPTION
Safari will not allow a form to be submitted with the enter key unless
there is a submit button on the page that is not hidden. This is in contrast
to Chrome, which worked fine with a hidden submit button.