### PR TITLE
cmd/cored: use 'prod' tag to determine production mode

### DIFF
--- a/cmd/cored/dev.go
+++ b/cmd/cored/dev.go
@@ -15,7 +15,10 @@ import (
 	"chain/log"
 )
 
-var reset = env.String("RESET", "")
+var (
+	reset = env.String("RESET", "")
+	prod  = "no"
+)
 
 func resetInDevIfRequested(db pg.DB) {
 	if *reset != "" {

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -81,6 +81,7 @@ var (
 )
 
 func init() {
+	expvar.NewString("prod").Set(prod)
 	expvar.NewString("buildtag").Set(buildTag)
 	expvar.NewString("builddate").Set(buildDate)
 	expvar.NewString("buildcommit").Set(buildCommit)

--- a/cmd/cored/prod.go
+++ b/cmd/cored/prod.go
@@ -8,6 +8,8 @@ import (
 	"chain/database/pg"
 )
 
+var prod = "yes"
+
 func resetInDevIfRequested(db pg.DB) {}
 
 func authLoopbackInDev(req *http.Request) bool {

--- a/core/core.go
+++ b/core/core.go
@@ -32,8 +32,8 @@ const (
 )
 
 func isProduction() bool {
-	bt := expvar.Get("prod")
-	return bt != nil && bt.String() == `"yes"`
+	p := expvar.Get("prod")
+	return p != nil && p.String() == `"yes"`
 }
 
 func (h *Handler) reset(ctx context.Context, req struct {

--- a/core/core.go
+++ b/core/core.go
@@ -32,8 +32,8 @@ const (
 )
 
 func isProduction() bool {
-	bt := expvar.Get("buildtag")
-	return bt != nil && bt.String() != `"dev"`
+	bt := expvar.Get("prod")
+	return bt != nil && bt.String() == `"yes"`
 }
 
 func (h *Handler) reset(ctx context.Context, req struct {

--- a/core/coreunsafe/reset.go
+++ b/core/coreunsafe/reset.go
@@ -23,8 +23,8 @@ var (
 )
 
 func isProduction() bool {
-	bt := expvar.Get("buildtag")
-	return bt != nil && bt.String() != `"dev"`
+	bt := expvar.Get("prod")
+	return bt != nil && bt.String() == `"yes"`
 }
 
 // ResetBlockchain deletes all blockchain data, resulting in an

--- a/core/coreunsafe/reset.go
+++ b/core/coreunsafe/reset.go
@@ -23,8 +23,8 @@ var (
 )
 
 func isProduction() bool {
-	bt := expvar.Get("prod")
-	return bt != nil && bt.String() == `"yes"`
+	p := expvar.Get("prod")
+	return p != nil && p.String() == `"yes"`
 }
 
 // ResetBlockchain deletes all blockchain data, resulting in an


### PR DESCRIPTION
When determining whether cored is in "production" mode, there is
some confusion between the build tags "prod" and "buildTag". This
commit uses "prod" to determine production status, which frees
"buildTag" to convey version information for official releases.