### PR TITLE
core/account: move utxodb reserver here

### DIFF
--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/golang/groupcache/lru"
 
-	"chain/core/account/utxodb"
 	"chain/core/pin"
 	"chain/core/signers"
 	"chain/crypto/ed25519/chainkd"
@@ -30,7 +29,7 @@ func NewManager(db *sql.DB, chain *protocol.Chain) *Manager {
 	return &Manager{
 		db:         db,
 		chain:      chain,
-		utxoDB:     utxodb.NewReserver(db),
+		utxoDB:     newReserver(db),
 		cache:      lru.New(maxAccountCache),
 		aliasCache: lru.New(maxAccountCache),
 	}
@@ -40,7 +39,7 @@ func NewManager(db *sql.DB, chain *protocol.Chain) *Manager {
 type Manager struct {
 	db       *sql.DB
 	chain    *protocol.Chain
-	utxoDB   *utxodb.Reserver
+	utxoDB   *reserver
 	indexer  Saver
 	pinStore *pin.Store
 

--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"chain/core/account/utxodb"
 	"chain/core/signers"
 	"chain/core/txbuilder"
 	chainjson "chain/encoding/json"
@@ -55,7 +54,7 @@ func (a *spendAction) Build(ctx context.Context, maxTime time.Time) (*txbuilder.
 		return nil, errors.Wrap(err, "get account info")
 	}
 
-	src := utxodb.Source{
+	src := source{
 		AssetID:   a.AssetID,
 		AccountID: a.AccountID,
 	}
@@ -153,7 +152,7 @@ func canceler(ctx context.Context, m *Manager, rid uint64) func() {
 	}
 }
 
-func utxoToInputs(ctx context.Context, account *signers.Signer, u *utxodb.UTXO, refData []byte) (
+func utxoToInputs(ctx context.Context, account *signers.Signer, u *utxo, refData []byte) (
 	*bc.TxInput,
 	*txbuilder.SigningInstruction,
 	error,

--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -1,4 +1,4 @@
-package utxodb
+package account
 
 import (
 	"context"
@@ -42,7 +42,7 @@ func TestCancelReservation(t *testing.T) {
 	}
 	out := bc.Outpoint{Hash: h, Index: 0}
 
-	utxoDB := NewReserver(db)
+	utxoDB := newReserver(db)
 	res, err := utxoDB.ReserveUTXO(ctx, out, nil, time.Now())
 	if err != nil {
 		t.Fatal(err)

--- a/core/errors.go
+++ b/core/errors.go
@@ -5,7 +5,6 @@ import (
 
 	"chain/core/accesstoken"
 	"chain/core/account"
-	"chain/core/account/utxodb"
 	"chain/core/asset"
 	"chain/core/blocksigner"
 	"chain/core/config"
@@ -131,8 +130,8 @@ var (
 		txbuilder.ErrNoTxSighashCommitment: errorInfo{400, "CH736", "Transaction is not final, additional actions still allowed"},
 
 		// account action error namespace (76x)
-		utxodb.ErrInsufficient: errorInfo{400, "CH760", "Insufficient funds for tx"},
-		utxodb.ErrReserved:     errorInfo{400, "CH761", "Some outputs are reserved; try again"},
+		account.ErrInsufficient: errorInfo{400, "CH760", "Insufficient funds for tx"},
+		account.ErrReserved:     errorInfo{400, "CH761", "Some outputs are reserved; try again"},
 
 		// Mock HSM error namespace (80x)
 		mockhsm.ErrInvalidAfter:         errorInfo{400, "CH801", "Invalid `after` in query"},


### PR DESCRIPTION
The utxodb package was only called by the account package, so it can be
moved in unexported.