### PR TITLE
core/account: don't index unconfirmed outputs

### DIFF
--- a/core/account/indexer.go
+++ b/core/account/indexer.go
@@ -184,10 +184,7 @@ func (m *Manager) upsertConfirmedAccountOutputs(ctx context.Context, outs []*out
 		SELECT unnest($1::text[]), unnest($2::bigint[]), unnest($3::text[]),  unnest($4::bigint[]),
 			   unnest($5::text[]), unnest($6::bigint[]), unnest($7::bytea[]), unnest($8::bytea[]),
 			   $9, unnest($10::bigint[]), $11
-		ON CONFLICT (tx_hash, index) DO UPDATE SET
-			confirmed_in    = excluded.confirmed_in,
-			block_pos       = excluded.block_pos,
-			block_timestamp = excluded.block_timestamp;
+		ON CONFLICT (tx_hash, index) DO NOTHING
 	`
 	_, err := m.db.Exec(ctx, q,
 		txHash,

--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -12,12 +12,12 @@ import (
 const sampleAccountUTXOs = `
 	INSERT INTO account_utxos
 	(tx_hash, index, asset_id, amount, account_id, control_program_index,
-     control_program, metadata)
+     control_program, metadata, confirmed_in, block_pos, block_timestamp)
 	VALUES (
 		'270b725a94429496a178c56b390a89d03f801fe2ee992d90cf4fdf7d7855318e',
 		0,
 		'df1df9d4f66437ab5be715e4d1faeb29d24c80a6dc8276d6a630f05c5f1f7693',
-		1000, 'accEXAMPLE', 1, '\x6a'::bytea, '\x'::bytea
+		1000, 'accEXAMPLE', 1, '\x6a'::bytea, '\x'::bytea, 1, 2, extract(epoch from now())
 	);
 `
 

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -46,4 +46,12 @@ var migrations = []migration{
 		DROP INDEX account_control_programs_control_program_idx;
 		ALTER TABLE account_control_programs ADD PRIMARY KEY (control_program);
 	`},
+	{Name: "2016-11-18.0.account.confirmed-utxos.sql", SQL: `
+		DELETE FROM account_utxos WHERE confirmed_in IS NULL;
+		ALTER TABLE account_utxos
+			DROP COLUMN expiry_height,
+			ALTER COLUMN confirmed_in SET NOT NULL,
+			ALTER COLUMN block_pos SET NOT NULL,
+			ALTER COLUMN block_timestamp SET NOT NULL;
+	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -195,10 +195,9 @@ CREATE TABLE account_utxos (
     control_program_index bigint NOT NULL,
     control_program bytea NOT NULL,
     metadata bytea NOT NULL,
-    confirmed_in bigint,
-    block_pos integer,
-    block_timestamp bigint,
-    expiry_height bigint
+    confirmed_in bigint NOT NULL,
+    block_pos integer NOT NULL,
+    block_timestamp bigint NOT NULL
 );
 
 
@@ -796,13 +795,6 @@ CREATE INDEX account_utxos_account_id_asset_id_tx_hash_idx ON account_utxos USIN
 
 
 --
--- Name: account_utxos_expiry_height_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX account_utxos_expiry_height_idx ON account_utxos USING btree (expiry_height) WHERE (confirmed_in IS NULL);
-
-
---
 -- Name: annotated_accounts_jsondata_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -890,3 +882,4 @@ insert into migrations (filename, hash) values ('2016-11-07.0.core.remove-client
 insert into migrations (filename, hash) values ('2016-11-09.0.utxodb.drop-reservations.sql', '99bbf49814a12d2fee7430710d493958dc634e3395ac8c4839f084116a3e58be');
 insert into migrations (filename, hash) values ('2016-11-10.0.txdb.drop-pool-txs.sql', 'c52f610d5bd471cde5fbc083681e201f026b0cab89e7beeaa6a071ebbb99ff69');
 insert into migrations (filename, hash) values ('2016-11-16.0.account.drop-cp-id.sql', '149dd9ff2107e12452180bb73716a0985547bae843e5f99e5441717d6ec64a00');
+insert into migrations (filename, hash) values ('2016-11-18.0.account.confirmed-utxos.sql', 'b01e126edfcfe97f94eeda46f5a0eab6752e907104cecf247e90886f92795e94');

--- a/core/transact.go
+++ b/core/transact.go
@@ -207,19 +207,6 @@ func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Temp
 	if err != nil {
 		return err
 	}
-
-	// As a rule we only index confirmed blockchain data to prevent dirty
-	// reads, but here we're explicitly breaking that rule iff all of the
-	// inputs to the transaction are from locally-controlled keys. In that
-	// case, we're confident that this tx will be confirmed, so we relax
-	// that constraint to allow use of unconfirmed change, etc.
-	if txTemplate.Local {
-		err := h.Accounts.IndexUnconfirmedUTXOs(ctx, tx)
-		if err != nil {
-			return errors.Wrap(err, "indexing unconfirmed account utxos")
-		}
-	}
-
 	if waitUntil == "none" {
 		return nil
 	}
@@ -228,7 +215,6 @@ func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Temp
 	if err != nil {
 		return err
 	}
-
 	if waitUntil == "confirmed" {
 		return nil
 	}

--- a/core/transact_test.go
+++ b/core/transact_test.go
@@ -8,21 +8,25 @@ import (
 	"chain/core/account"
 	"chain/core/asset"
 	"chain/core/coretest"
+	"chain/core/pin"
+	"chain/core/query"
 	"chain/core/txbuilder"
 	"chain/database/pg/pgtest"
-	chainjson "chain/encoding/json"
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
 	"chain/testutil"
 )
 
-func TestLocalAccountTransfer(t *testing.T) {
+func TestAccountTransferSpendChange(t *testing.T) {
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
 	ctx := context.Background()
 	c := prottest.NewChain(t)
 	assets := asset.NewRegistry(db, c)
 	accounts := account.NewManager(db, c)
-	h := &Handler{Assets: assets, Accounts: accounts, DB: db, Chain: c}
+	pinStore := pin.NewStore(db)
+	coretest.CreatePins(ctx, t, pinStore)
+	accounts.IndexAccounts(query.NewIndexer(db, c, pinStore), pinStore)
+	go accounts.ProcessBlocks(ctx)
 
 	acc, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, nil)
 	if err != nil {
@@ -35,35 +39,37 @@ func TestLocalAccountTransfer(t *testing.T) {
 		Amount:  100,
 	}
 
-	sources := txbuilder.Action(assets.NewIssueAction(assetAmt, nil))
-	dests := accounts.NewControlAction(assetAmt, acc.ID, nil)
+	source := txbuilder.Action(assets.NewIssueAction(assetAmt, nil))
+	dest := accounts.NewControlAction(assetAmt, acc.ID, nil)
 
-	tmpl, err := txbuilder.Build(ctx, nil, []txbuilder.Action{sources, dests}, time.Now().Add(time.Minute))
+	tmpl, err := txbuilder.Build(ctx, nil, []txbuilder.Action{source, dest}, time.Now().Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)
 	}
-	coretest.SignTxTemplate(t, ctx, tmpl, &testutil.TestXPrv)
-
-	// Submit the transaction but w/o waiting long for confirmation.
-	// The outputs should be indexed because the transaction template
-	// indicates that the transaction is completely local to this Core.
-	_, _ = h.submitSingle(ctx, submitSingleArg{tpl: tmpl, wait: chainjson.Duration{Duration: time.Millisecond}})
-
-	// Add a new source, spending the change output produced above.
-	sources = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil)
-	tmpl, err = txbuilder.Build(ctx, nil, []txbuilder.Action{sources, dests}, time.Now().Add(time.Minute))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	coretest.SignTxTemplate(t, ctx, tmpl, &testutil.TestXPrv)
 	err = txbuilder.FinalizeTx(ctx, c, bc.NewTx(*tmpl.Transaction))
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	b := prottest.MakeBlock(t, c)
-	if len(b.Transactions) != 2 {
-		t.Errorf("len(b.Transactions) = %d, want 2", len(b.Transactions))
+	if len(b.Transactions) != 1 {
+		t.Errorf("len(b.Transactions) = %d, want 1", len(b.Transactions))
+	}
+	<-pinStore.PinWaiter(account.PinName, c.Height())
+
+	// Add a new source, spending the change output produced above.
+	source = accounts.NewSpendAction(assetAmt, acc.ID, nil, nil)
+	tmpl, err = txbuilder.Build(ctx, nil, []txbuilder.Action{source, dest}, time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	coretest.SignTxTemplate(t, ctx, tmpl, &testutil.TestXPrv)
+	err = txbuilder.FinalizeTx(ctx, c, bc.NewTx(*tmpl.Transaction))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b = prottest.MakeBlock(t, c)
+	if len(b.Transactions) != 1 {
+		t.Errorf("len(b.Transactions) = %d, want 1", len(b.Transactions))
 	}
 }


### PR DESCRIPTION
Only index confirmed account UTXOs. Indexing and spending unconfirmed
UTXOs allows for cascading failures if a single transaction fails.
Previously, we indexed unconfirmed outputs only if we had reasonable
certainty that the transaction would be accepted by the network (all of
the associated keys are local to the Chain Core). Transactions can still
fail due to latency issues and the transaction's MaxTime elapsing.

If other transactions had spent the failed tx's pool outputs, the entire
tree of transactions would fail. These cascading failures are difficult
to recover from. If we can avoid indexing/spending pool outputs, we'll
have a simpler system.

Long-term the removal of pool output spending can simplify tx rejection
detection because a Core can validate the transaction against its local
state tree.