### PR TITLE
docs: remove docker for mac option

### DIFF
--- a/docs/core/get-started/install.partial.html
+++ b/docs/core/get-started/install.partial.html
@@ -39,24 +39,6 @@
               <img src="/docs/images/download-icon.png" class="btn-icon icon-download">
             </a>
           </p>
-          <hr class="separator-line">
-          <span class="separator-tag">or</span>
-
-          <h2>Install with Docker</h2>
-
-          <p>Install <a href="https://www.docker.com/products/docker#/mac">Docker for Mac</a> and run the following command. Docker will automatically download and run Chain Core.</p>
-
-          <p>Running Chain Core in a Docker container requires API and Dashboard <a href="../learn-more/authentication">authentication</a>. Once the Chain Core container has been initialized, a client access token will be displayed in the console. You can use this access token to authenticate to the API and Dashboard.</p>
-
-          <h3>Run the latest Docker image</h3>
-          <pre>
-            <code class="language-bash">docker run -it -p 1999:1999 chaincore/developer</code>
-          </pre>
-
-          <h3>Visit dashboard</h3>
-          <pre>
-            <code class="language-bash">open http://localhost:1999</code>
-          </pre>
 
         </div>
 


### PR DESCRIPTION
Due to performance issues, docker for mac is being removed as an
offering.