### PR TITLE
protocol: restructure transactions to contain a flat list of entries

### DIFF
--- a/docs/protocol/specifications/consensus.md
+++ b/docs/protocol/specifications/consensus.md
@@ -108,7 +108,7 @@ The block generator collects transactions to include in each block it generates.
 **Algorithm:**
 
 1. [Validate the transaction](validation.md#validate-transaction) with respect to the current blockchain state, but using system timestamp instead of the latest block timestamp; if invalid, halt and return false.
-2. If the transaction contains at least one [issuance input with asset version 1](data.md#asset-version-1-issuance-commitment) and a non-empty nonce:
+2. If the transaction contains at least one [issuance entry](data.md#issuance-entry) with a non-empty nonce:
     1. Test that transaction minimum timestamp plus the [maximum issuance window](#generator-state) is greater or equal to the transaction maximum timestamp; if not, halt and return false.
 3. Add the transaction to the transaction pool.
 4. Return true.
@@ -177,9 +177,7 @@ See also the note in the [Make Block](#make-block) algorithm.
     1. The block version must equal 1.
     2. For every transaction in the block:
         1. Transaction version must equal 1.
-        2. [Transaction common witness](data.md#transaction-common-witness) string must be empty.
-        3. Every [input witness](data.md#transaction-input-witness) must contain only the fields defined in this version of the protocol (no additional data included).
-        4. Every [output witness](data.md#transaction-output-witness) must be empty.
+        2. Every [entry witness](data.md#entry-witness) must contain only the fields defined in this version of the protocol (no additional data included).
 6. Check that the block's timestamp is less than 2 minutes after the system time. If it is not, halt and return nothing.
 7. Compute the [block signature hash](data.md#block-signature-hash) for the block.
 8. Sign the signature hash with the signing key, yielding a [signature](data.md#signature).

--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -153,7 +153,7 @@ Unknown appended commitments must be ignored. Changes to the format of the commi
 Field                                   | Type        | Description
 ----------------------------------------|-------------|----------------------------------------------------------
 Transactions Merkle Root                | sha3-256    | Root hash of the [merkle binary hash tree](#merkle-binary-tree) formed by the transaction witness hashes of all transactions included in the block.
-Assets Merkle Root                      | sha3-256    | Root hash of the [merkle patricia tree](#merkle-patricia-tree) of the set of unspent outputs with asset version 1 after applying the block. See [Assets Merkle Root](#assets-merkle-root) for details.
+Assets Merkle Root                      | sha3-256    | Root hash of the [merkle patricia tree](#merkle-patricia-tree) of the set of unspent [outputs](#output-entry) after applying the block. See [Assets Merkle Root](#assets-merkle-root) for details.
 Next [Consensus Program](#consensus-program) | varstring31 | Authentication predicate for adding a new block after this one.
 —                                       | —           | Additional fields may be added by future extensions.
 
@@ -215,10 +215,10 @@ The present version of Chain Protocol defines five entry types:
 Entry type                             | Numeric value | Purpose
 ---------------------------------------|---------------|----------------
 [Reference](#reference-entry)          | 0x00          | Provides transaction-level reference data without affecting asset flow. 
-[Issuance](#issuance-entry)            | 0x04          | Creates new units of a given asset ID.
-[Input](#input-entry)                  | 0x05          | Consumes existing units from a previous transaction’s output.
-[Output](#output-entry)                | 0x06          | Distributes units to specified control program.
-[Retirement](#retirement-entry)        | 0x07          | Removes units from circulation.
+[Issuance](#issuance-entry)            | 0x01          | Creates new units of a given asset ID.
+[Input](#input-entry)                  | 0x02          | Consumes existing units from a previous transaction’s output.
+[Output](#output-entry)                | 0x03          | Distributes units to specified control program.
+[Retirement](#retirement-entry)        | 0x04          | Removes units from circulation.
 
 Other entry types are reserved for future extensions.
 
@@ -232,7 +232,7 @@ The *witness* string contains [program arguments](#program-arguments) ([cryptogr
 
 The witness string can be extended with additional commitments, proofs or validation hints that are excluded from the [transaction ID](#transaction-id), but committed to the blockchain via the [witness hash](#transaction-witness-hash).
 
-Exact format of the witness field is defined according to the asset version and additional entry type flags (if any) used within the [entry content](#entry-content).
+Exact format of the witness field is defined according to the [entry type](#entry-type).
 
 
 ### Reference Entry
@@ -462,7 +462,7 @@ A list of binary strings in the [issuance witness](#issuance-entry-witness), [in
 
 ### Asset ID
 
-Globally unique identifier of a given asset. Future versions of the protocol may introduce new [issuance entry types](#issuance-entry) with another definition of an asset ID, but an asset ID is always guaranteed to be unique across all asset versions and across all blockchains.
+Globally unique identifier of a given asset. Future versions of the protocol may introduce new [issuance entry types](#issuance-entry) with a different definition of an asset ID, but an asset ID is always guaranteed to be unique across all blockchains.
 
 Present version of the protocol defines asset ID as the [SHA3-256](#sha3) of the following structure:
 
@@ -475,9 +475,9 @@ Issuance Program | varstring31   | Program used in the issuance input.
 
 ### Asset Definition
 
-An asset definition is an arbitrary binary string that corresponds to a particular [asset ID](#asset-id). Each asset version may define its own method to declare and commit to asset definitions.
+An asset definition is an arbitrary binary string that corresponds to a particular [asset ID](#asset-id). Future [issuance entry types](#issuance-entry) may define their own methods to declare and commit to asset definitions.
 
-For version 1 assets, asset definitions are included in the issuance program. Issuance programs must start with a [PUSHDATA](vm1.md#pushdata) opcode, followed by the asset definition, followed by a [DROP](vm1.md#drop) opcode. Since the issuance program is part of the string hashed to determine an asset ID, the asset definition for a particular asset ID is immutable.
+In he present version of the protocol, asset definitions are included in the issuance program. Issuance programs must start with a [PUSHDATA](vm1.md#pushdata) opcode, followed by the asset definition, followed by a [DROP](vm1.md#drop) opcode. Since the issuance program is part of the string hashed to determine an asset ID, the asset definition for a particular asset ID is immutable.
 
 ### Retired Asset
 
@@ -493,7 +493,7 @@ Root hash of the [merkle binary hash tree](#merkle-binary-tree) formed by the *t
 
 ### Assets Merkle Root
 
-Root hash of the [merkle patricia tree](#merkle-patricia-tree) formed by unspent outputs with an **asset version 1** after applying the block. Allows bootstrapping nodes from recent blocks and an archived copy of the corresponding merkle patricia tree without processing all historical transactions.
+Root hash of the [merkle patricia tree](#merkle-patricia-tree) formed by unspent [output entries](#output-entry) after applying the block. Allows bootstrapping nodes from recent blocks and an archived copy of the corresponding merkle patricia tree without processing all historical transactions.
 
 The tree contains unspent outputs (one or more per [asset ID](#asset-id)):
 

--- a/docs/protocol/specifications/txentries-todo.md
+++ b/docs/protocol/specifications/txentries-todo.md
@@ -3,9 +3,9 @@ TODO:
 
 - Tx = {txversion, mintime, maxtime, [entry] }
 - Entry = {content, witness}
-- TxID = Hash(txversion, mintime, maxtime, [{entry.assetversion, entry.content}] )
+- TxID = Hash(txversion, mintime, maxtime, [{entry.entrytype, entry.content}] )
 - TxWitHash = Hash(TxID, [{entry.witness}] )
-- Content = {assetversion, ...}
+- Content = {entrytype, ...}
 - Content = {0, refdata_hash}
 - Content = {1, entry_type, ...}
 - Content = {1, "issue", ...}

--- a/docs/protocol/specifications/txentries-todo.md
+++ b/docs/protocol/specifications/txentries-todo.md
@@ -1,0 +1,17 @@
+
+TODO:
+
+- Tx = {txversion, mintime, maxtime, [entry] }
+- Entry = {content, witness}
+- TxID = Hash(txversion, mintime, maxtime, [{entry.assetversion, entry.content}] )
+- TxWitHash = Hash(TxID, [{entry.witness}] )
+- Content = {assetversion, ...}
+- Content = {0, refdata_hash}
+- Content = {1, entry_type, ...}
+- Content = {1, "issue", ...}
+- Content = {1, "input", outpoint}
+- Content = {1, "output", ...}
+- Content = {1, "retire", ...}
+- remove OP_FAIL
+- rename CHECKOUTPUT -> CHECKENTRY
+- outpoint = SHA3(txid || entry_index || SHA3(output))

--- a/docs/protocol/specifications/validation.md
+++ b/docs/protocol/specifications/validation.md
@@ -260,7 +260,7 @@ A transaction is said to be *valid* with respect to a particular blockchain stat
 1. Load an output hash from the state as identified by the input’s [spent output reference](data.md#outpoint), yielding a *previous output hash*.
 2. If the previous output does not exist, halt and return false.
 3. Compute the SHA3-256 hash of the *previous output* provided in the [input witness](data.md#input-entry-witness).
-4. Test that the *previous output hash* from the blockchain state equals the hash of the *previous output* in the wintess; if not, halt and return false.
+4. Test that the *previous output hash* from the blockchain state equals the hash of the *previous output* in the witness; if not, halt and return false.
 5. [Evaluate](#evaluate-predicate) the control program specified in the *previous output*, for the VM version specified in the previous output and with the [input witness](data.md#input-entry-witness) program arguments.
 6. If the evaluation returns false, halt and return false.
 7. Return true.

--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -1185,7 +1185,7 @@ Fails if executed in the [block context](#block-context).
 
 Code  | Stack Diagram   | Cost
 ------|-----------------|-----------------------------------------------------
-0xc9  | (∅ → index)     | 1; [standard memory cost](#standard-memory-cost)
+0xc7  | (∅ → index)     | 1; [standard memory cost](#standard-memory-cost)
 
 Pushes the index of the current entry on the data stack.
 
@@ -1196,7 +1196,7 @@ Fails if executed in the [block context](#block-context).
 
 Code  | Stack Diagram   | Cost
 ------|-----------------|-----------------------------------------------------
-0xcb  | (∅ → outpointtx outpointindex)  | 1; [standard memory cost](#standard-memory-cost)
+0xc8  | (∅ → outpointtx outpointindex)  | 1; [standard memory cost](#standard-memory-cost)
 
 Pushes the transaction ID and output index fields of the current entry’s [outpoint](#outpoint) on the data stack as separate items. The index is encoded as a [VM number](#vm-number).
 
@@ -1209,7 +1209,7 @@ Fails if executed in the [block context](#block-context).
 
 Code  | Stack Diagram   | Cost
 ------|-----------------|-----------------------------------------------------
-0xcc  | (∅ → nonce)     | 1; [standard memory cost](#standard-memory-cost)
+0xc9  | (∅ → nonce)     | 1; [standard memory cost](#standard-memory-cost)
 
 Pushes the nonce declared in the current issuance entry’s [content](data.md#issuance-entry-content) on the data stack.
 
@@ -1222,7 +1222,7 @@ Fails if executed in the [block context](#block-context).
 
 Code  | Stack Diagram  | Cost
 ------|----------------|-----------------------------------------------------
-0xcd  | (∅ → program)   | 1; [standard memory cost](#standard-memory-cost)
+0xca  | (∅ → program)   | 1; [standard memory cost](#standard-memory-cost)
 
 Pushes the [next consensus program](data.md#consensus-program) specified in the current block header.
 
@@ -1233,7 +1233,7 @@ Fails if executed in the [transaction context](#transaction-context).
 
 Code  | Stack Diagram   | Cost
 ------|-----------------|-----------------------------------------------------
-0xce  | (∅ → timestamp) | 1; [standard memory cost](#standard-memory-cost)
+0xcb  | (∅ → timestamp) | 1; [standard memory cost](#standard-memory-cost)
 
 Pushes the block timestamp in milliseconds on the data stack.
 
@@ -1245,7 +1245,7 @@ Fails if executed in the [transaction context](#transaction-context).
 
 Code  | Stack Diagram   | Cost
 ------|-----------------|-----------------------------------------------------
-0x50, 0x61, 0x62, 0x65, 0x66, 0x67, 0x68, 0x8a, 0x8d, 0x8e, 0xa9, 0xab, 0xb0..0xbf, 0xca, 0xcd..0xcf, 0xd0..0xff  | (∅ → ∅)     | 1
+0x50, 0x61, 0x62, 0x65, 0x66, 0x67, 0x68, 0x8a, 0x8d, 0x8e, 0xa9, 0xab, 0xb0..0xbf, 0xca, 0xcc..0xcf, 0xd0..0xff  | (∅ → ∅)     | 1
 
 The unassigned codes are reserved for future expansion and have no effect on the state of the VM apart from reducing run limit by 1.
 

--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -59,7 +59,7 @@ A program executes in a context, either a *block* or a *transaction*. Some instr
 
 Transactions use [control programs](data.md#control-program) to define predicates governing spending of an asset in the next transaction, *issuance programs* for predicates authenticating issuance of an asset, and *program arguments* to provide input data for the predicates in output and issuance programs.
 
-Blocks use [consensus programs](data.md#consensus-program) to define predicates for signing the next block and *program arguments* to provide input data for the predicate in the previous block. Consensus programs have restricted functionality and do not use version tags. Some instructions (such as [ASSET](#asset) or [CHECKOUTPUT](#checkoutput)) that do not make sense within a context of signing a block are disabled and cause an immediate validation failure.
+Blocks use [consensus programs](data.md#consensus-program) to define predicates for signing the next block and *program arguments* to provide input data for the predicate in the previous block. Consensus programs have restricted functionality and do not use version tags. Some instructions (such as [ASSET](#asset) or [ENTRY](#entry)) that do not make sense within a context of signing a block are disabled and cause an immediate validation failure.
 
 ### Block context
 
@@ -70,7 +70,7 @@ Instruction [PROGRAM](#program) behaves differently than in transaction context.
 Execution of any of the following instructions results in immediate failure:
 
 * [TXSIGHASH](#txsighash)
-* [CHECKOUTPUT](#checkoutput)
+* [ENTRY](#entry)
 * [ASSET](#asset)
 * [AMOUNT](#amount)
 * [MINTIME](#mintime)
@@ -1113,25 +1113,15 @@ The following instructions are defined within a [transaction context](#execution
 Note: [standard memory cost](#standard-memory-cost) is applied *after* the instruction is executed in order to determine the exact size of the encoded data (this also applies to [ASSET](#asset), even though the result is always 32 bytes long).
 
 
-#### CHECKOUTPUT
+#### ENTRY
 
 Code  | Stack Diagram                                        | Cost
 ------|------------------------------------------------------|-----------------------------------------------------
-0xc1  | (index refdatahash amount assetid version prog → q)  | 16; [standard memory cost](#standard-memory-cost)
+0xc1  | (m → field<sub>n-1</sub> ... field<sub>0</sub> type  | 16; [standard memory cost](#standard-memory-cost)
 
-1. Pops 6 items from the data stack: `index`, `refdatahash`, `amount`, `assetid`, `version`, `prog`.
-2. Fails if `index` is negative or not a valid [number](#vm-number).
-3. Fails if the number of outputs is less or equal to `index`.
-4. Fails if `amount` and `version` are not non-negative [numbers](#vm-number).
-5. Finds a transaction output at the given `index`.
-6. If the output satisfies all of the following conditions pushes [true](#vm-boolean) on the data stack; otherwise pushes [false](#vm-boolean):
-    1. control program equals `prog`,
-    2. VM version equals `version`,
-    3. asset ID equals `assetid`,
-    4. amount equals `amount`,
-    5. `refdatahash` is an empty string or it matches the [SHA3-256](data.md#sha3) hash of the reference data.
+Pushes to the stack each of the `n` fields of the [content](data.md#transaction-entry-content) of the `m`th [entry](data.md#transaction-entry) in the transaction. Also pushes the type of that entry to the top of the stack.
 
-Fails if executed in the [block context](#block-context).
+Fails if executed in the [block context](#block-context), or if the transaction has fewer than `m-1` entries.
 
 
 #### ASSET
@@ -1140,7 +1130,7 @@ Code  | Stack Diagram  | Cost
 ------|----------------|-----------------------------------------------------
 0xc2  | (∅ → assetid)   | 1; [standard memory cost](#standard-memory-cost)
 
-Pushes the asset ID assigned to the current input on the data stack.
+Pushes the asset ID assigned to the current entry on the data stack.
 
 Fails if executed in the [block context](#block-context).
 
@@ -1151,7 +1141,7 @@ Code  | Stack Diagram  | Cost
 ------|----------------|-----------------------------------------------------
 0xc3  | (∅ → amount)    | 1; [standard memory cost](#standard-memory-cost)
 
-Pushes the amount assigned to the current input on the data stack.
+Pushes the amount assigned to the current entry on the data stack.
 
 Fails if executed in the [block context](#block-context).
 

--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -75,7 +75,6 @@ Execution of any of the following instructions results in immediate failure:
 * [AMOUNT](#amount)
 * [MINTIME](#mintime)
 * [MAXTIME](#maxtime)
-* [REFDATAHASH](#refdatahash)
 * [INDEX](#index)
 * [OUTPOINT](#outpoint)
 * [NONCE](#nonce)

--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -75,7 +75,6 @@ Execution of any of the following instructions results in immediate failure:
 * [AMOUNT](#amount)
 * [MINTIME](#mintime)
 * [MAXTIME](#maxtime)
-* [TXREFDATAHASH](#txrefdatahash)
 * [REFDATAHASH](#refdatahash)
 * [INDEX](#index)
 * [OUTPOINT](#outpoint)
@@ -84,7 +83,7 @@ Execution of any of the following instructions results in immediate failure:
 
 ### Transaction context
 
-Transaction context is defined by the pair of the entire transaction and the index of one of its inputs indicating the “current input”.
+Transaction context is defined by the pair of the entire transaction and the index of one of its issuance or input entries indicating the “current entry”.
 
 Execution of any of the following instructions results in immediate failure:
 
@@ -104,7 +103,7 @@ Execution of any of the following instructions results in immediate failure:
 5. Run Limit
 6. Execution Context:
     a. Block
-    b. (Transaction, Input Index)
+    b. (Transaction, Entry Index)
 
 **Initial State** has empty stacks, uninitialized program, PC set to zero, and *run limit* set to 10,000.
 
@@ -1083,7 +1082,7 @@ Code  | Stack Diagram                  | Cost
 ------|--------------------------------|-----------------------------------------------------
 0xae  | (∅ → hash)                     | 256 + [standard memory cost](#standard-memory-cost)
 
-Computes the [transaction signature hash](data.md#transaction-signature-hash) corresponding to the current input.
+Computes the [transaction signature hash](data.md#transaction-signature-hash) corresponding to the current entry.
 
 Typically used with [CHECKSIG](#checksig) or [CHECKMULTISIG](#checkmultisig).
 
@@ -1153,8 +1152,8 @@ Code  | Stack Diagram  | Cost
 0xc4  | (∅ → program)   | 1; [standard memory cost](#standard-memory-cost)
 
 1. In [transaction context](#transaction-context):
-  * For spend inputs: pushes the control program from the output being spent.
-  * For issuance inputs: pushes the issuance program.
+  * For input entries: pushes the control program from the output being spent.
+  * For issuance entries: pushes the issuance program.
 2. In [block context](#block-context):
   * Pushes the current [consensus program](data.md#consensus-program) being executed (that is specified in the previous block header).
 
@@ -1181,27 +1180,6 @@ If the value is zero or greater than 2<sup>63</sup>–1, pushes 2<sup>63</sup>�
 
 Fails if executed in the [block context](#block-context).
 
-#### TXREFDATAHASH
-
-Code  | Stack Diagram   | Cost
-------|-----------------|-----------------------------------------------------
-0xc7  | (∅ → hash)      | 1; [standard memory cost](#standard-memory-cost)
-
-Pushes the SHA3-256 hash of the [transaction](data.md#transaction)'s reference data.
-
-Fails if executed in the [block context](#block-context).
-
-
-#### REFDATAHASH
-
-Code  | Stack Diagram   | Cost
-------|-----------------|-----------------------------------------------------
-0xc8  | (∅ → hash)      | 1; [standard memory cost](#standard-memory-cost)
-
-Pushes the SHA3-256 hash of the current [input](data.md#transaction-input)'s reference data.
-
-Fails if executed in the [block context](#block-context).
-
 
 #### INDEX
 
@@ -1209,7 +1187,7 @@ Code  | Stack Diagram   | Cost
 ------|-----------------|-----------------------------------------------------
 0xc9  | (∅ → index)     | 1; [standard memory cost](#standard-memory-cost)
 
-Pushes the index of the current input on the data stack.
+Pushes the index of the current entry on the data stack.
 
 Fails if executed in the [block context](#block-context).
 
@@ -1220,7 +1198,7 @@ Code  | Stack Diagram   | Cost
 ------|-----------------|-----------------------------------------------------
 0xcb  | (∅ → outpointtx outpointindex)  | 1; [standard memory cost](#standard-memory-cost)
 
-Pushes the transaction ID and output index fields of the current input's [outpoint](#outpoint) on the data stack as separate items. The index is encoded as a [VM number](#vm-number).
+Pushes the transaction ID and output index fields of the current entry’s [outpoint](#outpoint) on the data stack as separate items. The index is encoded as a [VM number](#vm-number).
 
 Fails if the current entry is an [issuance entry](data.md#issuance-entry).
 
@@ -1235,7 +1213,7 @@ Code  | Stack Diagram   | Cost
 
 Pushes the nonce declared in the current issuance entry’s [content](data.md#issuance-entry-content) on the data stack.
 
-Fails if the current input is not an [issuance entry](data.md#issuance-entry).
+Fails if the current entry is not an [issuance entry](data.md#issuance-entry).
 
 Fails if executed in the [block context](#block-context).
 

--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -1119,7 +1119,7 @@ Code  | Stack Diagram                                        | Cost
 ------|------------------------------------------------------|-----------------------------------------------------
 0xc1  | (m → field<sub>n-1</sub> ... field<sub>0</sub> type  | 16; [standard memory cost](#standard-memory-cost)
 
-Pushes to the stack each of the `n` fields of the [content](data.md#transaction-entry-content) of the `m`th [entry](data.md#transaction-entry) in the transaction. Also pushes the type of that entry to the top of the stack.
+Pushes to the stack each of the `n` fields of the [content](data.md#entry-content) of the `m`th [entry](data.md#transaction-entry) in the transaction. Also pushes the type of that entry to the top of the stack.
 
 Fails if executed in the [block context](#block-context), or if the transaction has fewer than `m-1` entries.
 
@@ -1222,7 +1222,7 @@ Code  | Stack Diagram   | Cost
 
 Pushes the transaction ID and output index fields of the current input's [outpoint](#outpoint) on the data stack as separate items. The index is encoded as a [VM number](#vm-number).
 
-Fails if the current input is an [issuance input](data.md#transaction-input-commitment).
+Fails if the current entry is an [issuance entry](data.md#issuance-entry).
 
 Fails if executed in the [block context](#block-context).
 
@@ -1233,9 +1233,9 @@ Code  | Stack Diagram   | Cost
 ------|-----------------|-----------------------------------------------------
 0xcc  | (∅ → nonce)     | 1; [standard memory cost](#standard-memory-cost)
 
-Pushes the nonce declared in the current input's [issuance commitment](data.md#asset-version-1-issuance-commitment) on the data stack.
+Pushes the nonce declared in the current issuance entry’s [content](data.md#issuance-entry-content) on the data stack.
 
-Fails if the current input is not an [issuance input](data.md#transaction-input-commitment).
+Fails if the current input is not an [issuance entry](data.md#issuance-entry).
 
 Fails if executed in the [block context](#block-context).
 


### PR DESCRIPTION
Transactions can be made more flexible in the face of future enhancements to the protocol if two lists of inputs and outputs are replaced with a flat list of *entries*. Entries can be issuances, inputs, outputs or retirements. We can remove `OP_FAIL` opcode. We can have multiple "reference data" entries, so each party in the transaction can attach that data. Arbitrary accounting rules and behaviours can be added with future entry types.

Full summary of changes: TBD.

This is a part of a package of breaking changes in P1: #239