### PR TITLE
sdk/ruby: add missing transaction feed API calls

### DIFF
--- a/sdk/ruby/lib/chain/query.rb
+++ b/sdk/ruby/lib/chain/query.rb
@@ -5,7 +5,7 @@ module Chain
     # @return [Client]
     attr_reader :client
 
-    def initialize(client, first_query)
+    def initialize(client, first_query = {})
       @client = client
       @first_query = first_query
     end

--- a/sdk/ruby/lib/chain/transaction_feed.rb
+++ b/sdk/ruby/lib/chain/transaction_feed.rb
@@ -3,6 +3,7 @@ require 'securerandom'
 require_relative './client_module'
 require_relative './connection'
 require_relative './constants'
+require_relative './query'
 require_relative './response_object'
 
 module Chain
@@ -94,6 +95,30 @@ module Chain
         TransactionFeed.new(client.conn.request('get-transaction-feed', opts), client.conn)
       end
 
+      # @param [Hash] opts
+      # @option opts [String] :id ID of the transaction feed. You must provide either :id or :alias.
+      # @option opts [String] :alias ID of the transaction feed. You must provide either :id or :alias.
+      # @return [void]
+      def delete(opts)
+        client.conn.request('delete-transaction-feed', opts)
+        nil
+      end
+
+      # @return [Query]
+      def query
+        Query.new(client)
+      end
+
+    end
+
+    class Query < Chain::Query
+      def fetch(query)
+        client.conn.request('list-transaction-feeds', query)
+      end
+
+      def translate(raw)
+        TransactionFeed.new(raw, client.conn)
+      end
     end
 
   end

--- a/sdk/ruby/spec/integration/integration_spec.rb
+++ b/sdk/ruby/spec/integration/integration_spec.rb
@@ -315,6 +315,20 @@ context 'Chain SDK integration test' do
     t.join
 
     expect(consumed).to eq(produced)
+
+    # Query transaction feeds
+
+    expect(
+      chain.transaction_feeds.query.map(&:alias)
+    ).to eq(['spends', 'issuances'])
+
+    # Delete transaction feeds
+
+    expect(chain.transaction_feeds.delete(alias: :issuances)).to be_nil
+
+    expect(
+      chain.transaction_feeds.query.map(&:alias)
+    ).to eq(['spends'])
   end
 
 end


### PR DESCRIPTION
Including:

- querying/listing transaction feeds
- deleting transaction feeds