### PR TITLE
core/account: fix paged reservation

### DIFF
--- a/core/account/reserve.go
+++ b/core/account/reserve.go
@@ -274,6 +274,7 @@ func (sr *sourceReserver) reserve(ctx context.Context, rid uint64, amount uint64
 	for o, u := range sr.cached {
 		// If the UTXO is already reserved, skip it.
 		if _, ok := sr.reserved[u.Outpoint]; ok {
+			unavailable += u.Amount
 			continue
 		}
 		// Cached utxos aren't guaranteed to still be valid; they may
@@ -299,8 +300,6 @@ func (sr *sourceReserver) reserve(ctx context.Context, rid uint64, amount uint64
 		return reservedUTXOs, reserved, nil
 	}
 	sr.mu.Unlock()
-	reserved = 0
-	reservedUTXOs = nil
 
 	// Find the set of UTXOs that match this source.
 	utxos, err := findMatchingUTXOs(ctx, sr.db, sr.src, sr.lastHeight, sr.lastIndex)

--- a/core/account/reserve.go
+++ b/core/account/reserve.go
@@ -266,11 +266,35 @@ type sourceReserver struct {
 }
 
 func (sr *sourceReserver) reserve(ctx context.Context, rid uint64, amount uint64) ([]*utxo, uint64, error) {
-	var reserved, unavailable uint64
-	var reservedUTXOs []*utxo
+	reservedUTXOs, reservedAmount, err := sr.reserveFromCache(rid, amount)
+	if err == nil {
+		return reservedUTXOs, reservedAmount, nil
+	}
 
-	// First try to reserve using only cached UTXOs.
+	// Find the set of UTXOs that match this source.
+	utxos, err := findMatchingUTXOs(ctx, sr.db, sr.src, sr.lastHeight, sr.lastIndex)
+	if err != nil {
+		return nil, 0, err
+	}
+
 	sr.mu.Lock()
+	for _, u := range utxos {
+		sr.cached[u.Outpoint] = u
+		sr.lastHeight, sr.lastIndex = u.confirmedIn, u.blockPos
+	}
+	sr.mu.Unlock()
+
+	return sr.reserveFromCache(rid, amount)
+}
+
+func (sr *sourceReserver) reserveFromCache(rid uint64, amount uint64) ([]*utxo, uint64, error) {
+	var (
+		reserved, unavailable uint64
+		reservedUTXOs         []*utxo
+	)
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+
 	for o, u := range sr.cached {
 		// If the UTXO is already reserved, skip it.
 		if _, ok := sr.reserved[u.Outpoint]; ok {
@@ -291,43 +315,6 @@ func (sr *sourceReserver) reserve(ctx context.Context, rid uint64, amount uint64
 			break
 		}
 	}
-	if reserved >= amount {
-		// We've found enough to satisfy the request.
-		for _, u := range reservedUTXOs {
-			sr.reserved[u.Outpoint] = rid
-		}
-		sr.mu.Unlock()
-		return reservedUTXOs, reserved, nil
-	}
-	sr.mu.Unlock()
-
-	// Find the set of UTXOs that match this source.
-	utxos, err := findMatchingUTXOs(ctx, sr.db, sr.src, sr.lastHeight, sr.lastIndex)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	sr.mu.Lock()
-	defer sr.mu.Unlock()
-	for _, u := range utxos {
-		sr.cached[u.Outpoint] = u
-		sr.lastHeight, sr.lastIndex = u.confirmedIn, u.blockPos
-	}
-
-	for _, utxo := range utxos {
-		// If the utxo is already reserved, skip it.
-		if _, ok := sr.reserved[utxo.Outpoint]; ok {
-			unavailable += utxo.Amount
-			continue
-		}
-
-		// This utxo is available for the taking.
-		reserved += utxo.Amount
-		reservedUTXOs = append(reservedUTXOs, utxo)
-		if reserved >= amount {
-			break
-		}
-	}
 	if reserved+unavailable < amount {
 		// Even if everything was available, this account wouldn't have
 		// enough to satisfy the request.
@@ -343,6 +330,7 @@ func (sr *sourceReserver) reserve(ctx context.Context, rid uint64, amount uint64
 	for _, u := range reservedUTXOs {
 		sr.reserved[u.Outpoint] = rid
 	}
+
 	return reservedUTXOs, reserved, nil
 }
 


### PR DESCRIPTION
Since the findMatchingUTXOs function only returns new UTXOs, any UTXOs
identified in the cache should be retried in a reservation attempt.