### PR TITLE
protocol: streamline asset ID definition

### DIFF
--- a/cmd/multitool/multitool.go
+++ b/cmd/multitool/multitool.go
@@ -178,7 +178,7 @@ func assetid(args []string) {
 	issuance := mustDecodeHex(issuanceInp)
 	initialBlock := mustDecodeHash(initialBlockInp)
 	assetdefHash := bc.EmptyHash
-	// TODO(oleg): this case is not supported by multitool yet, move this func to its own command
+	// This case is not supported by multitool yet. Keep this in mind when moving this func to its own command.
 	if len(assetdefInp) > 0 {
 		assetdefHash = mustDecodeHash(assetdefInp)
 	}

--- a/cmd/multitool/multitool.go
+++ b/cmd/multitool/multitool.go
@@ -69,7 +69,7 @@ type command struct {
 }
 
 var subcommands = map[string]command{
-	"assetid":     command{assetid, "compute asset id", "ISSUANCEPROG GENESISHASH"},
+	"assetid":     command{assetid, "compute asset id", "ISSUANCEPROG GENESISHASH ASSETDEFINITIONHASH"},
 	"block":       command{block, "decode and pretty-print a block", "BLOCK"},
 	"blockheader": command{blockheader, "decode and pretty-print a block header", "BLOCKHEADER"},
 	"derive":      command{derive, "derive child from given xpub or xprv and given path", "[-xpub|-xprv] XPUB/XPRV PATH PATH..."},
@@ -167,14 +167,22 @@ func mustDecodeHash(s string) bc.Hash {
 
 func assetid(args []string) {
 	var (
-		issuanceInp, initialBlockInp string
-		usedStdin                    bool
+		issuanceInp     string
+		initialBlockInp string
+		assetdefInp     string
+		usedStdin       bool
 	)
 	issuanceInp, usedStdin = input(args, 0, false)
 	initialBlockInp, _ = input(args, 1, usedStdin)
+	assetdefInp, _ = input(args, 2, usedStdin)
 	issuance := mustDecodeHex(issuanceInp)
 	initialBlock := mustDecodeHash(initialBlockInp)
-	assetID := bc.ComputeAssetID(issuance, initialBlock, 1)
+	assetdefHash := bc.EmptyHash
+	// TODO(oleg): this case is not supported by multitool yet, move this func to its own command
+	if len(assetdefInp) > 0 {
+		assetdefHash = mustDecodeHash(assetdefInp)
+	}
+	assetID := bc.ComputeAssetID(issuance, initialBlock, 1, assetdefHash)
 	fmt.Println(assetID.String())
 }
 

--- a/cmd/multitool/multitool.go
+++ b/cmd/multitool/multitool.go
@@ -177,7 +177,7 @@ func assetid(args []string) {
 	assetdefInp, _ = input(args, 2, usedStdin)
 	issuance := mustDecodeHex(issuanceInp)
 	initialBlock := mustDecodeHash(initialBlockInp)
-	assetdefHash := bc.EmptyHash
+	assetdefHash := bc.EmptyStringHash
 	// This case is not supported by multitool yet. Keep this in mind when moving this func to its own command.
 	if len(assetdefInp) > 0 {
 		assetdefHash = mustDecodeHash(assetdefInp)

--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -93,14 +93,13 @@ func (reg *Registry) indexAssets(ctx context.Context, b *bc.Block) error {
 			if seen[in.AssetID()] {
 				continue
 			}
-			definition, err := definitionFromProgram(in.IssuanceProgram())
-			if err != nil {
-				continue
+			if ii, ok := in.TypedInput.(*bc.IssuanceInput); ok {
+				definition := ii.AssetDefinition
+				seen[in.AssetID()] = true
+				assetIDs = append(assetIDs, in.AssetID().String())
+				definitions = append(definitions, string(definition))
+				issuancePrograms = append(issuancePrograms, in.IssuanceProgram())
 			}
-			seen[in.AssetID()] = true
-			assetIDs = append(assetIDs, in.AssetID().String())
-			definitions = append(definitions, string(definition))
-			issuancePrograms = append(issuancePrograms, in.IssuanceProgram())
 		}
 	}
 	if len(assetIDs) == 0 {

--- a/core/asset/block_test.go
+++ b/core/asset/block_test.go
@@ -35,7 +35,7 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	}
 
 	// Create the issuance program of a remote asset.
-	issuanceProgram, err := programWithDefinition([]ed25519.PublicKey{testutil.TestPub}, 1, []byte(def))
+	issuanceProgram, err := multisigIssuanceProgram([]ed25519.PublicKey{testutil.TestPub, testutil.TestPub}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,6 +52,7 @@ func TestIndexNonLocalAssets(t *testing.T) {
 							TypedInput: &bc.IssuanceInput{
 								InitialBlock:    r.initialBlockHash,
 								Amount:          10000,
+								AssetDefinition: []byte(def),
 								IssuanceProgram: issuanceProgram,
 								VMVersion:       1,
 							},

--- a/core/asset/block_test.go
+++ b/core/asset/block_test.go
@@ -29,6 +29,10 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	localdef, err := local.SerializedDefinition()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Create the issuance program of a remote asset.
 	issuanceProgram, err := programWithDefinition([]ed25519.PublicKey{testutil.TestPub}, 1, []byte(def))
@@ -57,6 +61,7 @@ func TestIndexNonLocalAssets(t *testing.T) {
 							TypedInput: &bc.IssuanceInput{
 								InitialBlock:    r.initialBlockHash,
 								Amount:          10000,
+								AssetDefinition: localdef,
 								IssuanceProgram: local.IssuanceProgram,
 								VMVersion:       1,
 							},

--- a/core/asset/builder.go
+++ b/core/asset/builder.go
@@ -52,7 +52,13 @@ func (a *issueAction) Build(ctx context.Context, builder *txbuilder.TemplateBuil
 	if err != nil {
 		return err
 	}
-	txin := bc.NewIssuanceInput(nonce[:], a.Amount, a.ReferenceData, asset.InitialBlockHash, asset.IssuanceProgram, nil)
+
+	assetdef, err := asset.SerializedDefinition()
+	if err != nil {
+		return err
+	}
+
+	txin := bc.NewIssuanceInput(nonce[:], a.Amount, a.ReferenceData, asset.InitialBlockHash, asset.IssuanceProgram, nil, assetdef)
 
 	tplIn := &txbuilder.SigningInstruction{AssetAmount: a.AssetAmount}
 	path := signers.Path(asset.Signer, signers.AssetKeySpace)

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -119,7 +119,7 @@ func TestMaterializeWitnesses(t *testing.T) {
 		t.Fatal(err)
 	}
 	issuanceProg, _ := vmutil.P2SPMultiSigProgram([]ed25519.PublicKey{pubkey.PublicKey()}, 1)
-	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1)
+	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
 	outscript := mustDecodeHex("76a914c5d128911c28776f56baaac550963f7b88501dc388c0")
 	unsigned := &bc.TxData{
 		Version: 1,
@@ -187,7 +187,7 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 		t.Fatal(err)
 	}
 	issuanceProg, _ := vmutil.P2SPMultiSigProgram([]ed25519.PublicKey{pubkey1.PublicKey(), pubkey2.PublicKey(), pubkey3.PublicKey()}, 2)
-	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1)
+	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
 	outscript := mustDecodeHex("76a914c5d128911c28776f56baaac550963f7b88501dc388c0")
 	unsigned := &bc.TxData{
 		Version: 1,
@@ -279,7 +279,7 @@ func TestTxSighashCommitment(t *testing.T) {
 	var initialBlockHash bc.Hash
 
 	issuanceProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1)
+	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
 
 	// Tx with only issuance inputs is OK
 	tx := bc.NewTx(bc.TxData{

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -119,7 +119,7 @@ func TestMaterializeWitnesses(t *testing.T) {
 		t.Fatal(err)
 	}
 	issuanceProg, _ := vmutil.P2SPMultiSigProgram([]ed25519.PublicKey{pubkey.PublicKey()}, 1)
-	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
+	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyStringHash)
 	outscript := mustDecodeHex("76a914c5d128911c28776f56baaac550963f7b88501dc388c0")
 	unsigned := &bc.TxData{
 		Version: 1,
@@ -187,7 +187,7 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 		t.Fatal(err)
 	}
 	issuanceProg, _ := vmutil.P2SPMultiSigProgram([]ed25519.PublicKey{pubkey1.PublicKey(), pubkey2.PublicKey(), pubkey3.PublicKey()}, 2)
-	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
+	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyStringHash)
 	outscript := mustDecodeHex("76a914c5d128911c28776f56baaac550963f7b88501dc388c0")
 	unsigned := &bc.TxData{
 		Version: 1,
@@ -279,7 +279,7 @@ func TestTxSighashCommitment(t *testing.T) {
 	var initialBlockHash bc.Hash
 
 	issuanceProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
+	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyStringHash)
 
 	// Tx with only issuance inputs is OK
 	tx := bc.NewTx(bc.TxData{

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -124,7 +124,7 @@ func TestMaterializeWitnesses(t *testing.T) {
 	unsigned := &bc.TxData{
 		Version: 1,
 		Inputs: []*bc.TxInput{
-			bc.NewIssuanceInput(nil, 5, nil, initialBlockHash, issuanceProg, nil),
+			bc.NewIssuanceInput(nil, 5, nil, initialBlockHash, issuanceProg, nil, nil),
 		},
 		Outputs: []*bc.TxOutput{
 			bc.NewTxOutput(assetID, 5, outscript, nil),
@@ -192,7 +192,7 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 	unsigned := &bc.TxData{
 		Version: 1,
 		Inputs: []*bc.TxInput{
-			bc.NewIssuanceInput(nil, 100, nil, initialBlockHash, issuanceProg, nil),
+			bc.NewIssuanceInput(nil, 100, nil, initialBlockHash, issuanceProg, nil, nil),
 		},
 		Outputs: []*bc.TxOutput{
 			bc.NewTxOutput(assetID, 100, outscript, nil),

--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -468,12 +468,11 @@ An *asset version* is a variable-length integer encoded as [varint63](#varint63)
 
 Globally unique identifier of a given asset. Each [asset version](#asset-version) defines its own method to compute the asset ID, but an asset ID is always guaranteed to be unique across all asset versions and across all blockchains.
 
-**Asset version 1** defines asset ID as the [SHA3-256](#sha3) of the following structure:
+Asset ID is defined as the [SHA3-256](#sha3) of the following structure:
 
 Field            | Type          | Description
 -----------------|---------------|-------------------------------------------------
 Initial Block ID | sha3-256      | Hash of the first block in this blockchain.
-Asset Version    | varint63      | [Version](#asset-version) of this asset.
 VM Version       | varint63      | [Version of the VM](#vm-version) for the issuance program.
 Issuance Program | varstring31   | Program used in the issuance input.
 

--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -475,7 +475,7 @@ Field                 | Type          | Description
 Initial Block ID      | sha3-256      | Hash of the first block in this blockchain.
 VM Version            | varint63      | [Version of the VM](#vm-version) for the issuance program.
 Issuance Program      | varstring31   | Program used in the issuance input.
-Asset Definition Hash | varstring31   | [Optional hash](#optional-hash) of the asset definition data.
+Asset Definition Hash | sha3-256      | [SHA3-256](#sha3) hash of the asset definition data.
 
 
 ### Asset Definition

--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -305,11 +305,11 @@ Asset version 1 defines two witness structures: one for issuances and another on
 Field                   | Type                    | Description
 ------------------------|-------------------------|----------------------------------------------------------
 Initial Block ID        | sha3-256                | Hash of the first block in this blockchain.
+Asset Definition        | varstring31             | Arbitrary string or its [optional hash](#optional-hash), depending on [serialization flags](#transaction-serialization-flags).
 VM Version              | varint63                | [Version of the VM](#vm-version) that executes the issuance program.
 Issuance Program        | varstring31             | Predicate defining the conditions of issue.
 Program Arguments Count | varint31                | Number of [program arguments](#program-arguments) that follow.
 Program Arguments       | [varstring31]           | [Signatures](#signature) and other data satisfying the spent output’s predicate. Used to initialize the [data stack](vm1.md#vm-state) of the VM that executes an issuance or an control program.
-Asset Definition        | varstring31             | Arbitrary string or its [optional hash](#optional-hash), depending on [serialization flags](#transaction-serialization-flags).
 —                       | —                       | Additional fields may be added by future extensions.
 
 Note: nodes must verify that the initial block ID and issuance program are valid and match the declared asset ID in the [issuance commitment](#asset-version-1-issuance-commitment).

--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -382,15 +382,15 @@ The **first (least significant) bit** indicates whether the transaction includes
 
 The **second bit** indicates whether the output commitment from the spent output is present in the [input spend commitment](#asset-version-1-spend-commitment). If set to zero, the output commitment field is absent.
 
-The **third bit** indicates whether transaction reference data is present. If set to zero, the reference data is replaced by its optional hash value.
+The **third bit** indicates whether transaction reference data and asset definitions are present. If set to zero, the reference data and asset definitions are replaced by their optional hash values.
 
 All three bits can be used independently. Non-zero **higher bits** are reserved for future use.
 
 Serialization Flags Examples | Description
 -----------------------------|---------------------------------------------------------------------------
-0000 0000                    | Minimal serialization without witness and with reference data hashes instead of content.
-0000 0011                    | Minimal serialization needed for full verification. Contains witness fields and redundant [output commitment](#transaction-output-commitment), but not complete reference data.
-0000 0101                    | Non-redundant full binary serialization with witness fields and reference data.
+0000 0000                    | Minimal serialization without witness and with hashes of reference data and asset definitions instead of their actual content.
+0000 0011                    | Minimal serialization needed for full verification. Contains witness fields and redundant [output commitment](#transaction-output-commitment), but with hashes of reference data and asset definitions instead of their actual content.
+0000 0101                    | Non-redundant full binary serialization with witness fields, reference data and asset definitions.
 
 
 ### Transaction ID

--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -309,6 +309,7 @@ VM Version              | varint63                | [Version of the VM](#vm-vers
 Issuance Program        | varstring31             | Predicate defining the conditions of issue.
 Program Arguments Count | varint31                | Number of [program arguments](#program-arguments) that follow.
 Program Arguments       | [varstring31]           | [Signatures](#signature) and other data satisfying the spent output’s predicate. Used to initialize the [data stack](vm1.md#vm-state) of the VM that executes an issuance or an control program.
+Asset Definition        | varstring31             | Arbitrary string or its [optional hash](#optional-hash), depending on [serialization flags](#transaction-serialization-flags).
 —                       | —                       | Additional fields may be added by future extensions.
 
 Note: nodes must verify that the initial block ID and issuance program are valid and match the declared asset ID in the [issuance commitment](#asset-version-1-issuance-commitment).
@@ -454,7 +455,6 @@ The control program is a program specifying a predicate for transferring an asse
 
 The issuance program is a [program](#program) specifying a predicate for issuing an asset within an [input issuance commitment](#asset-version-1-issuance-commitment). The asset ID is derived from the issuance program, guaranteeing the authenticity of the issuer.
 
-Issuance programs must start with a [PUSHDATA](vm1.md#pushdata) opcode, followed by the [asset definition](#asset-definition), followed by a [DROP](vm1.md#drop) opcode.
 
 ### Program Arguments
 
@@ -470,17 +470,18 @@ Globally unique identifier of a given asset. Each [asset version](#asset-version
 
 Asset ID is defined as the [SHA3-256](#sha3) of the following structure:
 
-Field            | Type          | Description
------------------|---------------|-------------------------------------------------
-Initial Block ID | sha3-256      | Hash of the first block in this blockchain.
-VM Version       | varint63      | [Version of the VM](#vm-version) for the issuance program.
-Issuance Program | varstring31   | Program used in the issuance input.
+Field                 | Type          | Description
+----------------------|---------------|-------------------------------------------------
+Initial Block ID      | sha3-256      | Hash of the first block in this blockchain.
+VM Version            | varint63      | [Version of the VM](#vm-version) for the issuance program.
+Issuance Program      | varstring31   | Program used in the issuance input.
+Asset Definition Hash | varstring31   | [Optional hash](#optional-hash) of the asset definition data.
+
 
 ### Asset Definition
 
 An asset definition is an arbitrary binary string that corresponds to a particular [asset ID](#asset-id). Each asset version may define its own method to declare and commit to asset definitions.
 
-For version 1 assets, asset definitions are included in the issuance program. Issuance programs must start with a [PUSHDATA](vm1.md#pushdata) opcode, followed by the asset definition, followed by a [DROP](vm1.md#drop) opcode. Since the issuance program is part of the string hashed to determine an asset ID, the asset definition for a particular asset ID is immutable.
 
 ### Retired Asset
 

--- a/encoding/blockchain/blockchain_test.go
+++ b/encoding/blockchain/blockchain_test.go
@@ -164,3 +164,26 @@ func TestVarstring31(t *testing.T) {
 		t.Errorf("got %x, expected %x", s, want)
 	}
 }
+
+func TestEmptyVarstring31(t *testing.T) {
+	s := []byte{}
+	b := new(bytes.Buffer)
+	_, err := WriteVarstr31(b, s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{0x00}
+	if !bytes.Equal(b.Bytes(), want) {
+		t.Errorf("got %x, want %x", b.Bytes(), want)
+	}
+
+	b = bytes.NewBuffer(want)
+	s, _, err = ReadVarstr31(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = nil // we deliberately return nil for empty strings to avoid unnecessary byteslice allocation
+	if !bytes.Equal(s, want) {
+		t.Errorf("got %x, expected %x", s, want)
+	}
+}

--- a/protocol/bc/asset.go
+++ b/protocol/bc/asset.go
@@ -28,11 +28,7 @@ func ComputeAssetID(issuanceProgram []byte, initialHash [32]byte, vmVersion uint
 	h.Write(initialHash[:])
 	blockchain.WriteVarint63(h, vmVersion)
 	blockchain.WriteVarstr31(h, issuanceProgram) // TODO(bobg): check and return error
-	if assetDefinitionHash == EmptyStringHash {
-		blockchain.WriteVarstr31(h, nil)
-	} else {
-		blockchain.WriteVarstr31(h, assetDefinitionHash[:])
-	}
+	h.Write(assetDefinitionHash[:])
 	h.Read(assetID[:])
 	return assetID
 }

--- a/protocol/bc/asset.go
+++ b/protocol/bc/asset.go
@@ -28,7 +28,7 @@ func ComputeAssetID(issuanceProgram []byte, initialHash [32]byte, vmVersion uint
 	h.Write(initialHash[:])
 	blockchain.WriteVarint63(h, vmVersion)
 	blockchain.WriteVarstr31(h, issuanceProgram) // TODO(bobg): check and return error
-	if assetDefinitionHash == EmptyHash {
+	if assetDefinitionHash == EmptyStringHash {
 		blockchain.WriteVarstr31(h, nil)
 	} else {
 		blockchain.WriteVarstr31(h, assetDefinitionHash[:])

--- a/protocol/bc/asset.go
+++ b/protocol/bc/asset.go
@@ -22,13 +22,17 @@ func (a *AssetID) Scan(b interface{}) error     { return (*Hash)(a).Scan(b) }
 
 // ComputeAssetID computes the asset ID of the asset defined by
 // the given issuance program and initial block hash.
-func ComputeAssetID(issuanceProgram []byte, initialHash [32]byte, vmVersion uint64) (assetID AssetID) {
+func ComputeAssetID(issuanceProgram []byte, initialHash [32]byte, vmVersion uint64, assetDefinitionHash Hash) (assetID AssetID) {
 	h := sha3pool.Get256()
 	defer sha3pool.Put256(h)
 	h.Write(initialHash[:])
-	blockchain.WriteVarint63(h, assetVersion)
 	blockchain.WriteVarint63(h, vmVersion)
 	blockchain.WriteVarstr31(h, issuanceProgram) // TODO(bobg): check and return error
+	if assetDefinitionHash == EmptyHash {
+		blockchain.WriteVarstr31(h, nil)
+	} else {
+		blockchain.WriteVarstr31(h, assetDefinitionHash[:])
+	}
 	h.Read(assetID[:])
 	return assetID
 }

--- a/protocol/bc/asset_test.go
+++ b/protocol/bc/asset_test.go
@@ -9,7 +9,7 @@ import (
 func TestComputeAssetID(t *testing.T) {
 	issuanceScript := []byte{1}
 	initialBlockHash := mustDecodeHash("dd506f5d4c3f904d3d4b3c3be597c9198c6193ffd14a28570e4a923ce40cf9e5")
-	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash)
+	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyStringHash)
 
 	unhashed := append([]byte{}, initialBlockHash[:]...)
 	unhashed = append(unhashed, 0x01) // vmVersion
@@ -32,6 +32,6 @@ func BenchmarkComputeAssetID(b *testing.B) {
 	)
 
 	for i := 0; i < b.N; i++ {
-		assetIDSink = ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash)
+		assetIDSink = ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyStringHash)
 	}
 }

--- a/protocol/bc/asset_test.go
+++ b/protocol/bc/asset_test.go
@@ -9,13 +9,13 @@ import (
 func TestComputeAssetID(t *testing.T) {
 	issuanceScript := []byte{1}
 	initialBlockHash := mustDecodeHash("dd506f5d4c3f904d3d4b3c3be597c9198c6193ffd14a28570e4a923ce40cf9e5")
-	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1)
+	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash)
 
 	unhashed := append([]byte{}, initialBlockHash[:]...)
-	unhashed = append(unhashed, 0x01) // assetVersion
 	unhashed = append(unhashed, 0x01) // vmVersion
 	unhashed = append(unhashed, 0x01) // length of issuanceScript
 	unhashed = append(unhashed, issuanceScript...)
+	unhashed = append(unhashed, 0x00) // length of the optional asset definition hash
 	want := sha3.Sum256(unhashed)
 
 	if assetID != want {
@@ -32,6 +32,6 @@ func BenchmarkComputeAssetID(b *testing.B) {
 	)
 
 	for i := 0; i < b.N; i++ {
-		assetIDSink = ComputeAssetID(issuanceScript, initialBlockHash, 1)
+		assetIDSink = ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash)
 	}
 }

--- a/protocol/bc/asset_test.go
+++ b/protocol/bc/asset_test.go
@@ -15,7 +15,7 @@ func TestComputeAssetID(t *testing.T) {
 	unhashed = append(unhashed, 0x01) // vmVersion
 	unhashed = append(unhashed, 0x01) // length of issuanceScript
 	unhashed = append(unhashed, issuanceScript...)
-	unhashed = append(unhashed, 0x00) // length of the optional asset definition hash
+	unhashed = append(unhashed, EmptyStringHash[:]...)
 	want := sha3.Sum256(unhashed)
 
 	if assetID != want {

--- a/protocol/bc/hash.go
+++ b/protocol/bc/hash.go
@@ -19,7 +19,7 @@ import (
 // typically passed as values, not as pointers.
 type Hash [32]byte
 
-var emptyHash = sha3.Sum256(nil)
+var EmptyHash = sha3.Sum256(nil)
 
 // String returns the bytes of h encoded in hex.
 func (h Hash) String() string {

--- a/protocol/bc/hash.go
+++ b/protocol/bc/hash.go
@@ -19,7 +19,7 @@ import (
 // typically passed as values, not as pointers.
 type Hash [32]byte
 
-var EmptyHash = sha3.Sum256(nil)
+var EmptyStringHash = sha3.Sum256(nil)
 
 // String returns the bytes of h encoded in hex.
 func (h Hash) String() string {

--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -295,7 +295,7 @@ func (s *SigHasher) Hash(idx int) Hash {
 		sha3pool.Sum256(outHash[:], ocBuf.Bytes())
 	} else {
 		// inp is an issuance
-		outHash = EmptyHash
+		outHash = EmptyStringHash
 	}
 
 	h.Write(outHash[:])

--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -295,7 +295,7 @@ func (s *SigHasher) Hash(idx int) Hash {
 		sha3pool.Sum256(outHash[:], ocBuf.Bytes())
 	} else {
 		// inp is an issuance
-		outHash = emptyHash
+		outHash = EmptyHash
 	}
 
 	h.Write(outHash[:])

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -94,8 +94,8 @@ func TestTransaction(t *testing.T) {
 				"066f7574707574" + // output 0, reference data
 				"00" + // output 0, output witness
 				"0869737375616e6365"), // reference data
-			hash:        mustDecodeHash("f7118e7b6889f00b433a4195e3428ebc06779ed077845f216da0f7c904c39fdb"),
-			witnessHash: mustDecodeHash("38a531b8e92e3613353d1475792ad2ac1d172be0949ffd135f4fafc741c59e28"),
+			hash:        mustDecodeHash("946b6c226d88723020ab50665fbb76191639b5f1fd851b35edb729d4b17373cc"),
+			witnessHash: mustDecodeHash("274412cdf972ac27b68e57faf1b8eaeeb148ac45eb4bb6c1ff024d7a846e079c"),
 		},
 		{
 			tx: NewTx(TxData{
@@ -134,7 +134,7 @@ func TestTransaction(t *testing.T) {
 				"02" + // outputs count
 				"01" + // output 0, asset version
 				"29" + // output 0, output commitment length
-				"4a0414e98145e85f85a29b2f881d5111adaabaa86d0593481a9834dcbf6eb5b5" + // output 0, output commitment, asset id
+				"a9b2b6c5394888ab5396f583ae484b8459486b14268e2bef1b637440335eb6c1" + // output 0, output commitment, asset id
 				"80e0a596bb11" + // output 0, output commitment, amount
 				"01" + // output 0, output commitment, vm version
 				"0101" + // output 0, output commitment, control program
@@ -142,15 +142,15 @@ func TestTransaction(t *testing.T) {
 				"00" + // output 0, output witness
 				"01" + // output 1, asset version
 				"29" + // output 1, output commitment length
-				"4a0414e98145e85f85a29b2f881d5111adaabaa86d0593481a9834dcbf6eb5b5" + // output 1, output commitment, asset id
+				"a9b2b6c5394888ab5396f583ae484b8459486b14268e2bef1b637440335eb6c1" + // output 1, output commitment, asset id
 				"80c0ee8ed20b" + // output 1, output commitment, amount
 				"01" + // output 1, vm version
 				"0102" + // output 1, output commitment, control program
 				"00" + // output 1, reference data
 				"00" + // output 1, output witness
 				"0c646973747269627574696f6e"), // reference data
-			hash:        mustDecodeHash("b85e0f31a9641eec303940b6bc6c1367f2ad697e258700aa7fdfa91d83adb398"),
-			witnessHash: mustDecodeHash("5bdc619596d5ecb3eea7f28fdfdd9e8205302d8217a48b836379afc1c7085371"),
+			hash:        mustDecodeHash("7af758d0d27a7885cb65243164e2f8084b06aa1a647792cae028926b19324604"),
+			witnessHash: mustDecodeHash("335498668b169b5faea9a87410bc35626654941599815be655d532acf9925286"),
 		},
 	}
 
@@ -315,8 +315,8 @@ func TestTxHashForSig(t *testing.T) {
 		idx      int
 		wantHash string
 	}{
-		{0, "1f5ad8058b508b1c2a39bf77fbcae1eea535741c8315f4dddbdd8aaa5a22d635"},
-		{1, "d4ff86927710937dd27bbf90658c0816e4ca0e8a61ec9395268b9748b3895f29"},
+		{0, "94b72d62d47a8ba581246c0c721b18b36282cf81f2cdb92a3b1ab4fef4640654"},
+		{1, "6bcbf29804ebb70ae9887c4fc343bc06ee69f04befa1dc77ddf2f4a43eff0862"},
 	}
 
 	sigHasher := NewSigHasher(tx)

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -18,7 +18,7 @@ func TestTransaction(t *testing.T) {
 	initialBlockHashHex := "03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d"
 	initialBlockHash := mustDecodeHash(initialBlockHashHex)
 
-	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1)
+	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash)
 
 	cases := []struct {
 		tx          *Tx
@@ -93,8 +93,8 @@ func TestTransaction(t *testing.T) {
 				"066f7574707574" + // output 0, reference data
 				"00" + // output 0, output witness
 				"0869737375616e6365"), // reference data
-			hash:        mustDecodeHash("d5d90a4b6b179ec4c49badcec24f3c8890b3c03ed7f397a2de89b3f873de74a7"),
-			witnessHash: mustDecodeHash("34a7b5eb0a40dbab132b4a4c0ca90044efc9d086d84503e1fb9175d12230ed1f"),
+			hash:        mustDecodeHash("f7118e7b6889f00b433a4195e3428ebc06779ed077845f216da0f7c904c39fdb"),
+			witnessHash: mustDecodeHash("0834b4cf5bdeaa180e42b02102af180501809451a777a0a4771bf16e3a8aec82"),
 		},
 		{
 			tx: NewTx(TxData{
@@ -103,8 +103,8 @@ func TestTransaction(t *testing.T) {
 					NewSpendInput(mustDecodeHash("dd385f6fe25d91d8c1bd0fa58951ad56b0c5229dcc01f61d9f9e8b9eb92d3292"), 0, nil, AssetID{}, 1000000000000, []byte{1}, []byte("input")),
 				},
 				Outputs: []*TxOutput{
-					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1), 600000000000, []byte{1}, nil),
-					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1), 400000000000, []byte{2}, nil),
+					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash), 600000000000, []byte{1}, nil),
+					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash), 400000000000, []byte{2}, nil),
 				},
 				MinTime:       1492590000,
 				MaxTime:       1492590591,
@@ -133,7 +133,7 @@ func TestTransaction(t *testing.T) {
 				"02" + // outputs count
 				"01" + // output 0, asset version
 				"29" + // output 0, output commitment length
-				"9ed3e85a8c2d3717b5c94bd2db2ab9cab56955b2c4fb4696f345ca97aaab82d6" + // output 0, output commitment, asset id
+				"4a0414e98145e85f85a29b2f881d5111adaabaa86d0593481a9834dcbf6eb5b5" + // output 0, output commitment, asset id
 				"80e0a596bb11" + // output 0, output commitment, amount
 				"01" + // output 0, output commitment, vm version
 				"0101" + // output 0, output commitment, control program
@@ -141,15 +141,15 @@ func TestTransaction(t *testing.T) {
 				"00" + // output 0, output witness
 				"01" + // output 1, asset version
 				"29" + // output 1, output commitment length
-				"9ed3e85a8c2d3717b5c94bd2db2ab9cab56955b2c4fb4696f345ca97aaab82d6" + // output 1, output commitment, asset id
+				"4a0414e98145e85f85a29b2f881d5111adaabaa86d0593481a9834dcbf6eb5b5" + // output 1, output commitment, asset id
 				"80c0ee8ed20b" + // output 1, output commitment, amount
 				"01" + // output 1, vm version
 				"0102" + // output 1, output commitment, control program
 				"00" + // output 1, reference data
 				"00" + // output 1, output witness
 				"0c646973747269627574696f6e"), // reference data
-			hash:        mustDecodeHash("d2587bdb93c65cd89d2d648f2adba54f9997d8e2d649bd222288519cb7224f49"),
-			witnessHash: mustDecodeHash("a87eac712f74deb95bda148cc37375a0d8e16003a992b8d70531f7089dca4333"),
+			hash:        mustDecodeHash("b85e0f31a9641eec303940b6bc6c1367f2ad697e258700aa7fdfa91d83adb398"),
+			witnessHash: mustDecodeHash("5bdc619596d5ecb3eea7f28fdfdd9e8205302d8217a48b836379afc1c7085371"),
 		},
 	}
 
@@ -297,7 +297,7 @@ func TestOutpointWriteErr(t *testing.T) {
 }
 
 func TestTxHashForSig(t *testing.T) {
-	assetID := ComputeAssetID([]byte{1}, mustDecodeHash("03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d"), 1)
+	assetID := ComputeAssetID([]byte{1}, mustDecodeHash("03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d"), 1, EmptyHash)
 	tx := &TxData{
 		Version: 1,
 		Inputs: []*TxInput{
@@ -313,8 +313,8 @@ func TestTxHashForSig(t *testing.T) {
 		idx      int
 		wantHash string
 	}{
-		{0, "698a33855c638fc17c49fa0a2e297a47df4d89498bf7294f8b187cf77e05aa5a"},
-		{1, "d5ec94cb0ca0ab1f8ccaae3f0310aa254f18f8877b0225a65965aab544302e69"},
+		{0, "1f5ad8058b508b1c2a39bf77fbcae1eea535741c8315f4dddbdd8aaa5a22d635"},
+		{1, "d4ff86927710937dd27bbf90658c0816e4ca0e8a61ec9395268b9748b3895f29"},
 	}
 
 	sigHasher := NewSigHasher(tx)

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -51,7 +51,7 @@ func TestTransaction(t *testing.T) {
 			tx: NewTx(TxData{
 				Version: 1,
 				Inputs: []*TxInput{
-					NewIssuanceInput([]byte{10, 9, 8}, 1000000000000, []byte("input"), initialBlockHash, issuanceScript, [][]byte{[]byte{1, 2, 3}}),
+					NewIssuanceInput([]byte{10, 9, 8}, 1000000000000, []byte("input"), initialBlockHash, issuanceScript, [][]byte{[]byte{1, 2, 3}}, nil),
 				},
 				Outputs: []*TxOutput{
 					NewTxOutput(AssetID{}, 1000000000000, []byte{1}, []byte("output")),
@@ -75,8 +75,9 @@ func TestTransaction(t *testing.T) {
 				assetID.String() + // input 0, input commitment, asset id
 				"80a094a58d1d" + // input 0, input commitment, amount
 				"05696e707574" + // input 0, reference data
-				"28" + // input 0, issuance input witness length prefix
+				"29" + // input 0, issuance input witness length prefix
 				initialBlockHashHex + // input 0, issuance input witness, initial block
+				"00" + // input 0, issuance input witness, asset definition
 				"01" + // input 0, issuance input witness, vm version
 				"01" + // input 0, issuance input witness, issuance program length prefix
 				"01" + // input 0, issuance input witness, issuance program
@@ -94,7 +95,7 @@ func TestTransaction(t *testing.T) {
 				"00" + // output 0, output witness
 				"0869737375616e6365"), // reference data
 			hash:        mustDecodeHash("f7118e7b6889f00b433a4195e3428ebc06779ed077845f216da0f7c904c39fdb"),
-			witnessHash: mustDecodeHash("0834b4cf5bdeaa180e42b02102af180501809451a777a0a4771bf16e3a8aec82"),
+			witnessHash: mustDecodeHash("38a531b8e92e3613353d1475792ad2ac1d172be0949ffd135f4fafc741c59e28"),
 		},
 		{
 			tx: NewTx(TxData{
@@ -194,14 +195,14 @@ func TestHasIssuance(t *testing.T) {
 		want bool
 	}{{
 		tx: &TxData{
-			Inputs: []*TxInput{NewIssuanceInput(nil, 0, nil, Hash{}, nil, nil)},
+			Inputs: []*TxInput{NewIssuanceInput(nil, 0, nil, Hash{}, nil, nil, nil)},
 		},
 		want: true,
 	}, {
 		tx: &TxData{
 			Inputs: []*TxInput{
 				NewSpendInput(Hash{}, 0, nil, AssetID{}, 0, nil, nil),
-				NewIssuanceInput(nil, 0, nil, Hash{}, nil, nil),
+				NewIssuanceInput(nil, 0, nil, Hash{}, nil, nil, nil),
 			},
 		},
 		want: true,
@@ -241,8 +242,9 @@ func TestInvalidIssuance(t *testing.T) {
 		"0000000000000000000000000000000000000000000000000000000000000000" + // input 0, input commitment, WRONG asset id
 		"80a094a58d1d" + // input 0, input commitment, amount
 		"05696e707574" + // input 0, reference data
-		"28" + // input 0, issuance input witness length prefix
+		"29" + // input 0, issuance input witness length prefix
 		"03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d" + // input 0, issuance input witness, initial block
+		"00" + // input 0, issuance input witness, asset definition
 		"01" + // input 0, issuance input witness, vm version
 		"01" + // input 0, issuance input witness, issuance program length prefix
 		"01" + // input 0, issuance input witness, issuance program

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -18,7 +18,7 @@ func TestTransaction(t *testing.T) {
 	initialBlockHashHex := "03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d"
 	initialBlockHash := mustDecodeHash(initialBlockHashHex)
 
-	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash)
+	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyStringHash)
 
 	cases := []struct {
 		tx          *Tx
@@ -104,8 +104,8 @@ func TestTransaction(t *testing.T) {
 					NewSpendInput(mustDecodeHash("dd385f6fe25d91d8c1bd0fa58951ad56b0c5229dcc01f61d9f9e8b9eb92d3292"), 0, nil, AssetID{}, 1000000000000, []byte{1}, []byte("input")),
 				},
 				Outputs: []*TxOutput{
-					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash), 600000000000, []byte{1}, nil),
-					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyHash), 400000000000, []byte{2}, nil),
+					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyStringHash), 600000000000, []byte{1}, nil),
+					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyStringHash), 400000000000, []byte{2}, nil),
 				},
 				MinTime:       1492590000,
 				MaxTime:       1492590591,
@@ -299,7 +299,7 @@ func TestOutpointWriteErr(t *testing.T) {
 }
 
 func TestTxHashForSig(t *testing.T) {
-	assetID := ComputeAssetID([]byte{1}, mustDecodeHash("03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d"), 1, EmptyHash)
+	assetID := ComputeAssetID([]byte{1}, mustDecodeHash("03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d"), 1, EmptyStringHash)
 	tx := &TxData{
 		Version: 1,
 		Inputs: []*TxInput{

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -246,7 +246,7 @@ func (t *TxInput) readFrom(r io.Reader, txVersion uint64) (err error) {
 				return err
 			}
 
-			computedAssetID := ComputeAssetID(ii.IssuanceProgram, ii.InitialBlock, ii.VMVersion)
+			computedAssetID := ComputeAssetID(ii.IssuanceProgram, ii.InitialBlock, ii.VMVersion, EmptyHash)
 			if computedAssetID != assetID {
 				return errBadAssetID
 			}
@@ -352,5 +352,5 @@ func (si *SpendInput) IsIssuance() bool { return false }
 func (ii *IssuanceInput) IsIssuance() bool { return true }
 
 func (ii *IssuanceInput) AssetID() AssetID {
-	return ComputeAssetID(ii.IssuanceProgram, ii.InitialBlock, ii.VMVersion)
+	return ComputeAssetID(ii.IssuanceProgram, ii.InitialBlock, ii.VMVersion, EmptyHash) // TODO(oleg): use asset definition hash from the issuance input
 }

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -106,7 +106,7 @@ func (to *TxOutput) writeTo(w io.Writer, serflags byte) {
 }
 
 func (to *TxOutput) witnessHash() Hash {
-	return EmptyHash
+	return EmptyStringHash
 }
 
 func (to *TxOutput) WriteCommitment(w io.Writer) {

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -106,7 +106,7 @@ func (to *TxOutput) writeTo(w io.Writer, serflags byte) {
 }
 
 func (to *TxOutput) witnessHash() Hash {
-	return emptyHash
+	return EmptyHash
 }
 
 func (to *TxOutput) WriteCommitment(w io.Writer) {

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -176,8 +176,8 @@ func TestGenerateBlock(t *testing.T) {
 
 	// TODO(bobg): verify these hashes are correct
 	var wantTxRoot, wantAssetsRoot bc.Hash
-	copy(wantTxRoot[:], mustDecodeHex("ea048d3be17b422e04848ca9f6bc665491b5b7c4a66ca4993f5fb79cc4585b2a"))
-	copy(wantAssetsRoot[:], mustDecodeHex("dfb50c176548cfd5c74b8a4742983c09c6ead42932489d1894f81ef9ed0d7af7"))
+	copy(wantTxRoot[:], mustDecodeHex("e09fb2a187c95234d748d0b8158ca329c9ad84860b2c882b0e468fd837bbf295"))
+	copy(wantAssetsRoot[:], mustDecodeHex("0feb95ec66c0b3931f1336cc52da01d46a5d0761c984346eafb812e10f129d0a"))
 
 	want := &bc.Block{
 		BlockHeader: bc.BlockHeader{

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -140,7 +140,7 @@ func TestGenerateBlock(t *testing.T) {
 				bc.NewIssuanceInput(nil, 50, nil, initialBlockHash, nil, [][]byte{
 					nil,
 					mustDecodeHex("30450221009037e1d39b7d59d24eba8012baddd5f4ab886a51b46f52b7c479ddfa55eeb5c5022076008409243475b25dfba6db85e15cf3d74561a147375941e4830baa69769b5101"),
-					mustDecodeHex("51210210b002870438af79b829bc22c4505e14779ef0080c411ad497d7a0846ee0af6f51ae")}),
+					mustDecodeHex("51210210b002870438af79b829bc22c4505e14779ef0080c411ad497d7a0846ee0af6f51ae")}, nil),
 			},
 			Outputs: []*bc.TxOutput{
 				bc.NewTxOutput(assetID, 50, mustDecodeHex("a9145881cd104f8d64635751ac0f3c0decf9150c110687"), nil),
@@ -153,7 +153,7 @@ func TestGenerateBlock(t *testing.T) {
 					nil,
 					mustDecodeHex("3045022100f3bcffcfd6a1ce9542b653500386cd0ee7b9c86c59390ca0fc0238c0ebe3f1d6022065ac468a51a016842660c3a616c99a9aa5109a3bad1877ba3e0f010f3972472e01"),
 					mustDecodeHex("51210210b002870438af79b829bc22c4505e14779ef0080c411ad497d7a0846ee0af6f51ae"),
-				}),
+				}, nil),
 			},
 			Outputs: []*bc.TxOutput{
 				bc.NewTxOutput(assetID, 50, mustDecodeHex("a914c171e443e05b953baa7b7d834028ed91e47b4d0b87"), nil),
@@ -176,7 +176,7 @@ func TestGenerateBlock(t *testing.T) {
 
 	// TODO(bobg): verify these hashes are correct
 	var wantTxRoot, wantAssetsRoot bc.Hash
-	copy(wantTxRoot[:], mustDecodeHex("4e39bac8545fe486772dcb41eebda4b74b2c38a9d04d027e5e7430ea24f3857a"))
+	copy(wantTxRoot[:], mustDecodeHex("ea048d3be17b422e04848ca9f6bc665491b5b7c4a66ca4993f5fb79cc4585b2a"))
 	copy(wantAssetsRoot[:], mustDecodeHex("dfb50c176548cfd5c74b8a4742983c09c6ead42932489d1894f81ef9ed0d7af7"))
 
 	want := &bc.Block{

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -131,7 +131,7 @@ func TestGenerateBlock(t *testing.T) {
 	c, b1 := newTestChain(t, now)
 
 	initialBlockHash := b1.Hash()
-	assetID := bc.ComputeAssetID(nil, initialBlockHash, 1, bc.EmptyHash)
+	assetID := bc.ComputeAssetID(nil, initialBlockHash, 1, bc.EmptyStringHash)
 
 	txs := []*bc.Tx{
 		bc.NewTx(bc.TxData{

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -97,7 +97,7 @@ func TestWaitForBlockSoonWaits(t *testing.T) {
 	makeEmptyBlock(t, c) // height=2
 
 	go func() {
-		time.Sleep(10 * time.Millisecond) // sorry for the slow test 😔
+		time.Sleep(10 * time.Millisecond) // sorry for the slow test 
 		makeEmptyBlock(t, c)              // height=3
 	}()
 
@@ -131,7 +131,7 @@ func TestGenerateBlock(t *testing.T) {
 	c, b1 := newTestChain(t, now)
 
 	initialBlockHash := b1.Hash()
-	assetID := bc.ComputeAssetID(nil, initialBlockHash, 1)
+	assetID := bc.ComputeAssetID(nil, initialBlockHash, 1, bc.EmptyHash)
 
 	txs := []*bc.Tx{
 		bc.NewTx(bc.TxData{
@@ -176,8 +176,8 @@ func TestGenerateBlock(t *testing.T) {
 
 	// TODO(bobg): verify these hashes are correct
 	var wantTxRoot, wantAssetsRoot bc.Hash
-	copy(wantTxRoot[:], mustDecodeHex("d0e593c846d7b189bd3e2f55e680016b14989329af1c5e388ff246caedf04bd3"))
-	copy(wantAssetsRoot[:], mustDecodeHex("903d9a10ece41f86b7c2cf23c25b09c2086b321d6d63e2ec7fc7405f84121542"))
+	copy(wantTxRoot[:], mustDecodeHex("4e39bac8545fe486772dcb41eebda4b74b2c38a9d04d027e5e7430ea24f3857a"))
+	copy(wantAssetsRoot[:], mustDecodeHex("dfb50c176548cfd5c74b8a4742983c09c6ead42932489d1894f81ef9ed0d7af7"))
 
 	want := &bc.Block{
 		BlockHeader: bc.BlockHeader{

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -97,7 +97,7 @@ func TestWaitForBlockSoonWaits(t *testing.T) {
 	makeEmptyBlock(t, c) // height=2
 
 	go func() {
-		time.Sleep(10 * time.Millisecond) // sorry for the slow test 
+		time.Sleep(10 * time.Millisecond) // sorry for the slow test 😔
 		makeEmptyBlock(t, c)              // height=3
 	}()
 

--- a/protocol/prottest/tx.go
+++ b/protocol/prottest/tx.go
@@ -44,7 +44,8 @@ func NewIssuanceTx(tb testing.TB, c *protocol.Chain) *bc.Tx {
 	builder := vmutil.NewBuilder()
 
 	// TODO(oleg): move this asset definition to a proper field in the issuance input
-	builder.AddData([]byte(`{"type": "prottest issuance"}`)).AddOp(vm.OP_DROP)
+	assetdef := []byte(`{"type": "prottest issuance"}`)
+	builder.AddData(assetdef).AddOp(vm.OP_DROP)
 	builder.AddRawBytes(sigProg)
 	issuanceProgram := builder.Program
 
@@ -54,7 +55,7 @@ func NewIssuanceTx(tb testing.TB, c *protocol.Chain) *bc.Tx {
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
-	txin := bc.NewIssuanceInput(nonce[:], 100, nil, b1.Hash(), issuanceProgram, nil)
+	txin := bc.NewIssuanceInput(nonce[:], 100, nil, b1.Hash(), issuanceProgram, nil, assetdef)
 
 	tx := bc.TxData{
 		Version: bc.CurrentTransactionVersion,

--- a/protocol/prottest/tx.go
+++ b/protocol/prottest/tx.go
@@ -42,10 +42,6 @@ func NewIssuanceTx(tb testing.TB, c *protocol.Chain) *bc.Tx {
 		testutil.FatalErr(tb, err)
 	}
 	builder := vmutil.NewBuilder()
-
-	// TODO(oleg): move this asset definition to a proper field in the issuance input
-	assetdef := []byte(`{"type": "prottest issuance"}`)
-	builder.AddData(assetdef).AddOp(vm.OP_DROP)
 	builder.AddRawBytes(sigProg)
 	issuanceProgram := builder.Program
 
@@ -55,6 +51,7 @@ func NewIssuanceTx(tb testing.TB, c *protocol.Chain) *bc.Tx {
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
+	assetdef := []byte(`{"type": "prottest issuance"}`)
 	txin := bc.NewIssuanceInput(nonce[:], 100, nil, b1.Hash(), issuanceProgram, nil, assetdef)
 
 	tx := bc.TxData{

--- a/protocol/prottest/tx.go
+++ b/protocol/prottest/tx.go
@@ -42,6 +42,8 @@ func NewIssuanceTx(tb testing.TB, c *protocol.Chain) *bc.Tx {
 		testutil.FatalErr(tb, err)
 	}
 	builder := vmutil.NewBuilder()
+
+	// TODO(oleg): move this asset definition to a proper field in the issuance input
 	builder.AddData([]byte(`{"type": "prottest issuance"}`)).AddOp(vm.OP_DROP)
 	builder.AddRawBytes(sigProg)
 	issuanceProgram := builder.Program

--- a/protocol/tx_test.go
+++ b/protocol/tx_test.go
@@ -67,7 +67,7 @@ type testAsset struct {
 func newAsset(t testing.TB) *testAsset {
 	dest := newDest(t)
 	cp, _ := dest.controlProgram()
-	assetID := bc.ComputeAssetID(cp, bc.Hash{}, 1, bc.EmptyHash)
+	assetID := bc.ComputeAssetID(cp, bc.Hash{}, 1, bc.EmptyStringHash)
 
 	return &testAsset{
 		AssetID:  assetID,

--- a/protocol/tx_test.go
+++ b/protocol/tx_test.go
@@ -87,7 +87,7 @@ func issue(t testing.TB, asset *testAsset, dest *testDest, amount uint64) (*bc.T
 	tx := &bc.TxData{
 		Version: bc.CurrentTransactionVersion,
 		Inputs: []*bc.TxInput{
-			bc.NewIssuanceInput([]byte{1}, amount, nil, bc.Hash{}, assetCP, nil),
+			bc.NewIssuanceInput([]byte{1}, amount, nil, bc.Hash{}, assetCP, nil, nil),
 		},
 		Outputs: []*bc.TxOutput{
 			bc.NewTxOutput(asset.AssetID, amount, destCP, nil),

--- a/protocol/tx_test.go
+++ b/protocol/tx_test.go
@@ -67,7 +67,7 @@ type testAsset struct {
 func newAsset(t testing.TB) *testAsset {
 	dest := newDest(t)
 	cp, _ := dest.controlProgram()
-	assetID := bc.ComputeAssetID(cp, bc.Hash{}, 1)
+	assetID := bc.ComputeAssetID(cp, bc.Hash{}, 1, bc.EmptyHash)
 
 	return &testAsset{
 		AssetID:  assetID,

--- a/protocol/validation/merkle_test.go
+++ b/protocol/validation/merkle_test.go
@@ -79,7 +79,7 @@ func TestDuplicateLeaves(t *testing.T) {
 		now := []byte(time.Now().String())
 		txs[i] = bc.NewTx(bc.TxData{
 			Version: 1,
-			Inputs:  []*bc.TxInput{bc.NewIssuanceInput(now, i, nil, initialBlockHash, trueProg, nil)},
+			Inputs:  []*bc.TxInput{bc.NewIssuanceInput(now, i, nil, initialBlockHash, trueProg, nil, nil)},
 			Outputs: []*bc.TxOutput{bc.NewTxOutput(assetID, i, trueProg, nil)},
 		})
 	}
@@ -102,7 +102,7 @@ func TestAllDuplicateLeaves(t *testing.T) {
 	trueProg := []byte{byte(vm.OP_TRUE)}
 	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyHash)
 	now := []byte(time.Now().String())
-	issuanceInp := bc.NewIssuanceInput(now, 1, nil, initialBlockHash, trueProg, nil)
+	issuanceInp := bc.NewIssuanceInput(now, 1, nil, initialBlockHash, trueProg, nil, nil)
 
 	tx := bc.NewTx(bc.TxData{
 		Version: 1,

--- a/protocol/validation/merkle_test.go
+++ b/protocol/validation/merkle_test.go
@@ -73,7 +73,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 func TestDuplicateLeaves(t *testing.T) {
 	var initialBlockHash bc.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1)
+	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyHash)
 	txs := make([]*bc.Tx, 6)
 	for i := uint64(0); i < 6; i++ {
 		now := []byte(time.Now().String())
@@ -100,7 +100,7 @@ func TestDuplicateLeaves(t *testing.T) {
 func TestAllDuplicateLeaves(t *testing.T) {
 	var initialBlockHash bc.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1)
+	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyHash)
 	now := []byte(time.Now().String())
 	issuanceInp := bc.NewIssuanceInput(now, 1, nil, initialBlockHash, trueProg, nil)
 

--- a/protocol/validation/merkle_test.go
+++ b/protocol/validation/merkle_test.go
@@ -73,7 +73,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 func TestDuplicateLeaves(t *testing.T) {
 	var initialBlockHash bc.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyHash)
+	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyStringHash)
 	txs := make([]*bc.Tx, 6)
 	for i := uint64(0); i < 6; i++ {
 		now := []byte(time.Now().String())
@@ -100,7 +100,7 @@ func TestDuplicateLeaves(t *testing.T) {
 func TestAllDuplicateLeaves(t *testing.T) {
 	var initialBlockHash bc.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyHash)
+	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyStringHash)
 	now := []byte(time.Now().String())
 	issuanceInp := bc.NewIssuanceInput(now, 1, nil, initialBlockHash, trueProg, nil, nil)
 

--- a/protocol/validation/tx_test.go
+++ b/protocol/validation/tx_test.go
@@ -14,7 +14,7 @@ import (
 func TestUniqueIssuance(t *testing.T) {
 	var initialBlockHash bc.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyHash)
+	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyStringHash)
 	now := time.Now()
 	issuanceInp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, trueProg, nil, nil)
 
@@ -87,7 +87,7 @@ func TestUniqueIssuance(t *testing.T) {
 	}
 
 	true2Prog := []byte{byte(vm.OP_TRUE), byte(vm.OP_TRUE)}
-	asset2ID := bc.ComputeAssetID(true2Prog, initialBlockHash, 1, bc.EmptyHash)
+	asset2ID := bc.ComputeAssetID(true2Prog, initialBlockHash, 1, bc.EmptyStringHash)
 	issuance2Inp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, true2Prog, nil, nil)
 
 	// Transaction with empty nonce does not get added to issuance memory
@@ -169,7 +169,7 @@ func TestTxWellFormed(t *testing.T) {
 	var initialBlockHash bc.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
 	issuanceProg := trueProg
-	aid1 := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
+	aid1 := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyStringHash)
 	aid2 := bc.AssetID([32]byte{2})
 	txhash1 := bc.Hash{10}
 	txhash2 := bc.Hash{11}
@@ -806,7 +806,7 @@ func TestTxWellFormed(t *testing.T) {
 func TestValidateInvalidIssuances(t *testing.T) {
 	var initialBlockHash bc.Hash
 	issuanceProg := []byte{1}
-	aid := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
+	aid := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyStringHash)
 	now := time.Now()
 
 	wrongInitialBlockHash := initialBlockHash

--- a/protocol/validation/tx_test.go
+++ b/protocol/validation/tx_test.go
@@ -14,7 +14,7 @@ import (
 func TestUniqueIssuance(t *testing.T) {
 	var initialBlockHash bc.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1)
+	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyHash)
 	now := time.Now()
 	issuanceInp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, trueProg, nil)
 
@@ -87,7 +87,7 @@ func TestUniqueIssuance(t *testing.T) {
 	}
 
 	true2Prog := []byte{byte(vm.OP_TRUE), byte(vm.OP_TRUE)}
-	asset2ID := bc.ComputeAssetID(true2Prog, initialBlockHash, 1)
+	asset2ID := bc.ComputeAssetID(true2Prog, initialBlockHash, 1, bc.EmptyHash)
 	issuance2Inp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, true2Prog, nil)
 
 	// Transaction with empty nonce does not get added to issuance memory
@@ -169,7 +169,7 @@ func TestTxWellFormed(t *testing.T) {
 	var initialBlockHash bc.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
 	issuanceProg := trueProg
-	aid1 := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1)
+	aid1 := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
 	aid2 := bc.AssetID([32]byte{2})
 	txhash1 := bc.Hash{10}
 	txhash2 := bc.Hash{11}
@@ -806,7 +806,7 @@ func TestTxWellFormed(t *testing.T) {
 func TestValidateInvalidIssuances(t *testing.T) {
 	var initialBlockHash bc.Hash
 	issuanceProg := []byte{1}
-	aid := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1)
+	aid := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyHash)
 	now := time.Now()
 
 	wrongInitialBlockHash := initialBlockHash

--- a/protocol/validation/tx_test.go
+++ b/protocol/validation/tx_test.go
@@ -16,7 +16,7 @@ func TestUniqueIssuance(t *testing.T) {
 	trueProg := []byte{byte(vm.OP_TRUE)}
 	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyHash)
 	now := time.Now()
-	issuanceInp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, trueProg, nil)
+	issuanceInp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, trueProg, nil, nil)
 
 	// Transaction with empty nonce (and no other inputs) is invalid
 	tx := bc.NewTx(bc.TxData{
@@ -88,7 +88,7 @@ func TestUniqueIssuance(t *testing.T) {
 
 	true2Prog := []byte{byte(vm.OP_TRUE), byte(vm.OP_TRUE)}
 	asset2ID := bc.ComputeAssetID(true2Prog, initialBlockHash, 1, bc.EmptyHash)
-	issuance2Inp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, true2Prog, nil)
+	issuance2Inp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, true2Prog, nil, nil)
 
 	// Transaction with empty nonce does not get added to issuance memory
 	tx = bc.NewTx(bc.TxData{
@@ -215,7 +215,7 @@ func TestTxWellFormed(t *testing.T) {
 			tx: bc.TxData{
 				Version: 1,
 				Inputs: []*bc.TxInput{
-					bc.NewIssuanceInput(nil, 0, nil, initialBlockHash, issuanceProg, nil),
+					bc.NewIssuanceInput(nil, 0, nil, initialBlockHash, issuanceProg, nil, nil),
 					bc.NewSpendInput(txhash1, 0, nil, aid2, 0, nil, nil),
 				},
 				Outputs: []*bc.TxOutput{
@@ -825,7 +825,7 @@ func TestValidateInvalidIssuances(t *testing.T) {
 					MinTime: bc.Millis(now),
 					MaxTime: bc.Millis(now.Add(time.Hour)),
 					Inputs: []*bc.TxInput{
-						bc.NewIssuanceInput(nil, 1000, nil, initialBlockHash, issuanceProg, nil),
+						bc.NewIssuanceInput(nil, 1000, nil, initialBlockHash, issuanceProg, nil, nil),
 					},
 					Outputs: []*bc.TxOutput{
 						bc.NewTxOutput(aid, 1000, nil, nil),
@@ -842,7 +842,7 @@ func TestValidateInvalidIssuances(t *testing.T) {
 					MinTime: bc.Millis(now),
 					MaxTime: bc.Millis(now.Add(time.Minute)),
 					Inputs: []*bc.TxInput{
-						bc.NewIssuanceInput(nil, 1000, nil, initialBlockHash, issuanceProg, nil),
+						bc.NewIssuanceInput(nil, 1000, nil, initialBlockHash, issuanceProg, nil, nil),
 					},
 					Outputs: []*bc.TxOutput{
 						bc.NewTxOutput(aid, 1000, nil, nil),
@@ -859,7 +859,7 @@ func TestValidateInvalidIssuances(t *testing.T) {
 					MinTime: bc.Millis(now),
 					MaxTime: bc.Millis(now.Add(time.Minute)),
 					Inputs: []*bc.TxInput{
-						bc.NewIssuanceInput(nil, 1000, nil, initialBlockHash, issuanceProg, nil),
+						bc.NewIssuanceInput(nil, 1000, nil, initialBlockHash, issuanceProg, nil, nil),
 					},
 					Outputs: []*bc.TxOutput{
 						bc.NewTxOutput(aid, 1000, nil, nil),
@@ -876,7 +876,7 @@ func TestValidateInvalidIssuances(t *testing.T) {
 					MinTime: bc.Millis(now),
 					MaxTime: bc.Millis(now.Add(time.Hour)),
 					Inputs: []*bc.TxInput{
-						bc.NewIssuanceInput(nil, 1000, nil, wrongInitialBlockHash, issuanceProg, nil),
+						bc.NewIssuanceInput(nil, 1000, nil, wrongInitialBlockHash, issuanceProg, nil, nil),
 					},
 					Outputs: []*bc.TxOutput{
 						bc.NewTxOutput(aid, 1000, nil, nil),

--- a/protocol/vm/introspection_test.go
+++ b/protocol/vm/introspection_test.go
@@ -91,7 +91,7 @@ func TestOutpointAndNonceOp(t *testing.T) {
 	tx := bc.NewTx(bc.TxData{
 		Inputs: []*bc.TxInput{
 			bc.NewSpendInput(zeroHash, 0, nil, bc.AssetID{1}, 5, []byte("spendprog"), []byte("ref")),
-			bc.NewIssuanceInput(nonce, 6, nil, zeroHash, []byte("issueprog"), nil),
+			bc.NewIssuanceInput(nonce, 6, nil, zeroHash, []byte("issueprog"), nil, nil),
 		},
 	})
 	vm := &virtualMachine{
@@ -151,7 +151,7 @@ func TestIntrospectionOps(t *testing.T) {
 		ReferenceData: []byte("txref"),
 		Inputs: []*bc.TxInput{
 			bc.NewSpendInput(bc.Hash{}, 0, nil, bc.AssetID{1}, 5, []byte("spendprog"), []byte("ref")),
-			bc.NewIssuanceInput(nil, 6, nil, bc.Hash{}, []byte("issueprog"), nil),
+			bc.NewIssuanceInput(nil, 6, nil, bc.Hash{}, []byte("issueprog"), nil, nil),
 		},
 		Outputs: []*bc.TxOutput{
 			bc.NewTxOutput(bc.AssetID{3}, 8, []byte("wrongprog"), nil),

--- a/protocol/vm/vm_test.go
+++ b/protocol/vm/vm_test.go
@@ -198,6 +198,7 @@ func TestVerifyTxInput(t *testing.T) {
 			bc.Hash{},
 			[]byte{byte(OP_ADD), byte(OP_5), byte(OP_NUMEQUAL)},
 			[][]byte{{2}, {3}},
+			nil,
 		),
 		want: true,
 	}, {
@@ -224,6 +225,7 @@ func TestVerifyTxInput(t *testing.T) {
 			bc.Hash{},
 			[]byte{byte(OP_ADD), byte(OP_5), byte(OP_NUMEQUAL)},
 			[][]byte{make([]byte, 50001)},
+			nil,
 		),
 		wantErr: ErrRunLimitExceeded,
 	}, {


### PR DESCRIPTION
This change does two things:

1. **Removes asset version from Asset ID** to allow compatibility of the AssetIDs with future output types in the future protocol versions. Security of non-upgraded clients should not be affected as they already verify balancing rule, therefore, preventing unaccounted transfer of assets from the old entries to the new ones.
2. **Moves asset definition from the issuance program into its own field in the issuance input**. So we no longer have clumsy `<data> DROP <actual code>` issuance programs, have an explicit asset definition field in the issuance input and, as a result, support serialization flags for asset definition just like for the rest of the reference data.

This is a part of a package of breaking changes in P1: https://github.com/chain/chain/issues/239