### PR TITLE
core/txbuilder: refactor Build

### DIFF
--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -50,27 +50,25 @@ func TestAccountSourceReserve(t *testing.T) {
 	}
 	source := accounts.NewSpendAction(assetAmount1, accID, nil, nil)
 
-	buildResult, err := source.Build(ctx, time.Now().Add(time.Minute))
+	var builder txbuilder.TemplateBuilder
+	err := source.Build(ctx, time.Now().Add(time.Minute), &builder)
 	if err != nil {
 		t.Log(errors.Stack(err))
 		t.Fatal(err)
 	}
+	tpl := builder.Build()
 
 	wantTxIns := []*bc.TxInput{bc.NewSpendInput(out.Hash, out.Index, nil, out.AssetID, out.Amount, out.ControlProgram, nil)}
-
-	if !reflect.DeepEqual(buildResult.Inputs, wantTxIns) {
-		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", buildResult.Inputs, wantTxIns)
+	if !reflect.DeepEqual(tpl.Transaction.Inputs, wantTxIns) {
+		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tpl.Transaction.Inputs, wantTxIns)
 	}
-
-	if len(buildResult.Outputs) != 1 {
+	if len(tpl.Transaction.Outputs) != 1 {
 		t.Errorf("expected 1 change output")
 	}
-
-	if buildResult.Outputs[0].Amount != 1 {
+	if tpl.Transaction.Outputs[0].Amount != 1 {
 		t.Errorf("expected change amount to be 1")
 	}
-
-	if !programInAccount(ctx, t, db, buildResult.Outputs[0].ControlProgram, accID) {
+	if !programInAccount(ctx, t, db, tpl.Transaction.Outputs[0].ControlProgram, accID) {
 		t.Errorf("expected change control program to belong to account")
 	}
 }
@@ -99,16 +97,19 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	source := accounts.NewSpendUTXOAction(out.Outpoint)
-	buildResult, err := source.Build(ctx, time.Now().Add(time.Minute))
+
+	var builder txbuilder.TemplateBuilder
+	err := source.Build(ctx, time.Now().Add(time.Minute), &builder)
 	if err != nil {
 		t.Log(errors.Stack(err))
 		t.Fatal(err)
 	}
+	tpl := builder.Build()
 
 	wantTxIns := []*bc.TxInput{bc.NewSpendInput(out.Hash, out.Index, nil, out.AssetID, out.Amount, out.ControlProgram, nil)}
 
-	if !reflect.DeepEqual(buildResult.Inputs, wantTxIns) {
-		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", buildResult.Inputs, wantTxIns)
+	if !reflect.DeepEqual(tpl.Transaction.Inputs, wantTxIns) {
+		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tpl.Transaction.Inputs, wantTxIns)
 	}
 }
 
@@ -148,15 +149,18 @@ func TestAccountSourceReserveIdempotency(t *testing.T) {
 	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	reserveFunc := func(source txbuilder.Action) []*bc.TxInput {
-		buildResult, err := source.Build(ctx, time.Now().Add(time.Minute))
+		var builder txbuilder.TemplateBuilder
+
+		err := source.Build(ctx, time.Now().Add(time.Minute), &builder)
 		if err != nil {
 			t.Log(errors.Stack(err))
 			t.Fatal(err)
 		}
-		if len(buildResult.Inputs) != 1 {
-			t.Fatalf("expected 1 result utxo")
+		tpl := builder.Build()
+		if len(tpl.Transaction.Inputs) != 1 {
+			t.Fatalf("got %d result utxo, expected 1 result utxo", len(tpl.Transaction.Inputs))
 		}
-		return buildResult.Inputs
+		return tpl.Transaction.Inputs
 	}
 
 	var (

--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -56,7 +56,10 @@ func TestAccountSourceReserve(t *testing.T) {
 		t.Log(errors.Stack(err))
 		t.Fatal(err)
 	}
-	tpl := builder.Build()
+	tpl, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wantTxIns := []*bc.TxInput{bc.NewSpendInput(out.Hash, out.Index, nil, out.AssetID, out.Amount, out.ControlProgram, nil)}
 	if !reflect.DeepEqual(tpl.Transaction.Inputs, wantTxIns) {
@@ -104,7 +107,10 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 		t.Log(errors.Stack(err))
 		t.Fatal(err)
 	}
-	tpl := builder.Build()
+	tpl, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	wantTxIns := []*bc.TxInput{bc.NewSpendInput(out.Hash, out.Index, nil, out.AssetID, out.Amount, out.ControlProgram, nil)}
 
@@ -156,7 +162,10 @@ func TestAccountSourceReserveIdempotency(t *testing.T) {
 			t.Log(errors.Stack(err))
 			t.Fatal(err)
 		}
-		tpl := builder.Build()
+		tpl, err := builder.Build()
+		if err != nil {
+			t.Fatal(err)
+		}
 		if len(tpl.Transaction.Inputs) != 1 {
 			t.Fatalf("got %d result utxo, expected 1 result utxo", len(tpl.Transaction.Inputs))
 		}

--- a/core/txbuilder/actions.go
+++ b/core/txbuilder/actions.go
@@ -21,9 +21,9 @@ type controlProgramAction struct {
 	ReferenceData json.Map      `json:"reference_data"`
 }
 
-func (c *controlProgramAction) Build(ctx context.Context, maxTime time.Time) (*BuildResult, error) {
+func (c *controlProgramAction) Build(ctx context.Context, maxTime time.Time, b *TemplateBuilder) error {
 	out := bc.NewTxOutput(c.AssetID, c.Amount, c.Program, c.ReferenceData)
-	return &BuildResult{Outputs: []*bc.TxOutput{out}}, nil
+	return b.AddOutput(out)
 }
 
 func DecodeSetTxRefDataAction(data []byte) (Action, error) {
@@ -36,6 +36,6 @@ type setTxRefDataAction struct {
 	Data json.Map `json:"reference_data"`
 }
 
-func (a *setTxRefDataAction) Build(ctx context.Context, maxTime time.Time) (*BuildResult, error) {
-	return &BuildResult{ReferenceData: a.Data}, nil
+func (a *setTxRefDataAction) Build(ctx context.Context, maxTime time.Time, b *TemplateBuilder) error {
+	return b.setReferenceData(a.Data)
 }

--- a/core/txbuilder/builder.go
+++ b/core/txbuilder/builder.go
@@ -1,0 +1,112 @@
+package txbuilder
+
+import (
+	"bytes"
+	"math"
+	"time"
+
+	"chain/errors"
+	"chain/protocol/bc"
+)
+
+type TemplateBuilder struct {
+	base                *bc.TxData
+	maxTime             time.Time
+	inputs              []*bc.TxInput
+	outputs             []*bc.TxOutput
+	signingInstructions []*SigningInstruction
+	minTimeMS           uint64
+	referenceData       []byte
+	rollbacks           []func()
+}
+
+func (b *TemplateBuilder) AddInput(in *bc.TxInput, sigInstruction *SigningInstruction) error {
+	if in.Amount() > math.MaxInt64 {
+		return errors.WithDetailf(ErrBadAmount, "amount %d exceeds maximum value 2^63", in.Amount())
+	}
+	b.inputs = append(b.inputs, in)
+	b.signingInstructions = append(b.signingInstructions, sigInstruction)
+	return nil
+}
+
+func (b *TemplateBuilder) AddOutput(o *bc.TxOutput) error {
+	if o.Amount > math.MaxInt64 {
+		return errors.WithDetailf(ErrBadAmount, "amount %d exceeds maximum value 2^63", o.Amount)
+	}
+	b.outputs = append(b.outputs, o)
+	return nil
+}
+
+func (b *TemplateBuilder) RestrictMinTimeMS(ms uint64) {
+	if ms > b.minTimeMS {
+		b.minTimeMS = ms
+	}
+}
+
+// OnRollback registers a function that can be
+// used to attempt to undo any side effects of building
+// actions. For example, it might cancel any reservations
+// reservations that were made on UTXOs in a spend action.
+// Rollback is a "best-effort" operation and not guaranteed
+// to succeed. Each action's side effects, if any, must be
+// designed with this in mind.
+func (b *TemplateBuilder) OnRollback(rollbackFn func()) {
+	b.rollbacks = append(b.rollbacks, rollbackFn)
+}
+
+func (b *TemplateBuilder) setReferenceData(data []byte) error {
+	if b.base != nil && len(b.base.ReferenceData) != 0 && !bytes.Equal(b.base.ReferenceData, data) {
+		return errors.Wrap(ErrBadRefData)
+	}
+	if len(b.referenceData) != 0 && !bytes.Equal(b.referenceData, data) {
+		return errors.Wrap(ErrBadRefData)
+	}
+	b.referenceData = data
+	return nil
+}
+
+func (b *TemplateBuilder) rollback() {
+	for _, f := range b.rollbacks {
+		f()
+	}
+}
+
+func (b *TemplateBuilder) Build() *Template {
+	tpl := &Template{Transaction: b.base}
+	if tpl.Transaction == nil {
+		tpl.Transaction = &bc.TxData{
+			Version: bc.CurrentTransactionVersion,
+		}
+		tpl.Local = true
+	}
+
+	// Update min & max times.
+	if b.minTimeMS > 0 && b.minTimeMS > tpl.Transaction.MinTime {
+		tpl.Transaction.MinTime = b.minTimeMS
+	}
+	if tpl.Transaction.MaxTime == 0 || tpl.Transaction.MaxTime > bc.Millis(b.maxTime) {
+		tpl.Transaction.MaxTime = bc.Millis(b.maxTime)
+	}
+
+	// Set transaction reference data if applicable.
+	if len(b.referenceData) > 0 {
+		tpl.Transaction.ReferenceData = b.referenceData
+	}
+
+	// Add all the built outputs.
+	tpl.Transaction.Outputs = append(tpl.Transaction.Outputs, b.outputs...)
+
+	// Add all the built inputs and their corresponding signing instructions.
+	for i, in := range b.inputs {
+		instruction := b.signingInstructions[i]
+		instruction.Position = len(tpl.Transaction.Inputs)
+
+		// Empty signature arrays should be serialized as empty arrays, not null.
+		if instruction.WitnessComponents == nil {
+			instruction.WitnessComponents = []WitnessComponent{}
+		}
+		tpl.SigningInstructions = append(tpl.SigningInstructions, instruction)
+		tpl.Transaction.Inputs = append(tpl.Transaction.Inputs, in)
+	}
+	return tpl
+}

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -51,9 +51,13 @@ func Build(ctx context.Context, tx *bc.TxData, actions []Action, maxTime time.Ti
 	}
 
 	// Build the transaction template.
-	tpl := builder.Build()
+	tpl, err := builder.Build()
+	if err != nil {
+		builder.rollback()
+		return nil, err
+	}
 
-	err := checkBlankCheck(tpl.Transaction)
+	err = checkBlankCheck(tpl.Transaction)
 	if err != nil {
 		builder.rollback()
 		return nil, err

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -70,29 +70,11 @@ func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type (
-	BuildResult struct {
-		Inputs              []*bc.TxInput
-		Outputs             []*bc.TxOutput
-		SigningInstructions []*SigningInstruction
-		MinTimeMS           uint64
-		ReferenceData       []byte
-
-		// If set, Rollback attempts to undo any side effects
-		// of building the action. For example, it might cancel
-		// any reservations that were made on UTXOs in a spend
-		// action. Rollback is a "best-effort" operation and not
-		// guaranteed to succeed. Each action's side effects,
-		// if any, must be designed with this in mind.
-		Rollback func()
-	}
-
-	Action interface {
-		// TODO(bobg, jeffomatic): see if there is a way to remove the maxTime
-		// parameter from the build call. One possibility would be to treat TTL as
-		// a transaction-wide default parameter that gets folded into actions that
-		// care about it. This could happen when the build request is being
-		// deserialized.
-		Build(context.Context, time.Time) (*BuildResult, error)
-	}
-)
+type Action interface {
+	// TODO(bobg, jeffomatic): see if there is a way to remove the maxTime
+	// parameter from the build call. One possibility would be to treat TTL as
+	// a transaction-wide default parameter that gets folded into actions that
+	// care about it. This could happen when the build request is being
+	// deserialized.
+	Build(context.Context, time.Time, *TemplateBuilder) error
+}


### PR DESCRIPTION
Refactor txbuilder.Build and txbuilder.Action so that actions modify a shared txbuilder.TemplateBuilder instead of returning txbuilder.BuildResult. Some tests depend on actions orderings matching their corresponding inputs and outputs, so this removes the parallelism from building, at least for now.

This change has one API implication: ErrBadRefData will now correctly be returned as a part of the ErrAction multierror.