### PR TITLE
cmd/cored: set MaxIdleConns to MAXDBCONNS too

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -100,7 +100,7 @@ func main() {
 		chainlog.Fatal(ctx, chainlog.KeyError, err)
 	}
 	db.SetMaxOpenConns(*maxDBConns)
-	db.SetMaxIdleConns(100)
+	db.SetMaxIdleConns(*maxDBConns)
 
 	err = migrate.Run(db)
 	if err != nil {


### PR DESCRIPTION
If max conns and max idle conns are not equal, cored will create many db
connections when build & submit requests are coming in, but close them
soon after while waiting for the block to land. Our DB conn needs are very
periodic.