### PR TITLE
cmd/md2html: multi-language code snippets

### DIFF
--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -222,22 +222,24 @@ func interpolateCode(md []byte, hostPath string) []byte {
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.HasPrefix(line, pat) {
-			var snippath, snippet string
 			fields := strings.Fields(line)
-			if len(fields) >= 2 {
-				snippath = fields[1]
-			}
-			if len(fields) >= 3 {
-				snippet = fields[2]
+			if len(fields) < 3 {
+				fmt.Fprintln(w, "Error: invalid snippet:", line)
+				continue
 			}
 
-			if path.IsAbs(snippath) {
-				snippath = path.Join(os.Getenv("CHAIN"), snippath)
-			} else {
-				snippath = path.Join(hostPath, snippath)
+			snippet := fields[1]
+			paths := fields[2:]
+
+			for _, p := range paths {
+				if path.IsAbs(p) {
+					p = path.Join(os.Getenv("CHAIN"), p)
+				} else {
+					p = path.Join(hostPath, p)
+				}
+				writeCode(w, p, snippet)
 			}
 
-			writeCode(w, snippath, snippet)
 			continue
 		}
 		fmt.Fprintln(w, line)

--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -290,7 +290,7 @@ func writeCode(w io.Writer, path, snippet string) {
 
 	ext := extension(path)
 
-	fmt.Fprintln(w, "<pre class='snippet "+ext+"'><code>"+code+"</code></pre>")
+	fmt.Fprintln(w, "<pre class='"+ext+"'><code>"+code+"</code></pre>")
 }
 
 func readSnippet(path, snippet string) (string, error) {

--- a/docs/core/build-applications/accounts.md
+++ b/docs/core/build-applications/accounts.md
@@ -41,17 +41,17 @@ All code samples in this guide can be viewed in a single, runnable script. Avail
 
 Create an account for Alice.
 
-$code ../examples/java/Accounts.java create-account-alice
+$code create-account-alice ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 Create an account for Bob.
 
-$code ../examples/java/Accounts.java create-account-bob
+$code create-account-bob ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 ## List accounts by tags
 
 To list all savings accounts, we build an accounts query, filtering on the `type` tag.
 
-$code ../examples/java/Accounts.java list-accounts-by-tag
+$code list-accounts-by-tag ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 ## Transfer asset units between local accounts
 
@@ -59,27 +59,27 @@ To transfer assets between accounts within a Chain Core, we can build a transact
 
 We will build a transaction transferring to units of gold from Alice’s account to Bob’s account.
 
-$code ../examples/java/Accounts.java build-transfer
+$code build-transfer ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 Once we have built the transaction, we need to sign it with the key used to create Alice’s account. Note: We do not need to sign on behalf of Bob’s account, because Bob is not spending any assets - only receiving.
 
-$code ../examples/java/Accounts.java sign-transfer
+$code sign-transfer ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 Once we have signed the transaction, we can submit it for inclusion in the blockchain.
 
-$code ../examples/java/Accounts.java submit-transfer
+$code submit-transfer ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 ## Receive asset units from an external party
 
 Account IDs and aliases are local Chain Core data. They do not exist in the blockchain. When an external party wishes to transfer assets to your account, you must first create a control program for the account. We will create a control program for Bob’s account, which we can then send to the external party (see following example).
 
-$code ../examples/java/Accounts.java create-control-program
+$code create-control-program ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 ## Transfer asset units to an external party
 
 If you wish to transfer asset units to an external party, you must first request a control program from them. You can then build, sign, and submit a transaction sending asset units to their control program. We will use the control program we created in Bob’s account to demonstrate this external facing functionality.
 
-$code ../examples/java/Accounts.java transfer-to-control-program
+$code transfer-to-control-program ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 ## List account transactions
 
@@ -87,7 +87,7 @@ Chain Core keeps a time-ordered list of all transactions in the blockchain. Thes
 
 To list transactions involving Alice’s account, we build a transaction query, filtering on transactions where Alice spent or controlled any asset units.
 
-$code ../examples/java/Accounts.java list-account-txs
+$code list-account-txs ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 ## List account balances
 
@@ -95,8 +95,8 @@ The balance of an asset in an account is the sum of all units in unspent outputs
 
 To list the balances of all assets in Alice’s account, we build a balance query, filtering on Alice’s account alias.
 
-$code ../examples/java/Accounts.java list-account-balances
+$code list-account-balances ../examples/java/Accounts.java ../examples/ruby/accounts.rb
 
 To list all the unspent outputs that comprise the balance of gold in Alice’s account, we build an unspent outputs query, filtering on Alice’s account alias and the gold asset alias.
 
-$code ../examples/java/Accounts.java list-account-unspent-outputs
+$code list-account-unspent-outputs ../examples/java/Accounts.java ../examples/ruby/accounts.rb

--- a/docs/core/build-applications/assets.md
+++ b/docs/core/build-applications/assets.md
@@ -42,11 +42,11 @@ Creating an asset defines the asset object locally in the Chain Core. It does no
 
 Create an asset for Acme Common stock:
 
-$code ../examples/java/Assets.java create-asset-acme-common
+$code create-asset-acme-common ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 Create an asset for Acme Preferred stock:
 
-$code ../examples/java/Assets.java create-asset-acme-preferred
+$code create-asset-acme-preferred ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 ## List assets
 
@@ -54,11 +54,11 @@ Chain Core keeps a list of all assets in the blockchain, whether or not they wer
 
 To list all assets created in the local Core, we build an assets query, filtering on the `is_local` tag.
 
-$code ../examples/java/Assets.java list-local-assets
+$code list-local-assets ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 To list all assets defined as preferred stock of a private security, we build an assets query, filtering on several tags.
 
-$code ../examples/java/Assets.java list-private-preferred-securities
+$code list-private-preferred-securities ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 ## Issue asset units to a local account
 
@@ -66,15 +66,15 @@ To issue units of an asset into an account within the Chain Core, we can build a
 
 We first build a transaction issuing 1000 units of Acme Common stock to the Acme treasury account.
 
-$code ../examples/java/Assets.java build-issue
+$code build-issue ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 Once we have built the transaction, we need to sign it with the key used to create the Acme Common stock asset.
 
-$code ../examples/java/Assets.java sign-issue
+$code sign-issue ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 Once we have signed the transaction, we can submit it for inclusion in the blockchain.
 
-$code ../examples/java/Assets.java submit-issue
+$code submit-issue ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 ## Issue asset units to an external party
 
@@ -82,7 +82,7 @@ If you wish to issue asset units to an external party, you must first request a 
 
 We will issue 2000 units of Acme Common stock to an external party.
 
-$code ../examples/java/Assets.java external-issue
+$code external-issue ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 ## Retire asset units
 
@@ -90,15 +90,15 @@ To retire units of an asset from an account, we can build a transaction using an
 
 We first build a transaction retiring 50 units of Acme Common stock from Acme’s treasury account.
 
-$code ../examples/java/Assets.java build-retire
+$code build-retire ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 Once we have built the transaction, we need to sign it with the key used to create Acme’s treasury account.
 
-$code ../examples/java/Assets.java sign-retire
+$code sign-retire ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 Once we have signed the transaction, we can submit it for inclusion in the blockchain. The asset units in this transaction become permanently unavailable for further spending.
 
-$code ../examples/java/Assets.java submit-retire
+$code submit-retire ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 ## List asset transactions
 
@@ -108,19 +108,19 @@ Chain Core keeps a time-ordered list of all transactions in the blockchain. Thes
 
 To list transactions where Acme Common stock was issued, we build an assets query, filtering on inputs with the `issue` action and the Acme Common stock `asset_alias`.
 
-$code ../examples/java/Assets.java list-issuances
+$code list-issuances ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 ### Transfer transactions
 
 To list transactions where Acme Common stock was transferred, we build an assets query, filtering on inputs with the `spend` action and the Acme Common stock `asset_alias`.
 
-$code ../examples/java/Assets.java list-transfers
+$code list-transfers ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 ### Retirement transactions
 
 To list transactions where Acme Common stock was retired, we build an assets query, filtering on outputs with the `retire` action and the Acme Common stock `asset_alias`.
 
-$code ../examples/java/Assets.java list-retirements
+$code list-retirements ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 ## Get asset circulation
 
@@ -128,12 +128,12 @@ The circulation of an asset is the sum of all non-retired units of that asset ex
 
 To list the circulation of Acme Common stock, we build a balance query, filtering on the Acme Common stock `asset_alias`.
 
-$code ../examples/java/Assets.java list-acme-common-balance
+$code list-acme-common-balance ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 To list the circulation of all classes of Acme stock, we build a balance query, filtering on the `issuer` field in the `definition`.
 
-$code ../examples/java/Assets.java list-acme-balance
+$code list-acme-balance ../examples/java/Assets.java ../examples/ruby/assets.rb
 
 To list all the control programs that hold a portion of the circulation of Acme Common stock, we build an unspent outputs query, filtering on the Acme Common stock `asset_alias`.
 
-$code ../examples/java/Assets.java list-acme-common-unspents
+$code list-acme-common-unspents ../examples/java/Assets.java ../examples/ruby/assets.rb

--- a/docs/core/build-applications/balances.md
+++ b/docs/core/build-applications/balances.md
@@ -29,16 +29,16 @@ All code samples in this guide can be viewed in a single, runnable script. Avail
 
 List the asset IOU balances in Bank1's account:
 
-$code ../examples/java/Balances.java account-balance
+$code account-balance ../examples/java/Balances.java ../examples/ruby/balances.rb
 
 ## Get asset circulation
 
 Get the circulation of the Bank 1 USD IOU on the blockchain:
 
-$code ../examples/java/Balances.java usd-iou-circulation
+$code usd-iou-circulation ../examples/java/Balances.java ../examples/ruby/balances.rb
 
 ## List account balances with custom summation
 
 List the asset IOU balances in Bank1's account, summed by currency:
 
-$code ../examples/java/Balances.java account-balance-sum-by-currency
+$code account-balance-sum-by-currency ../examples/java/Balances.java ../examples/ruby/balances.rb

--- a/docs/core/build-applications/batch-operations.md
+++ b/docs/core/build-applications/batch-operations.md
@@ -30,7 +30,7 @@ Batch operations take similar input to their non-batch analogs, except that in b
 
 For our example, we’ll create a list of builder objects for our assets, one for each asset we want to create:
 
-$code ../examples/java/BatchOperations.java asset-builders
+$code asset-builders ../examples/java/BatchOperations.java ../examples/ruby/batch_operations.rb
 
 Note that we’re attempting to create the `bronze` asset with an invalid value for the `quorum` parameter. This will generate an API error, and since we’re performing a batch operation, we’ll have to handle the error in a special way.
 
@@ -38,7 +38,7 @@ Note that we’re attempting to create the `bronze` asset with an invalid value 
 
 All batch method names in the SDK end with `Batch`, and they return a special batch response object:
 
-$code ../examples/java/BatchOperations.java asset-create-batch
+$code asset-create-batch ../examples/java/BatchOperations.java ../examples/ruby/batch_operations.rb
 
 #### Handling the response
 
@@ -46,7 +46,7 @@ If there is a problem affecting the entire batch request, such as a network erro
 
 The `BatchResponse` object provides an easy interface for determining which items in the request successed, and which ones resulted in an error. We can iterate over the items in the batch response (there is one for every parameter object in the original request) and print out whether the operation succeeded or failed.
 
-$code ../examples/java/BatchOperations.java asset-create-handle-errors
+$code asset-create-handle-errors ../examples/java/BatchOperations.java ../examples/ruby/batch_operations.rb
 
 In our example, we expect at least one of the items in the batch request to fail, since we provided an invalid value for the `bronze` asset’s `quorum` parameter. This produces the following output:
 
@@ -60,7 +60,7 @@ asset 2 error: com.chain.exception.APIException: Code: CH200 Message: Quorum mus
 
 Batch operations are parallelized on the server side, so there may be some non-deterministic error behavior if items in your batch request conflict with each other. Consider the following example:
 
-$code ../examples/java/BatchOperations.java nondeterministic-errors
+$code nondeterministic-errors ../examples/java/BatchOperations.java ../examples/ruby/batch_operations.rb
 
 Here, all three asset builders are attempting to create an asset with the alias `platinum`. Aliases must be unique, so only one will succeed. Due to parallelization, it’s possible to get results that appear to be out-of-order relative to the original request. For example, it’s possible for the last item in the request to succeed while the first two produce errors:
 
@@ -78,11 +78,11 @@ Each of the three primary steps of transacting in Chain Core--building, signing,
 
 First, we’ll put together a list of transaction builders:
 
-$code ../examples/java/BatchOperations.java batch-build-builders
+$code batch-build-builders ../examples/java/BatchOperations.java ../examples/ruby/batch_operations.rb
 
 The second transaction (index `1`) in our list is attempting to issue a non-existent asset, so we expect it to fail. If we make the batch request, we can iterate over the response errors and display any errors.
 
-$code ../examples/java/BatchOperations.java batch-build-handle-errors
+$code batch-build-handle-errors ../examples/java/BatchOperations.java ../examples/ruby/batch_operations.rb
 
 This error handling loop should produce the following output:
 
@@ -94,13 +94,13 @@ Error building transaction 1: com.chain.exception.APIException: Code: CH002 Mess
 
 Let’s move on and try to sign and submit the transactions that we successfully built. We can extract the successful responses using the `successes()` method and pass them to `signBatch`:
 
-$code ../examples/java/BatchOperations.java batch-sign
+$code batch-sign ../examples/java/BatchOperations.java ../examples/ruby/batch_operations.rb
 
 #### Submitting
 
 Assuming there are no errors in signing, we can submit our batch of transactions:
 
-$code ../examples/java/BatchOperations.java batch-submit
+$code batch-submit ../examples/java/BatchOperations.java ../examples/ruby/batch_operations.rb
 
 Finally, assuming there are no errors during submission, we should see the following output:
 

--- a/docs/core/build-applications/control-programs.md
+++ b/docs/core/build-applications/control-programs.md
@@ -31,11 +31,11 @@ Although all control programs in one account are controlled by keys derived from
 
 If Alice wishes to be paid gold by an external party (Bob), she first creates a new control program in her account:
 
-$code ../examples/java/ControlPrograms.java create-control-program
+$code create-control-program ../examples/java/ControlPrograms.java ../examples/ruby/control_programs.rb
 
 She then delivers the control program to Bob, who provides it to the transaction builder:
 
-$code ../examples/java/ControlPrograms.java build-transaction
+$code build-transaction ../examples/java/ControlPrograms.java ../examples/ruby/control_programs.rb
 
 ## Retirement control programs
 
@@ -45,7 +45,7 @@ A retirement control program is a very simple control program with a single pred
 
 To retire units of gold from Alice's account, we use the `SpendFromAccount` and `Retire` actions on the `Transaction.QueryBuilder`, which prompts Chain Core to create the retirement control program and spent to it from Alice's account.
 
-$code ../examples/java/ControlPrograms.java retire
+$code retire ../examples/java/ControlPrograms.java ../examples/ruby/control_programs.rb
 
 ## Custom control programs
 

--- a/docs/core/build-applications/keys.md
+++ b/docs/core/build-applications/keys.md
@@ -29,16 +29,16 @@ All code samples in this guide can be viewed in a single, runnable script. Avail
 
 Create a new key in the Mock HSM. (Requires a context to have been created with `new Context()`.)
 
-$code ../examples/java/Keys.java create-key
+$code create-key ../examples/java/Keys.java ../examples/ruby/keys.rb
 
 ## Load key
 
 To be able to sign transactions, load the key into the HSM Signer, which will communicate with the Mock HSM.
 
-$code ../examples/java/Keys.java signer-add-key
+$code signer-add-key ../examples/java/Keys.java ../examples/ruby/keys.rb
 
 ## Sign transaction
 
 Once a transaction is built, send it to the HsmSigner for signing.
 
-$code ../examples/java/Keys.java sign-transaction
+$code sign-transaction ../examples/java/Keys.java ../examples/ruby/keys.rb

--- a/docs/core/build-applications/multiparty-trades.md
+++ b/docs/core/build-applications/multiparty-trades.md
@@ -23,7 +23,7 @@ In this example, Alice and Bob both have accounts on the same core. Alice holds 
 
 In this setting, the application can trade Alice’s Alice Dollars for Bob’s Bob Bucks directly, within a single transaction:
 
-$code ../examples/java/MultipartyTrades.java same-core-trade
+$code same-core-trade ../examples/java/MultipartyTrades.java ../examples/ruby/multiparty_trades.rb
 
 This is the simplest possible scenario for a multi-asset trade between two accounts. Because the assets and accounts are local to the same core, the application can name all of the relevant accounts and assets in the space of a single `build` call. And since the application has access to both Alice’s and Bob’s HSMs, it can sign for both parties simultaneously.
 
@@ -33,21 +33,21 @@ Suppose that we want to conduct a similar trade as above, but Alice’s account 
 
 Alice initiates the trade by building a transaction that stipulates what she will pay and what she expects to receive. Since the Bob Buck asset is not local to her core, Alice can’t refer to it by its human-readable alias. Instead, she has to know its asset ID from an out-of-band source, like an email from Bob.
 
-$code ../examples/java/MultipartyTrades.java build-trade-alice
+$code build-trade-alice ../examples/java/MultipartyTrades.java ../examples/ruby/multiparty_trades.rb
 
 Unlike the transaction in the first example, this transaction is _unbalanced_: there are 50 Alice Dollars in the inputs that appear in no output, and 100 Bob Bucks that appear in an output but no input. If Alice were to sign and submit the transaction at this point, it would be rejected by the blockchain.
 
 Instead, Alice provides a signature that commits her to her payment of Alice Dollars only if she receives Bob Bucks in the same transaction. The partial transaction will need more actions stacked on top of it to become complete, so Alice must explicitly allow additional actions to be added before she signs it:
 
-$code ../examples/java/MultipartyTrades.java sign-trade-alice
+$code sign-trade-alice ../examples/java/MultipartyTrades.java ../examples/ruby/multiparty_trades.rb
 
 Now Alice has a signed, partial transaction that she can send to someone who can give her Bob Bucks in exchange for her Alice Dollars:
 
-$code ../examples/java/MultipartyTrades.java base-transaction-alice
+$code base-transaction-alice ../examples/java/MultipartyTrades.java ../examples/ruby/multiparty_trades.rb
 
 Alice takes the raw transaction, `baseTransactionFromAlice`, and emails it to Bob. Now Bob can fill in the rest of the trade, using the partially-signed transaction from Alice as a base transaction:
 
-$code ../examples/java/MultipartyTrades.java build-trade-bob
+$code build-trade-bob ../examples/java/MultipartyTrades.java ../examples/ruby/multiparty_trades.rb
 
 As was the case with Alice, Bob can’t refer to non-local assets by alias, so he refers to the Alice Dollar asset by its asset ID.
 
@@ -55,8 +55,8 @@ Note that the transaction now has all of the components of the trade described i
 
 With Bob’s addition, the transaction’s incoming and outgoing assets are now balanced. But it’s not a valid transaction without his signature. Since Bob is the last participant in the trade, he does _not_ allow additional actions before he signs the transaction:
 
-$code ../examples/java/MultipartyTrades.java sign-trade-bob
+$code sign-trade-bob ../examples/java/MultipartyTrades.java ../examples/ruby/multiparty_trades.rb
 
 Finally, with the balanced transaction signed by both parties, Bob can submit the transaction to the blockchain network:
 
-$code ../examples/java/MultipartyTrades.java submit-trade-bob
+$code submit-trade-bob ../examples/java/MultipartyTrades.java ../examples/ruby/multiparty_trades.rb

--- a/docs/core/build-applications/queries.md
+++ b/docs/core/build-applications/queries.md
@@ -106,44 +106,44 @@ All code samples in this guide can be viewed in a single, runnable script. Avail
 
 List all transactions involving Alice’s account:
 
-$code ../examples/java/Queries.java list-alice-transactions
+$code list-alice-transactions ../examples/java/Queries.java ../examples/ruby/queries.rb
 
 List all transactions involving the local Core:
 
-$code ../examples/java/Queries.java list-local-transactions
+$code list-local-transactions ../examples/java/Queries.java ../examples/ruby/queries.rb
 
 ## Assets
 
 List all assets created in the local Core:
 
-$code ../examples/java/Queries.java list-local-assets
+$code list-local-assets ../examples/java/Queries.java ../examples/ruby/queries.rb
 
 List all assets with `USD` as the `currency` in the asset definition:
 
-$code ../examples/java/Queries.java list-usd-assets
+$code list-usd-assets ../examples/java/Queries.java ../examples/ruby/queries.rb
 
 ## Accounts
 
 List all accounts with `checking` as the `type` in the account tags:
 
-$code ../examples/java/Queries.java list-checking-accounts
+$code list-checking-accounts ../examples/java/Queries.java ../examples/ruby/queries.rb
 
 ## Unspent Outputs
 
 List all unspent outputs controlled by Alice’s account:
 
-$code ../examples/java/Queries.java list-alice-unspents
+$code list-alice-unspents ../examples/java/Queries.java ../examples/ruby/queries.rb
 
 ## Balances
 
 List the asset IOU balances in Bank1’s account:
 
-$code ../examples/java/Queries.java account-balance
+$code account-balance ../examples/java/Queries.java ../examples/ruby/queries.rb
 
 Get the circulation of the Bank 1 USD IOU on the blockchain:
 
-$code ../examples/java/Queries.java usd-iou-circulation
+$code usd-iou-circulation ../examples/java/Queries.java ../examples/ruby/queries.rb
 
 List the asset IOU balances in Bank1’s account, summed by currency:
 
-$code ../examples/java/Queries.java account-balance-sum-by-currency
+$code account-balance-sum-by-currency ../examples/java/Queries.java ../examples/ruby/queries.rb

--- a/docs/core/build-applications/real-time-transaction-processing.md
+++ b/docs/core/build-applications/real-time-transaction-processing.md
@@ -21,11 +21,11 @@ Transaction feeds can be created either in the Chain Core Dashboard, or from you
 
 First, we'll create a new feed programmatically, setting the filter expression to `is_local='yes'`.
 
-$code ../examples/java/RealTimeTransactionProcessing.java create-feed
+$code create-feed ../examples/java/RealTimeTransactionProcessing.java ../examples/ruby/real_time_transaction_processing.rb
 
 From now on, we can retrieve this feed using its alias:
 
-$code ../examples/java/RealTimeTransactionProcessing.java get-feed
+$code get-feed ../examples/java/RealTimeTransactionProcessing.java ../examples/ruby/real_time_transaction_processing.rb
 
 The Chain Core will record how much of a feed has been processed, so your application doesn't have to keep track itself.
 
@@ -33,23 +33,23 @@ The Chain Core will record how much of a feed has been processed, so your applic
 
 To process a transaction, our example application will print out some basic information to the console:
 
-$code ../examples/java/RealTimeTransactionProcessing.java processor-method
+$code processor-method ../examples/java/RealTimeTransactionProcessing.java ../examples/ruby/real_time_transaction_processing.rb
 
 Next, we'll set up an infinite loop that reads from the transaction feed, and sends each incoming transaction to our processor function:
 
-$code ../examples/java/RealTimeTransactionProcessing.java processing-loop
+$code processing-loop ../examples/java/RealTimeTransactionProcessing.java ../examples/ruby/real_time_transaction_processing.rb
 
 Note the call to `ack` at the end of every cycle. This updates the transaction feed via an API call so that if your program terminates for any reason, it can pick back up from the point that `ack` was last called.
 
 The body of the processing loop will run once for every new transaction that arrives on the blockchain. If you've already processed all available transactions, then the call to `next` will **block the active thread** until a transaction matching the filter arrives. Because of this blocking behavior, we'll run the processing loop in its own thread:
 
-$code ../examples/java/RealTimeTransactionProcessing.java processing-thread
+$code processing-thread ../examples/java/RealTimeTransactionProcessing.java ../examples/ruby/real_time_transaction_processing.rb
 
 #### Testing the example
 
 In order to push some transactions through the transaction feed, we'll try generating a sample transaction:
 
-$code ../examples/java/RealTimeTransactionProcessing.java issue
+$code issue ../examples/java/RealTimeTransactionProcessing.java ../examples/ruby/real_time_transaction_processing.rb
 
 Almost immediately, we should see the following output in the console:
 
@@ -71,7 +71,7 @@ New transaction at Sun Oct 16 17:08:53 PDT 2016
 
 Let's try submitting another transaction:
 
-$code ../examples/java/RealTimeTransactionProcessing.java transfer
+$code transfer ../examples/java/RealTimeTransactionProcessing.java ../examples/ruby/real_time_transaction_processing.rb
 
 This should result in the following output:
 

--- a/docs/core/build-applications/transaction-basics.md
+++ b/docs/core/build-applications/transaction-basics.md
@@ -96,17 +96,17 @@ Issue 1000 units of gold to Alice.
 
 #### Within a Chain Core
 
-$code ../examples/java/TransactionBasics.java issue-within-core
+$code issue-within-core ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 #### Between two Chain Cores
 
 First, Bob creates a control program in his account, which he can send to the issuer of gold.
 
-$code ../examples/java/TransactionBasics.java create-bob-issue-program
+$code create-bob-issue-program ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 The issuer then builds, signs, and submits a transaction, sending gold to Bob's control program.
 
-$code ../examples/java/TransactionBasics.java issue-to-bob-program
+$code issue-to-bob-program ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 ### Simple payment
 
@@ -114,17 +114,17 @@ Alice pays 10 units of gold to Bob.
 
 #### Within a Chain Core
 
-$code ../examples/java/TransactionBasics.java pay-within-core
+$code pay-within-core ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 #### Between two Chain Cores
 
 First, Bob creates a control program in his account, which he can send to Alice.
 
-$code ../examples/java/TransactionBasics.java create-bob-payment-program
+$code create-bob-payment-program ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 Alice then builds, signs, and submits a transaction, sending gold to Bob's control program.
 
-$code ../examples/java/TransactionBasics.java pay-between-cores
+$code pay-between-cores ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 ### Multi-asset payment
 
@@ -132,23 +132,23 @@ Alice pays 10 units of gold and 20 units of silver to Bob.
 
 #### Within a Chain Core
 
-$code ../examples/java/TransactionBasics.java multiasset-within-core
+$code multiasset-within-core ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 #### Between two Chain Cores
 
 First Bob creates a control program in his account, which he can send to Alice.
 
-$code ../examples/java/TransactionBasics.java create-bob-multiasset-program
+$code create-bob-multiasset-program ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 Alice then builds, signs, and submits a transaction, sending gold and silver to Bob's control program.
 
-$code ../examples/java/TransactionBasics.java multiasset-between-cores
+$code multiasset-between-cores ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 ### Asset retirement
 
 Alice retires 50 units of gold from her account.
 
-$code ../examples/java/TransactionBasics.java retire
+$code retire ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb
 
 ### Multiparty trades
 

--- a/docs/core/build-applications/unspent-outputs.md
+++ b/docs/core/build-applications/unspent-outputs.md
@@ -22,11 +22,11 @@ All code samples in this guide can be viewed in a single, runnable script. Avail
 
 List all unspent outputs in Alice's account:
 
-$code ../examples/java/UnspentOutputs.java alice-unspent-outputs
+$code alice-unspent-outputs ../examples/java/UnspentOutputs.java ../examples/ruby/unspent_outputs.rb
 
 List all unspent outputs of the gold asset:
 
-$code ../examples/java/UnspentOutputs.java gold-unspent-outputs
+$code gold-unspent-outputs ../examples/java/UnspentOutputs.java ../examples/ruby/unspent_outputs.rb
 
 ## Spend unspent outputs
 
@@ -53,7 +53,7 @@ Given the following unspent output in Alice's account:
 
 Build a transaction spending all units of gold in the unspent output to Bob's account:
 
-$code ../examples/java/UnspentOutputs.java build-transaction-all
+$code build-transaction-all ../examples/java/UnspentOutputs.java ../examples/ruby/unspent_outputs.rb
 
 ### Spend partial unspent output
 
@@ -74,4 +74,4 @@ Given the following unspent output in Alice's account:
 
 Build a transaction spending 40 units of gold in the unspent output to Bob's account, and spending 60 units back to Alice's account as change:
 
-$code ../examples/java/UnspentOutputs.java build-transaction-partial
+$code build-transaction-partial ../examples/java/UnspentOutputs.java ../examples/ruby/unspent_outputs.rb

--- a/docs/core/get-started/five-minute-guide.md
+++ b/docs/core/get-started/five-minute-guide.md
@@ -24,50 +24,50 @@ All code samples in this guide can be viewed in a single, runnable script. Avail
 
 Create an instance of the SDK. By default, the SDK will try to access a core located at `http://localhost:1999`, which is the default if you're running Chain Core locally.
 
-$code ../examples/java/FiveMinuteGuide.java create-client
+$code create-client ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb
 
 ## Create Keys
 
 Create a new key in the Mock HSM.
 
-$code ../examples/java/FiveMinuteGuide.java create-key
+$code create-key ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb
 
 ## Initialize the HSM Signer
 
 To be able to sign transactions, load the key into the HSM Signer, which will communicate with the Mock HSM.
 
-$code ../examples/java/FiveMinuteGuide.java signer-add-key
+$code signer-add-key ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb
 
 ## Create an Asset
 
 Create a new asset, providing an alias, key, and quorum. The quorum is the threshold of keys that must sign a transaction issuing units of the asset.
 
-$code ../examples/java/FiveMinuteGuide.java create-asset
+$code create-asset ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb
 
 ## Create an Account
 
 Create an account, providing an alias, key, and quorum. The quorum is the threshold of keys that must sign a transaction to spend asset units controlled by the account.
 
-$code ../examples/java/FiveMinuteGuide.java create-account-alice
+$code create-account-alice ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb
 
 Create a second account to interact with the first account.
 
-$code ../examples/java/FiveMinuteGuide.java create-account-bob
+$code create-account-bob ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb
 
 ## Issue Asset Units
 
 Build, sign, and submit a transaction that issues new units of the `gold` asset into the `alice` account.
 
-$code ../examples/java/FiveMinuteGuide.java issue
+$code issue ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb
 
 ## Spend Asset Units
 
 Build, sign, and submit a transaction that spends units of the `gold` asset from the `alice` account to the `bob` account.
 
-$code ../examples/java/FiveMinuteGuide.java spend
+$code spend ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb
 
 ## Retire Asset Units
 
 Build, sign, and submit a transaction that retires units of the `gold` asset from the `bob` account.
 
-$code ../examples/java/FiveMinuteGuide.java retire
+$code retire ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb

--- a/docs/core/learn-more/global-vs-local-data.md
+++ b/docs/core/learn-more/global-vs-local-data.md
@@ -83,16 +83,16 @@ All code samples in this guide can be viewed in a single, runnable script. Avail
 
 ### Create accounts with tags
 
-$code ../examples/java/GlobalVsLocalData.java create-accounts-with-tags
+$code create-accounts-with-tags ../examples/java/GlobalVsLocalData.java ../examples/ruby/global_vs_local_data.rb
 
 ### Create assets with tags and definition
 
-$code ../examples/java/GlobalVsLocalData.java create-asset-with-tags-and-definition
+$code create-asset-with-tags-and-definition ../examples/java/GlobalVsLocalData.java ../examples/ruby/global_vs_local_data.rb
 
 ### Create transaction with transaction-level reference data
 
-$code ../examples/java/GlobalVsLocalData.java build-tx-with-tx-ref-data
+$code build-tx-with-tx-ref-data ../examples/java/GlobalVsLocalData.java ../examples/ruby/global_vs_local_data.rb
 
 ### Create transaction with action-level reference data
 
-$code ../examples/java/GlobalVsLocalData.java build-tx-with-action-ref-data
+$code build-tx-with-action-ref-data ../examples/java/GlobalVsLocalData.java ../examples/ruby/global_vs_local_data.rb

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -1352,3 +1352,42 @@ and (-webkit-min-device-pixel-ratio: 2) {
         white-space: pre-wrap;
     }
 }
+
+.snippet-set {
+    margin-top: 18px;
+}
+
+.snippet-set pre {
+    margin: 0 !important;
+}
+
+.snippet-set ul {
+    margin: 0 !important;
+    list-style-type: none;
+    text-align: right;
+    font-size: 14px;
+}
+
+.snippet-set li {
+    display: inline;
+    margin: 0;
+    padding: 0;
+}
+
+.snippet-set li span {
+    color: #00BFAA;
+}
+
+.snippet-set li span.selected {
+    font-weight: bold;
+}
+
+.snippet-set li span:hover {
+    cursor: pointer;
+}
+
+.snippet-set li + li::before {
+    content: "•";
+    margin-left: 3px;
+    margin-right: 3px;
+}

--- a/docs/js/codeSelector.js
+++ b/docs/js/codeSelector.js
@@ -1,0 +1,29 @@
+function updateSelection(lang) {
+  try {
+    localStorage.setItem('docsSelectedLang', lang)
+  } catch (err) { /* no local storage */ }
+
+  $('.snippet-set pre:not(.' + lang + ')').hide()
+  $('.snippet-set pre.' + lang).show()
+  $('.snippet-set [data-docs-lang]').removeClass('selected')
+  $('.snippet-set [data-docs-lang="' + lang + '"]').addClass('selected')
+}
+
+$(function() {
+  var allowed = ['java', 'js', 'rb']
+
+  var initial
+  try {
+    initial = localStorage.getItem('docsSelectedLang')
+  } catch (err) { /* no local storage */ }
+
+  if (allowed.indexOf(initial) < 0) {
+    initial = 'java'
+  }
+
+  updateSelection(initial)
+
+  $(document).on('click', '[data-docs-lang]', function(event) {
+    updateSelection($(event.target).data('docs-lang'))
+  })
+})

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -10,6 +10,7 @@
   <script src="/docs/js/jquery.min.js"></script>
   <script src="/docs/js/layout.js"></script>
   <script src="/docs/js/init.js"></script>
+  <script src="/docs/js/codeSelector.js"></script>
   <meta name="viewport" content="width=1060">
 </head>
 <body>


### PR DESCRIPTION
This commit adds multi-language snippet support to md2html. Documents should provide snippet directives with the following structure:

    $code <snippet-name> <file1> <file2> ...

Example:

    $code create-client ../examples/java/FiveMinuteGuide.java ../examples/ruby/five_minute_guide.rb

A snippet block will be generated for every named file. The file must contain the specified snippet, or a block of error text will be generated instead.

In the browser, snippets for different languages will be displayed based on the currently-selected language.