### PR TITLE
core: guard against nil templates

### DIFF
--- a/core/transact.go
+++ b/core/transact.go
@@ -267,7 +267,7 @@ func waitForTxInBlock(ctx context.Context, c *protocol.Chain, tx *bc.Tx, height 
 }
 
 type submitArg struct {
-	Transactions []*txbuilder.Template
+	Transactions []txbuilder.Template
 	wait         chainjson.Duration
 	WaitUntil    string `json:"wait_until"` // values none, confirmed, processed. default: processed
 }
@@ -290,7 +290,7 @@ func (h *Handler) submit(ctx context.Context, x submitArg) (interface{}, error) 
 			defer batchRecover(subctx, &responses[i])
 
 			tx, err := h.submitSingle(subctx, submitSingleArg{
-				tpl:       x.Transactions[i],
+				tpl:       &x.Transactions[i],
 				wait:      x.wait,
 				waitUntil: x.WaitUntil,
 			})


### PR DESCRIPTION
Deserialize into `[]txbuilder.Template` instead of `[]*txbuilder.Template`
This prevents the need for an explicit check for a nil template if
`null` is provided instead of a transaction template JSON object.

Instead, txbuilder.ErrMissingRawTx will be returned:
https://github.com/chain/chain/blob/main/core/errors.go#L125

Fixes #128.