### PR TITLE
core/pin: process blocks in parallel

### DIFF
--- a/core/pin/pin.go
+++ b/core/pin/pin.go
@@ -229,7 +229,7 @@ func (p *pin) complete(ctx context.Context, height uint64) error {
 		max = p.completed[i]
 	}
 
-	if max < p.height {
+	if max == p.height {
 		return nil
 	}
 

--- a/core/pin/pin.go
+++ b/core/pin/pin.go
@@ -187,7 +187,7 @@ type pin struct {
 }
 
 func newPin(db pg.DB, name string, height uint64) *pin {
-	p := &pin{db: db, name: name, height: height, sem: make(chan bool, 10)}
+	p := &pin{db: db, name: name, height: height, sem: make(chan bool, processorWorkers)}
 	p.cond.L = &p.mu
 	return p
 }

--- a/core/pin/pin_test.go
+++ b/core/pin/pin_test.go
@@ -27,7 +27,7 @@ func TestWaitForPin(t *testing.T) {
 		}
 	}(sctx)
 
-	err := p.raiseTo(ctx, 1)
+	err := p.complete(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Each block processor is independent and idempotent, and so they can be
run in parallel. This particularly helps out the transaction indexer,
which can fall behind due to the long time it takes to process blocks.