### PR TITLE
protocol/mempool: topologically sort

### DIFF
--- a/protocol/mempool/mempool.go
+++ b/protocol/mempool/mempool.go
@@ -9,34 +9,49 @@ import (
 	"context"
 	"sync"
 
+	"chain/log"
 	"chain/protocol/bc"
 )
 
 // MemPool satisfies the protocol.Pool interface.
 type MemPool struct {
-	mu   sync.Mutex
-	pool []*bc.Tx // in topological order
+	mu     sync.Mutex
+	pool   []*bc.Tx // in topological order
+	hashes map[bc.Hash]bool
 }
 
 // New returns a new MemPool.
 func New() *MemPool {
-	return &MemPool{}
+	return &MemPool{hashes: make(map[bc.Hash]bool)}
 }
 
 // Insert adds a new pending tx to the pending tx pool.
 func (m *MemPool) Insert(ctx context.Context, tx *bc.Tx) error {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.hashes[tx.Hash] {
+		return nil
+	}
+
+	m.hashes[tx.Hash] = true
 	m.pool = append(m.pool, tx)
-	m.mu.Unlock()
 	return nil
 }
 
 // Dump returns all pending transactions in the pool and
 // empties the pool.
-func (m *MemPool) Dump(context.Context) ([]*bc.Tx, error) {
+func (m *MemPool) Dump(ctx context.Context) ([]*bc.Tx, error) {
 	m.mu.Lock()
 	txs := m.pool
 	m.pool = nil
+	m.hashes = make(map[bc.Hash]bool)
 	m.mu.Unlock()
+
+	if !isTopSorted(txs) {
+		log.Messagef(ctx, "set of %d txs not in topo order; sorting", len(txs))
+		txs = topSort(txs)
+	}
+
 	return txs, nil
 }

--- a/protocol/mempool/sort.go
+++ b/protocol/mempool/sort.go
@@ -1,19 +1,8 @@
-package txdb
+package mempool
 
-import (
-	"context"
+import "chain/protocol/bc"
 
-	"chain/log"
-	"chain/protocol/bc"
-)
-
-func topSort(ctx context.Context, txs []*bc.Tx) []*bc.Tx {
-	if isTopSorted(ctx, txs) {
-		return txs
-	}
-
-	log.Messagef(ctx, "set of %d txs not in topo order; sorting", len(txs))
-
+func topSort(txs []*bc.Tx) []*bc.Tx {
 	if len(txs) == 1 {
 		return txs
 	}
@@ -70,7 +59,7 @@ func topSort(ctx context.Context, txs []*bc.Tx) []*bc.Tx {
 	return l
 }
 
-func isTopSorted(ctx context.Context, txs []*bc.Tx) bool {
+func isTopSorted(txs []*bc.Tx) bool {
 	exists := make(map[bc.Hash]bool)
 	seen := make(map[bc.Hash]bool)
 	for _, tx := range txs {


### PR DESCRIPTION
Sort transactions topologically when dumping the contents of the
pool, if they're not already in topological order. The old txdb pool
used this, but I forgot to port when we moved to the mempool.

Also, don't add a tx to the pool if it's already there.

If we're already topo sorting, should we just use an unordered
`map[bc.Hash]*bc.Tx`?