### PR TITLE
sync/idempotency: make errors non-idempotent

### DIFF
--- a/sync/idempotency/group.go
+++ b/sync/idempotency/group.go
@@ -56,6 +56,11 @@ func (g *Group) Once(key string, fn func() (interface{}, error)) (interface{}, e
 	g.mu.Unlock()
 
 	c.val, c.err = fn()
+	if c.err != nil {
+		g.mu.Lock()
+		delete(g.m, key)
+		g.mu.Unlock()
+	}
 	c.wg.Done()
 
 	return c.val, c.err


### PR DESCRIPTION
The only use case for this right now is in utxo reservation. Errors such
as ErrReserved can be retried, and will continue to only result in
ErrReserved, even if there is an underlying change.