### PR TITLE
cored: add release version to compile

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -49,6 +49,7 @@ import (
 const (
 	httpReadTimeout  = 2 * time.Minute
 	httpWriteTimeout = time.Hour
+	version          = "?" // most recent release version, adjusted manually
 )
 
 var (
@@ -83,6 +84,7 @@ func init() {
 	expvar.NewString("buildtag").Set(buildTag)
 	expvar.NewString("builddate").Set(buildDate)
 	expvar.NewString("buildcommit").Set(buildCommit)
+	expvar.NewString("version").Set(version)
 	expvar.NewString("runtime.GOOS").Set(runtime.GOOS)
 	expvar.NewString("runtime.GOARCH").Set(runtime.GOARCH)
 	expvar.NewString("runtime.Version").Set(runtime.Version())

--- a/core/core.go
+++ b/core/core.go
@@ -99,6 +99,7 @@ func (h *Handler) leaderInfo(ctx context.Context) (map[string]interface{}, error
 
 	buildCommit := json.RawMessage(expvar.Get("buildcommit").String())
 	buildDate := json.RawMessage(expvar.Get("builddate").String())
+	version := json.RawMessage(expvar.Get("version").String())
 
 	m := map[string]interface{}{
 		"is_configured":                     true,
@@ -116,6 +117,7 @@ func (h *Handler) leaderInfo(ctx context.Context) (map[string]interface{}, error
 		"core_id":                           h.Config.ID,
 		"build_commit":                      &buildCommit,
 		"build_date":                        &buildDate,
+		"version":                           &version,
 		"health":                            h.health(),
 	}
 


### PR DESCRIPTION
This commit proposes a method for including version information into the
cored binary.

A new global constant, "version", is present in the cored executable.
It is returned by the /info endpoint.

When we have decided that the main branch contains the features and
bugfixes sufficient for a new release, we add a new commit that updates
the version constant. Initially, the version will be set to "?", but we
should schedule an uptick to 1.0.1 as soon as possible.

For posterity, we will also annotate this commit with the git tag
"cmd/cored-<VERSION>". (If we want a nice, public UI to navigate the
release history, we might consider using GitHub's releases feature to
perform the tagging).

When preparing new installers, we can refer back to these tags to get a
precise state of the repository.

Worth noting: the version constant is useful for tagging public releases
and communicating with outside users. However, it is not very useful for
our internal development process, since the value of the version
constant will change infrequently. In these cases, other means of
communicating the source version (such as the buildcommit expvar, or the
local HEAD ref) should be used.