### PR TITLE
docs/reference: introduce versioning schemes

### DIFF
--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -1,4 +1,4 @@
-# Chain Versioning
+# Versioning
 
 ## Summary
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -7,11 +7,11 @@ There are three distinct Chain versioning schemes:
 * **network** versioning
 * **signer** versioning
 
-Core versioning applies to the pieces of software that comprise, package, or directly interact with Chain Core. For example, the Chain Core Mac app and the Java SDK.
+Core versioning applies to the main pieces of software that comprise, package, or directly interact with Chain Core (excluding those that facilitate transaction and block signing). For example, the Chain Core Mac app and the Java SDK.
 
 Network versioning applies to the network API - the interface through which different Chain Cores on a network communicate to exchange transactions and blocks. Any breaking changes to the network API interface or the data structures as defined by the  Chain protocol are reflected by a change to the network version.
 
-Signer versioning applies to the pieces of software that facilitate transaction and block signing. These versions will change infrequently.
+Signer versioning applies to the pieces of software that operate or interact with HSMs to facilitate transaction and block signing. These versions will change infrequently.
 
 ## Core Versioning
 The various packages of the Chain Core suite each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages, with a tolerance of `+/-1`. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, you can use a version of an SDK whose first two numbers are **1.0**, **1.1**, or **1.2**.

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -20,7 +20,7 @@ Sometimes we make bugfixes and minor feature updates to individual software pack
 
 ### Scope
 
-The core versioning scheme covers a suite of individual software packages that make up Chain Core, including:
+The core versioning scheme covers a suite of individual software packages:
 
 - `cored`, the Chain Core server daemon
 - `corectl`, a CLI utility for operating Chain Core
@@ -70,7 +70,7 @@ The various packages of signing software each use a three number versioning sche
 Sometimes we make bugfixes and minor feature updates to individual software packages. When this occurs, we update the third number in the version string for that package only. This number doesn't affect compatibility with other packages. For example, you can safely use version **1.1.1** of `signerd` with version **1.1.3** of the Thales Codesafe HSM firmware.
 
 ### Scope
-The signer versioning scheme covers the following pieces of software:
+The signer versioning scheme covers the following packages:
 
 - Chain Core MockHSM
 - `signerd`, the HSM signing server daemon

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -97,7 +97,7 @@ The build version of a specific package may change independently of other packag
 This scheme has semantics that are unique to Chain Core, despite superficial similarities to other versioning schemes such as [Semantic Versioning](http://semver.org/).
 
 #### Compatibility between packages
-Software packages in the Chain Core suite are compatible if their major and minor versions are no more than one number apart. For example, if you are running version 1.1.x of the Chain Core server, you can use version 1.0.x, 1.1.x, or 1.2.x of the Java SDK.
+Signer software packages are compatible if their major and minor versions are no more than one number apart. For example, if you are running version 1.1.x of `signerd`, you can use version 1.0.x, 1.1.x, or 1.2.x of the Thales Codesafe HSM firmware.
 
 #### Breaking changes and backward compatibility
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -31,7 +31,7 @@ The core versioning scheme covers a suite of individual software packages:
 
 ### Format
 
-Each release of a software package is assigned a version string composed of three numbers separated by periods, such as **1.0.1**.
+Each release of a core software package is assigned a version string composed of three numbers separated by periods, such as **1.0.1**.
 
 These numbers represent, in order:
 
@@ -39,9 +39,9 @@ These numbers represent, in order:
 - **Minor version**: bugfixes, new features
 - **Build version**: package-specific bugfixes and features
 
-The major version is shared by all software packages in the Chain Core suite. If there is a change in the major version, then there will be a new release of all software packages in the suite.
+The major version is shared by all packages in the Chain Core suite. If there is a change in the major version, then there will be a new release of all packages in the suite.
 
-The minor version is shared is shared by all packages with a tolerance of `+/-1`.
+The minor version is shared by all packages with a tolerance of `+/-1`.
 
 The build version of a specific package may change independently of other packages.
 
@@ -78,7 +78,7 @@ The signer versioning scheme covers the following packages:
 
 ### Format
 
-Each release of a software package is assigned a version string composed of three numbers separated by periods, such as **1.0.1**.
+Each release of a signer software package is assigned a version string composed of three numbers separated by periods, such as **1.0.1**.
 
 These numbers represent, in order:
 
@@ -86,9 +86,9 @@ These numbers represent, in order:
 - **Minor version**: bugfixes, new features
 - **Build version**: package-specific bugfixes and features
 
-The major version is shared by all software packages in the Chain Core suite. If there is a change in the major version, then there will be a new release of all software packages in the suite.
+The major version is shared by all signer packages. If there is a change in the major version, then there will be a new release of all signer software packages.
 
-The minor version is shared is shared by all packages with a tolerance of `n+/-1`.
+The minor version is shared by all signer packages with a tolerance of `n+/-1`.
 
 The build version of a specific package may change independently of other packages.
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -1,0 +1,72 @@
+# Chain Core Versioning
+
+## Summary
+
+Chain Core versioning falls into two categories: **package** versioning and **network** versioning.
+
+Package versioning applies to the pieces of software that work together to participate in a blockchain network. For example, the Chain Core Mac app and the Java SDK.
+
+Network versioning applies to the network API - the interface through which different Chain Cores on a network comunicate to exchange transactions and blocks. Any breaking changes to the network API interface or Chain protocol are reflected by a change to the network version.
+
+## Package Versioning
+The various packages of Chain Core each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatablity between packages. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, then you should also use a version of an SDK whose first two numbers are also **1.1**.
+
+Sometimes we make bugfixes and minor feature updates to individual software packages. When this occurs, we update the third number in the version string for that package only. This number doesn't affect compatibility with other packages. For example, you can safely use version **1.1.1** of the Chain Core Mac App with version **1.1.3** of the Java SDK.
+
+### Scope
+
+The package versioning scheme covers a suite of individual software packages that make up Chain Core, including:
+
+- `cored`, the Chain Core server daemon
+- `corectl`, a CLI utility for operating Chain Core
+- `signerd`, the HSM signing server daemon
+- HSM firmware
+- Client API SDKs, such as the Java and Ruby SDKs
+- the Chain Core Mac app
+- the Chain Core Windows app
+- the Chain Core Docker image
+
+### Format
+
+Each release of a software package is assigned a version string composed of three numbers separated by periods, such as **1.0.1**.
+
+These numbers represent, in order:
+
+- **Major version**: significant product changes
+- **Minor version**: bugfixes, new features
+- **Build version**: package-specific bugfixes and features
+
+The major and minor versions are shared by all software packages in the Chain Core suite. If there is a change in the major or minor version, then there will be a new release of all software packages in the suite.
+
+The build version of a specific package may change independently of other packages.
+
+### Semantics
+
+This scheme has semantics that are unique to Chain Core, despite superficial similarities to other versioning schemes such as [Semantic Versioning](http://semver.org/).
+
+#### Compatibility between packages
+
+Software packages in the Chain Core suite are compatible if they share the same major and minor version. For example, if you are running version 1.1 of the Chain Core server, you should use version 1.1 of the SDK.
+
+#### Breaking changes and backward compatibility
+
+The version string does **not** convey whether a particular release contains a breaking change or not. Breaking changes will be announced in advance and documented in release notes. In general, we will do our best to avoid breaking changes.
+
+## Network versioning
+The network version is a single, incremented integer. All instances of Chain Core connecting to a network must have the same network version. The network version is determined by the Chain Core operating as the block generator.
+
+The network version will be incremented each time there is a breaking change in the network API interface or a breaking change in the version of the Chain protocol being implemented.
+
+### Breaking changes
+An upgrade in network version constitutes a breaking change at the network level. Any upgrade to the network version will be included in a new package version of Chain Core software and documented as a breaking network change in the release notes.
+
+
+## Notes
+
+### Enterprise vs. developer editions
+
+Chain Core Enterprise Edition is a superset of Developer Edition. The two editions share the same version space. For example, if a particular feature exists in version 1.1.x of Developer Edition, then it also exists in version 1.1.x of Enterprise Edition.
+
+### Older software
+
+Chain Core is a different product than older software released by Chain, such as the Chain Blockchain Platform and related SDKs, the Chain sandbox and related SDKs, or SDKs for the Chain Bitcoin API. Chain Core does **not** share the same version space as older products.

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -14,7 +14,7 @@ Network versioning applies to the network API - the interface through which diff
 Signer versioning applies to the pieces of software that facilitate transaction and block signing. These versions will change infrequently.
 
 ## Core Versioning
-The various packages of Chain Core each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, then you should also use a version of an SDK whose first two numbers are also **1.1**.
+The various packages of Chain Core each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages, with a tolerance of 'n+/-1'. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, you can use a version of an SDK whose first two numbers are **1.0**, **1.1**, or **1.2**.
 
 Sometimes we make bugfixes and minor feature updates to individual software packages. When this occurs, we update the third number in the version string for that package only. This number doesn't affect compatibility with other packages. For example, you can safely use version **1.1.1** of the Chain Core Mac App with version **1.1.3** of the Java SDK.
 
@@ -39,7 +39,9 @@ These numbers represent, in order:
 - **Minor version**: bugfixes, new features
 - **Build version**: package-specific bugfixes and features
 
-The major and minor versions are shared by all software packages in the Chain Core suite. If there is a change in the major or minor version, then there will be a new release of all software packages in the suite.
+The major version is shared by all software packages in the Chain Core suite. If there is a change in the major version, then there will be a new release of all software packages in the suite.
+
+The minor version is shared is shared by all packages with a tolerance of `n+/-1`.
 
 The build version of a specific package may change independently of other packages.
 
@@ -48,8 +50,7 @@ The build version of a specific package may change independently of other packag
 This scheme has semantics that are unique to Chain Core, despite superficial similarities to other versioning schemes such as [Semantic Versioning](http://semver.org/).
 
 #### Compatibility between packages
-
-Software packages in the Chain Core suite are compatible if they share the same major and minor version. For example, if you are running version 1.1 of the Chain Core server, you should use version 1.1 of the SDK.
+Software packages in the Chain Core suite are compatible if their major and minor versions are no more than one number apart. For example, if you are running version 1.1.x of the Chain Core server, you can use version 1.0.x, 1.1.x, or 1.2.x of the Java SDK.
 
 #### Breaking changes and backward compatibility
 
@@ -66,6 +67,8 @@ An upgrade in network version constitutes a breaking change at the network level
 ## Signer Versioning
 The various packages of signing software each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages. For example, if you are a running a version of `signerd` whose first two numbers are **1.1**, then you should also use a version of the Thales Codesafe HSM firmware whose first two numbers are also **1.1**.
 
+Sometimes we make bugfixes and minor feature updates to individual software packages. When this occurs, we update the third number in the version string for that package only. This number doesn't affect compatibility with other packages. For example, you can safely use version **1.1.1** of `signerd` with version **1.1.3** of the Thales Codesafe HSM firmware.
+
 ### Scope
 The signer versioning scheme covers the following pieces of software:
 
@@ -73,6 +76,32 @@ The signer versioning scheme covers the following pieces of software:
 - `signerd`, the HSM signing server daemon
 - Thales Codesafe HSM firmware
 
+### Format
+
+Each release of a software package is assigned a version string composed of three numbers separated by periods, such as **1.0.1**.
+
+These numbers represent, in order:
+
+- **Major version**: significant product changes
+- **Minor version**: bugfixes, new features
+- **Build version**: package-specific bugfixes and features
+
+The major version is shared by all software packages in the Chain Core suite. If there is a change in the major version, then there will be a new release of all software packages in the suite.
+
+The minor version is shared is shared by all packages with a tolerance of `n+/-1`.
+
+The build version of a specific package may change independently of other packages.
+
+### Semantics
+
+This scheme has semantics that are unique to Chain Core, despite superficial similarities to other versioning schemes such as [Semantic Versioning](http://semver.org/).
+
+#### Compatibility between packages
+Software packages in the Chain Core suite are compatible if their major and minor versions are no more than one number apart. For example, if you are running version 1.1.x of the Chain Core server, you can use version 1.0.x, 1.1.x, or 1.2.x of the Java SDK.
+
+#### Breaking changes and backward compatibility
+
+The version string does **not** convey whether a particular release contains a breaking change or not. Breaking changes will be announced in advance and documented in release notes. In general, we will do our best to avoid breaking changes.
 
 ## Notes
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -88,7 +88,7 @@ These numbers represent, in order:
 
 The major version is shared by all signer packages. If there is a change in the major version, then there will be a new release of all signer software packages.
 
-The minor version is shared by all signer packages with a tolerance of `n+/-1`.
+The minor version is shared by all signer packages with a tolerance of `+/-1`.
 
 The build version of a specific package may change independently of other packages.
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -1,8 +1,8 @@
-# Chain Core Versioning
+# Chain Versioning
 
 ## Summary
 
-There are three distinct Chain Core versioning schemes:
+There are three distinct Chain versioning schemes:
 * **core** versioning
 * **network** versioning
 * **signer** versioning

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -14,7 +14,7 @@ Network versioning applies to the network API - the interface through which diff
 Signer versioning applies to the pieces of software that facilitate transaction and block signing. These versions will change infrequently.
 
 ## Core Versioning
-The various packages of Chain Core each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages, with a tolerance of 'n+/-1'. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, you can use a version of an SDK whose first two numbers are **1.0**, **1.1**, or **1.2**.
+The various packages of Chain Core each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages, with a tolerance of `+/-1`. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, you can use a version of an SDK whose first two numbers are **1.0**, **1.1**, or **1.2**.
 
 Sometimes we make bugfixes and minor feature updates to individual software packages. When this occurs, we update the third number in the version string for that package only. This number doesn't affect compatibility with other packages. For example, you can safely use version **1.1.1** of the Chain Core Mac App with version **1.1.3** of the Java SDK.
 
@@ -41,7 +41,7 @@ These numbers represent, in order:
 
 The major version is shared by all software packages in the Chain Core suite. If there is a change in the major version, then there will be a new release of all software packages in the suite.
 
-The minor version is shared is shared by all packages with a tolerance of `n+/-1`.
+The minor version is shared is shared by all packages with a tolerance of `+/-1`.
 
 The build version of a specific package may change independently of other packages.
 
@@ -65,7 +65,7 @@ The network version will be incremented each time there is a breaking change in 
 An upgrade in network version constitutes a breaking change at the network level. Any upgrade to the network version will be included in a new package version of Chain Core software and documented as a breaking network change in the release notes.
 
 ## Signer Versioning
-The various packages of signing software each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages. For example, if you are a running a version of `signerd` whose first two numbers are **1.1**, then you should also use a version of the Thales Codesafe HSM firmware whose first two numbers are also **1.1**.
+The various packages of signing software each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages, with a tolerance of `+/-1`. For example, if you are a running a version of `signerd` whose first two numbers are **1.1**,  you can use a version of the Thales Codesafe HSM firmware whose first two numbers are **1.0**, **1.1**, or **1.2**.
 
 Sometimes we make bugfixes and minor feature updates to individual software packages. When this occurs, we update the third number in the version string for that package only. This number doesn't affect compatibility with other packages. For example, you can safely use version **1.1.1** of `signerd` with version **1.1.3** of the Thales Codesafe HSM firmware.
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -6,10 +6,10 @@ Chain Core versioning falls into two categories: **package** versioning and **ne
 
 Package versioning applies to the pieces of software that work together to participate in a blockchain network. For example, the Chain Core Mac app and the Java SDK.
 
-Network versioning applies to the network API - the interface through which different Chain Cores on a network comunicate to exchange transactions and blocks. Any breaking changes to the network API interface or Chain protocol are reflected by a change to the network version.
+Network versioning applies to the network API - the interface through which different Chain Cores on a network communicate to exchange transactions and blocks. Any breaking changes to the network API interface or Chain protocol are reflected by a change to the network version.
 
 ## Package Versioning
-The various packages of Chain Core each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatablity between packages. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, then you should also use a version of an SDK whose first two numbers are also **1.1**.
+The various packages of Chain Core each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, then you should also use a version of an SDK whose first two numbers are also **1.1**.
 
 Sometimes we make bugfixes and minor feature updates to individual software packages. When this occurs, we update the third number in the version string for that package only. This number doesn't affect compatibility with other packages. For example, you can safely use version **1.1.1** of the Chain Core Mac App with version **1.1.3** of the Java SDK.
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -2,25 +2,28 @@
 
 ## Summary
 
-Chain Core versioning falls into two categories: **package** versioning and **network** versioning.
+There are three distinct Chain Core versioning schemes:
+* **core** versioning
+* **network** versioning
+* **signer** versioning
 
-Package versioning applies to the pieces of software that work together to participate in a blockchain network. For example, the Chain Core Mac app and the Java SDK.
+Core versioning applies to the pieces of software that comprise, package, or directly interact with Chain Core. For example, the Chain Core Mac app and the Java SDK.
 
 Network versioning applies to the network API - the interface through which different Chain Cores on a network communicate to exchange transactions and blocks. Any breaking changes to the network API interface or Chain protocol are reflected by a change to the network version.
 
-## Package Versioning
+Signer versioning applies to the pieces of software that facilitate transaction and block signing. These versions will change infrequently.
+
+## Core Versioning
 The various packages of Chain Core each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, then you should also use a version of an SDK whose first two numbers are also **1.1**.
 
 Sometimes we make bugfixes and minor feature updates to individual software packages. When this occurs, we update the third number in the version string for that package only. This number doesn't affect compatibility with other packages. For example, you can safely use version **1.1.1** of the Chain Core Mac App with version **1.1.3** of the Java SDK.
 
 ### Scope
 
-The package versioning scheme covers a suite of individual software packages that make up Chain Core, including:
+The core versioning scheme covers a suite of individual software packages that make up Chain Core, including:
 
 - `cored`, the Chain Core server daemon
 - `corectl`, a CLI utility for operating Chain Core
-- `signerd`, the HSM signing server daemon
-- HSM firmware
 - Client API SDKs, such as the Java and Ruby SDKs
 - the Chain Core Mac app
 - the Chain Core Windows app
@@ -59,6 +62,16 @@ The network version will be incremented each time there is a breaking change in 
 
 ### Breaking changes
 An upgrade in network version constitutes a breaking change at the network level. Any upgrade to the network version will be included in a new package version of Chain Core software and documented as a breaking network change in the release notes.
+
+## Signer Versioning
+The various packages of signing software each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages. For example, if you are a running a version of `signerd` whose first two numbers are **1.1**, then you should also use a version of the Thales Codesafe HSM firmware whose first two numbers are also **1.1**.
+
+### Scope
+The signer versioning scheme covers the following pieces of software:
+
+- Chain Core MockHSM
+- `signerd`, the HSM signing server daemon
+- Thales Codesafe HSM firmware
 
 
 ## Notes

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -94,7 +94,7 @@ The build version of a specific package may change independently of other packag
 
 ### Semantics
 
-This scheme has semantics that are unique to Chain Core, despite superficial similarities to other versioning schemes such as [Semantic Versioning](http://semver.org/).
+This scheme has semantics that are unique to Chain signer software packages, despite superficial similarities to other versioning schemes such as [Semantic Versioning](http://semver.org/).
 
 #### Compatibility between packages
 Signer software packages are compatible if their major and minor versions are no more than one number apart. For example, if you are running version 1.1.x of `signerd`, you can use version 1.0.x, 1.1.x, or 1.2.x of the Thales Codesafe HSM firmware.

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -14,7 +14,7 @@ Network versioning applies to the network API - the interface through which diff
 Signer versioning applies to the pieces of software that facilitate transaction and block signing. These versions will change infrequently.
 
 ## Core Versioning
-The various packages of Chain Core each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages, with a tolerance of `+/-1`. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, you can use a version of an SDK whose first two numbers are **1.0**, **1.1**, or **1.2**.
+The various packages of the Chain Core suite each use a three number versioning scheme - **x.y.z**. The first two numbers indicate compatibility between packages, with a tolerance of `+/-1`. For example, if you are a running a version of the Chain Core Mac app whose first two numbers are **1.1**, you can use a version of an SDK whose first two numbers are **1.0**, **1.1**, or **1.2**.
 
 Sometimes we make bugfixes and minor feature updates to individual software packages. When this occurs, we update the third number in the version string for that package only. This number doesn't affect compatibility with other packages. For example, you can safely use version **1.1.1** of the Chain Core Mac App with version **1.1.3** of the Java SDK.
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -9,7 +9,7 @@ There are three distinct Chain Core versioning schemes:
 
 Core versioning applies to the pieces of software that comprise, package, or directly interact with Chain Core. For example, the Chain Core Mac app and the Java SDK.
 
-Network versioning applies to the network API - the interface through which different Chain Cores on a network communicate to exchange transactions and blocks. Any breaking changes to the network API interface or Chain protocol are reflected by a change to the network version.
+Network versioning applies to the network API - the interface through which different Chain Cores on a network communicate to exchange transactions and blocks. Any breaking changes to the network API interface or the data structures as defined by the  Chain protocol are reflected by a change to the network version.
 
 Signer versioning applies to the pieces of software that facilitate transaction and block signing. These versions will change infrequently.
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -3,6 +3,7 @@
 ## Summary
 
 There are three distinct Chain versioning schemes:
+
 * **core** versioning
 * **network** versioning
 * **signer** versioning

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -65,6 +65,7 @@
           <ul class="inner">
             <li><a href="/docs/java/javadoc/index.html" target="_blank" class="skip-next-up">Java SDK</a></li>
             <li><a href="/docs/ruby/doc/index.html" target="_blank" class="skip-next-up">Ruby SDK</a></li>
+            <li><a href="/docs/core/reference/versioning">Versioning</a></li>
             <li><a href="/docs/core/reference/api-objects">API Objects</a></li>
             <li><a href="/docs/core/reference/product-roadmap">Product Roadmap</a></li>
             <li><a href="/docs/core/reference/license" class="skip-next-up">License</a></li>


### PR DESCRIPTION
This document introduces the Chain versioning schemes: core versioning, network versioning, and signer versioning.