### PR TITLE
core/account: cache UTXOs in reserver

### DIFF
--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -31,7 +31,7 @@ func NewManager(db *sql.DB, chain *protocol.Chain) *Manager {
 	return &Manager{
 		db:          db,
 		chain:       chain,
-		utxoDB:      newReserver(db),
+		utxoDB:      newReserver(db, chain),
 		cache:       lru.New(maxAccountCache),
 		aliasCache:  lru.New(maxAccountCache),
 		delayedACPs: make(map[*txbuilder.TemplateBuilder][]*controlProgram),

--- a/core/account/reserve.go
+++ b/core/account/reserve.go
@@ -8,11 +8,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/golang/groupcache/singleflight"
-
 	"chain/database/pg"
 	"chain/errors"
+	"chain/protocol"
 	"chain/protocol/bc"
+	"chain/protocol/state"
 	"chain/sync/idempotency"
 )
 
@@ -63,8 +63,9 @@ type reservation struct {
 	ClientToken *string
 }
 
-func newReserver(db pg.DB) *reserver {
+func newReserver(db pg.DB, c *protocol.Chain) *reserver {
 	return &reserver{
+		c:            c,
 		db:           db,
 		reservations: make(map[uint64]*reservation),
 		sources:      make(map[source]*sourceReserver),
@@ -82,6 +83,7 @@ func newReserver(db pg.DB) *reserver {
 // reserver ensures idempotency of reservations until the reservation
 // expiration.
 type reserver struct {
+	c                 *protocol.Chain
 	db                pg.DB
 	nextReservationID uint64
 	idempotency       idempotency.Group
@@ -154,6 +156,9 @@ func (re *reserver) reserveUTXO(ctx context.Context, out bc.Outpoint, exp time.T
 	if err != nil {
 		return nil, err
 	}
+	if !re.checkUTXO(u) {
+		return nil, pg.ErrUserInputNotFound
+	}
 
 	rid := atomic.AddUint64(&re.nextReservationID, 1)
 	err = re.source(u.source()).reserveUTXO(rid, u)
@@ -221,6 +226,11 @@ func (re *reserver) ExpireReservations(ctx context.Context) error {
 	return nil
 }
 
+func (re *reserver) checkUTXO(u *utxo) bool {
+	_, s := re.c.State()
+	return s.Tree.ContainsKey(state.OutputKey(u.Outpoint))
+}
+
 func (re *reserver) source(src source) *sourceReserver {
 	re.sourcesMu.Lock()
 	defer re.sourcesMu.Unlock()
@@ -233,6 +243,8 @@ func (re *reserver) source(src source) *sourceReserver {
 	sr = &sourceReserver{
 		db:       re.db,
 		src:      src,
+		validFn:  re.checkUTXO,
+		cached:   make(map[bc.Outpoint]*utxo),
 		reserved: make(map[bc.Outpoint]uint64),
 	}
 	re.sources[src] = sr
@@ -240,34 +252,65 @@ func (re *reserver) source(src source) *sourceReserver {
 }
 
 type sourceReserver struct {
-	db    pg.DB
-	src   source
-	group singleflight.Group
+	db      pg.DB
+	src     source
+	validFn func(u *utxo) bool
 
 	mu       sync.Mutex
+	cached   map[bc.Outpoint]*utxo
 	reserved map[bc.Outpoint]uint64
-}
-
-func (sr *sourceReserver) findMatchingUTXOs(ctx context.Context) ([]*utxo, error) {
-	srcID := fmt.Sprintf("%s-%s", sr.src.AssetID, sr.src.AccountID)
-	untypedUTXOs, err := sr.group.Do(srcID, func() (interface{}, error) {
-		return findMatchingUTXOs(ctx, sr.db, sr.src)
-	})
-	return untypedUTXOs.([]*utxo), err
 }
 
 func (sr *sourceReserver) reserve(ctx context.Context, rid uint64, amount uint64) ([]*utxo, uint64, error) {
 	var reserved, unavailable uint64
 	var reservedUTXOs []*utxo
 
+	// First try to reserve using only cached UTXOs.
+	sr.mu.Lock()
+	for o, u := range sr.cached {
+		// If the UTXO is already reserved, skip it.
+		if _, ok := sr.reserved[u.Outpoint]; ok {
+			continue
+		}
+		// Cached utxos aren't guaranteed to still be valid; they may
+		// have been spent. Verify that that the outputs are still in
+		// the state tree.
+		if !sr.validFn(u) {
+			delete(sr.cached, o)
+			continue
+		}
+
+		reserved += u.Amount
+		reservedUTXOs = append(reservedUTXOs, u)
+		if reserved >= amount {
+			break
+		}
+	}
+	if reserved >= amount {
+		// We've found enough to satisfy the request.
+		for _, u := range reservedUTXOs {
+			sr.reserved[u.Outpoint] = rid
+			delete(sr.cached, u.Outpoint)
+		}
+		sr.mu.Unlock()
+		return reservedUTXOs, reserved, nil
+	}
+	sr.mu.Unlock()
+	reserved = 0
+	reservedUTXOs = nil
+
 	// Find the set of UTXOs that match this source.
-	utxos, err := sr.findMatchingUTXOs(ctx)
+	utxos, err := findMatchingUTXOs(ctx, sr.db, sr.src)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
+	for _, u := range utxos {
+		sr.cached[u.Outpoint] = u
+	}
+
 	for _, utxo := range utxos {
 		// If the utxo is already reserved, skip it.
 		if _, ok := sr.reserved[utxo.Outpoint]; ok {
@@ -294,8 +337,8 @@ func (sr *sourceReserver) reserve(ctx context.Context, rid uint64, amount uint64
 	}
 
 	// We've found enough to satisfy the request.
-	for _, utxo := range reservedUTXOs {
-		sr.reserved[utxo.Outpoint] = rid
+	for _, u := range reservedUTXOs {
+		sr.reserved[u.Outpoint] = rid
 	}
 	return reservedUTXOs, reserved, nil
 }
@@ -344,9 +387,6 @@ func findMatchingUTXOs(ctx context.Context, db pg.DB, src source) ([]*utxo, erro
 				ControlProgramIndex: cpIndex,
 			})
 		})
-	// TODO(jackson): This has the potential to be a large number of UTXOs.
-	// If we need to, we can cache UTXOs or at least avoid reading UTXOs once
-	// we've found enough to satisfy the reservation.
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}

--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -95,6 +95,15 @@ func walk(n *node, walkFn WalkFunc) error {
 	return err
 }
 
+// ContainsKey returns true if the key contains the provided
+// key, without checking its corresponding hash.
+func (t *Tree) ContainsKey(bkey []byte) bool {
+	if t.root == nil {
+		return false
+	}
+	return t.lookup(t.root, bitKey(bkey)) != nil
+}
+
 // Contains returns true if the tree contains the provided
 // key, value pair.
 func (t *Tree) Contains(bkey, val []byte) bool {

--- a/protocol/state/outputs.go
+++ b/protocol/state/outputs.go
@@ -34,12 +34,17 @@ func Prevout(in *bc.TxInput) *Output {
 	}
 }
 
+// OutputKey returns the key of an output in the state tree.
+func OutputKey(o bc.Outpoint) (bkey []byte) {
+	var b bytes.Buffer
+	w := errors.NewWriter(&b) // used to satisfy interfaces
+	o.WriteTo(w)
+	return b.Bytes()
+}
+
 // OutputTreeItem returns the key of an output in the state tree,
 // as well as the output commitment (a second []byte) for Inserts
 // into the state tree.
 func OutputTreeItem(o *Output) (bkey, commitment []byte) {
-	b := bytes.NewBuffer(nil)
-	w := errors.NewWriter(b) // used to satisfy interfaces
-	o.Outpoint.WriteTo(w)
-	return b.Bytes(), o.Commitment()
+	return OutputKey(o.Outpoint), o.Commitment()
 }


### PR DESCRIPTION
Cache account UTXOs in the reserver. This allows some reservation
requests to avoid hitting the database if there are enough cached
UTXOs to cover the reservation amount.