### PR TITLE
core/account/utxodb: cache confirmed UTXOs

### DIFF
--- a/core/account/utxodb/reserve.go
+++ b/core/account/utxodb/reserve.go
@@ -290,9 +290,9 @@ func (sr *sourceReserver) reserve(ctx context.Context, rid uint64, amount uint64
 		reserved += utxo.Amount
 		reservedUTXOs = append(reservedUTXOs, utxo)
 		if reserved >= amount {
+			cachedIdx = i
 			break
 		}
-		cachedIdx = i
 	}
 	if reserved >= amount {
 		// We've found enough to satisfy the request.

--- a/core/account/utxodb/reserve.go
+++ b/core/account/utxodb/reserve.go
@@ -38,6 +38,7 @@ type UTXO struct {
 	bc.AssetAmount
 	Script []byte
 
+	ConfirmedIn         uint64
 	AccountID           string
 	ControlProgramIndex uint64
 }
@@ -245,13 +246,29 @@ type sourceReserver struct {
 	group  singleflight.Group
 
 	mu       sync.Mutex
+	cached   []*UTXO
 	reserved map[bc.Outpoint]uint64
 }
 
 func (sr *sourceReserver) findMatchingUTXOs(ctx context.Context) ([]*UTXO, error) {
 	srcID := fmt.Sprintf("%s-%s", sr.source.AssetID, sr.source.AccountID)
 	untypedUTXOs, err := sr.group.Do(srcID, func() (interface{}, error) {
-		return findMatchingUTXOs(ctx, sr.db, sr.source)
+		utxos, err := findMatchingUTXOs(ctx, sr.db, sr.source)
+		if err != nil {
+			return nil, err
+		}
+
+		var cached []*UTXO
+		for _, u := range utxos {
+			if u.ConfirmedIn > 0 {
+				cached = append(cached, u)
+			}
+		}
+
+		sr.mu.Lock()
+		sr.cached = cached
+		sr.mu.Unlock()
+		return utxos, err
 	})
 	return untypedUTXOs.([]*UTXO), err
 }
@@ -259,6 +276,34 @@ func (sr *sourceReserver) findMatchingUTXOs(ctx context.Context) ([]*UTXO, error
 func (sr *sourceReserver) reserve(ctx context.Context, rid uint64, amount uint64) ([]*UTXO, uint64, error) {
 	var reserved, unavailable uint64
 	var reservedUTXOs []*UTXO
+
+	// First try to reserve using only confirmed, cached UTXOs.
+	sr.mu.Lock()
+	utxos := sr.cached
+	for _, utxo := range utxos {
+		// If the UTXO is already reserved, skip it.
+		if _, ok := sr.reserved[utxo.Outpoint]; ok {
+			continue
+		}
+
+		// This UTXO is available for the taking.
+		reserved += utxo.Amount
+		reservedUTXOs = append(reservedUTXOs, utxo)
+		if reserved >= amount {
+			break
+		}
+	}
+	if reserved >= amount {
+		// We've found enough to satisfy the request.
+		for _, utxo := range reservedUTXOs {
+			sr.reserved[utxo.Outpoint] = rid
+		}
+		sr.mu.Unlock()
+		return reservedUTXOs, reserved, nil
+	}
+	sr.mu.Unlock()
+	reserved = 0
+	reservedUTXOs = nil
 
 	// Find the set of UTXOs that match this source.
 	utxos, err := sr.findMatchingUTXOs(ctx)
@@ -323,13 +368,18 @@ func (sr *sourceReserver) cancel(res *Reservation) {
 
 func findMatchingUTXOs(ctx context.Context, db pg.DB, source Source) ([]*UTXO, error) {
 	const q = `
-		SELECT tx_hash, index, amount, control_program_index, control_program
+		SELECT tx_hash, index, amount, control_program_index, control_program, confirmed_in
 		FROM account_utxos
 		WHERE account_id = $1 AND asset_id = $2
 	`
 	var utxos []*UTXO
 	err := pg.ForQueryRows(ctx, db, q, source.AccountID, source.AssetID,
-		func(txHash bc.Hash, index uint32, amount uint64, cpIndex uint64, controlProg []byte) {
+		func(txHash bc.Hash, index uint32, amount uint64, cpIndex uint64, controlProg []byte, confirmedIn *uint64) {
+			var confirmedHeight uint64
+			if confirmedIn != nil {
+				confirmedHeight = *confirmedIn
+			}
+
 			utxos = append(utxos, &UTXO{
 				Outpoint: bc.Outpoint{
 					Hash:  txHash,
@@ -342,6 +392,7 @@ func findMatchingUTXOs(ctx context.Context, db pg.DB, source Source) ([]*UTXO, e
 				Script:              controlProg,
 				AccountID:           source.AccountID,
 				ControlProgramIndex: cpIndex,
+				ConfirmedIn:         confirmedHeight,
 			})
 		})
 	// TODO(jackson): This has the potential to be a large number of UTXOs.


### PR DESCRIPTION
Cache confirmed UTXOs on the sourceReserver. Since they're confirmed,
we're guaranteed that they will stay valid. Also, since the reserver is only
run on one leader process, no one else can have spent the UTXOs unless
they circumvented reservation.