### PR TITLE
core/account: rename Script to ControlProgram

### DIFF
--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -157,7 +157,7 @@ func utxoToInputs(ctx context.Context, account *signers.Signer, u *utxo, refData
 	*txbuilder.SigningInstruction,
 	error,
 ) {
-	txInput := bc.NewSpendInput(u.Hash, u.Index, nil, u.AssetID, u.Amount, u.Script, refData)
+	txInput := bc.NewSpendInput(u.Hash, u.Index, nil, u.AssetID, u.Amount, u.ControlProgram, refData)
 
 	sigInst := &txbuilder.SigningInstruction{
 		AssetAmount: u.AssetAmount,

--- a/core/account/reserve.go
+++ b/core/account/reserve.go
@@ -36,7 +36,7 @@ var (
 type utxo struct {
 	bc.Outpoint
 	bc.AssetAmount
-	Script []byte
+	ControlProgram []byte
 
 	AccountID           string
 	ControlProgramIndex uint64
@@ -339,7 +339,7 @@ func findMatchingUTXOs(ctx context.Context, db pg.DB, src source) ([]*utxo, erro
 					Amount:  amount,
 					AssetID: src.AssetID,
 				},
-				Script:              controlProg,
+				ControlProgram:      controlProg,
 				AccountID:           src.AccountID,
 				ControlProgramIndex: cpIndex,
 			})
@@ -360,7 +360,7 @@ func findSpecificUTXO(ctx context.Context, db pg.DB, out bc.Outpoint) (*utxo, er
 		WHERE tx_hash = $1 AND index = $2
 	`
 	u := new(utxo)
-	err := db.QueryRow(ctx, q, out.Hash, out.Index).Scan(&u.AccountID, &u.AssetID, &u.Amount, &u.ControlProgramIndex, &u.Script)
+	err := db.QueryRow(ctx, q, out.Hash, out.Index).Scan(&u.AccountID, &u.AssetID, &u.Amount, &u.ControlProgramIndex, &u.ControlProgram)
 	if err == sql.ErrNoRows {
 		return nil, pg.ErrUserInputNotFound
 	} else if err != nil {


### PR DESCRIPTION
It looks like we missed this one when renaming scripts to control programs.