### PR TITLE
cmd/benchcore: fix race

### DIFF
--- a/cmd/benchcore/main.go
+++ b/cmd/benchcore/main.go
@@ -506,6 +506,10 @@ func makeEC2(role string, inst *instance, wg *sync.WaitGroup) {
 			}
 			return fmt.Errorf("instance %s state %s (%s)", inst.id, *state.Name, reason)
 		}
+		if info.PrivateIPAddress == nil || info.PublicIPAddress == nil {
+			return errRetry
+		}
+
 		inst.privAddr = *info.PrivateIPAddress
 		inst.addr = *info.PublicIPAddress
 		return nil


### PR DESCRIPTION
When an instance switches to being RUNNING, I don't think it guarantees
that the public IP address has been assigned. I've seen this a couple of
times:

```
benchcore: 2016/11/17 11:49:00.780579 starting EC2 instances
benchcore: 2016/11/17 11:49:00.780740 building cored
benchcore: 2016/11/17 11:49:18.761466 cored executable: 55291846 bytes
benchcore: 2016/11/17 11:49:18.761487 building corectl
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xaa80]

goroutine 8 [running]:
panic(0x31d400, 0xc4200120f0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
main.makeEC2.func3(0x1dcd6500, 0xc420013980)
	/Users/jackson/src/chain/cmd/benchcore/main.go:510 +0x320
main.retry(0xc4201fdf00)
	/Users/jackson/src/chain/cmd/benchcore/main.go:536 +0x5d
main.makeEC2(0x380c73, 0x6, 0xc42011e150, 0xc420013af0)
	/Users/jackson/src/chain/cmd/benchcore/main.go:512 +0x386
created by main.main
	/Users/jackson/src/chain/cmd/benchcore/main.go:149 +0x546
```