### PR TITLE
core/account: use pin for paging utxos

### DIFF
--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -31,7 +31,7 @@ func NewManager(db *sql.DB, chain *protocol.Chain, pinStore *pin.Store) *Manager
 	return &Manager{
 		db:          db,
 		chain:       chain,
-		utxoDB:      newReserver(db, chain),
+		utxoDB:      newReserver(db, chain, pinStore),
 		pinStore:    pinStore,
 		cache:       lru.New(maxAccountCache),
 		aliasCache:  lru.New(maxAccountCache),

--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -52,7 +52,7 @@ func TestCancelReservation(t *testing.T) {
 		t.Error(err)
 	}
 
-	utxoDB := newReserver(db, c)
+	utxoDB := newReserver(db, c, nil)
 	res, err := utxoDB.ReserveUTXO(ctx, out, nil, time.Now())
 	if err != nil {
 		t.Fatal(err)

--- a/core/pin/pin.go
+++ b/core/pin/pin.go
@@ -72,6 +72,11 @@ func (s *Store) CreatePin(ctx context.Context, name string, height uint64) error
 	return nil
 }
 
+func (s *Store) Height(name string) uint64 {
+	p := <-s.pin(name)
+	return p.getHeight()
+}
+
 func (s *Store) LoadAll(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
This maintains the ability to grab only new UTXOs while introducing the ability to skip a database query altogether by seeing if any additional work has been done.