### PR TITLE
cmd/build-cored-release: new command

### DIFF
--- a/bin/build-cored-release
+++ b/bin/build-cored-release
@@ -18,7 +18,10 @@ if [ -z "$1" -o -z "$2" ]; then
 fi
 
 releaseRef=$1
-cd $2; outputDir=`pwd` # verify output dir and expand to absolute
+
+# verify output dir and expand to absolute
+cd $2 > /dev/null
+outputDir=`pwd`
 
 echo "Building ref $releaseRef to output directory $outputDir..."
 
@@ -55,3 +58,5 @@ echo "building corectl..."
 go build\
   -o "$outputDir/corectl"\
   chain/cmd/corectl
+
+echo "Done, build artifacts placed in $outputDir"

--- a/bin/build-cored-release
+++ b/bin/build-cored-release
@@ -36,6 +36,7 @@ cd $newChain
 git checkout $releaseRef
 
 # Cross-compilation args for cored and corectl
+export CGO_ENABLED=0 # There are issues with cgo (e.g. https://github.com/lib/pq/issues/395), so disable it entirely.
 export GOPATH=$buildGoPath
 export GOOS
 export GOARCH

--- a/bin/build-cored-release
+++ b/bin/build-cored-release
@@ -43,10 +43,9 @@ export GOARCH
 
 echo "building cored..."
 
-version=`echo $releaseRef | sed -e s/^cmd\.cored-//` # version is extracted if releaseRef fits cmd.cored-<version> pattern
 commit=`git rev-parse HEAD`
 DATE=${DATE:-`date +%s`} # date can be set via envvar
-ldflags="-X main.buildTag=$version -X main.buildCommit=$commit -X main.buildDate=$DATE"
+ldflags="-X main.buildTag=$releaseRef -X main.buildCommit=$commit -X main.buildDate=$DATE"
 
 go build\
   -tags 'insecure_disable_https_redirect'\

--- a/bin/build-cored-release
+++ b/bin/build-cored-release
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -e
+
+usage() {
+  echo "Usage: $0 <releaseRef> <outputDir>"
+  echo
+  echo "Envvars:"
+  echo "GOOS:   target OS"
+  echo "GOARCH: target CPU architecture"
+  echo "DATE:   build date; defaults to now"
+  exit 1
+}
+
+trap usage ERR
+
+if [ -z "$1" -o -z "$2" ]; then
+  usage
+fi
+
+releaseRef=$1
+cd $2; outputDir=`pwd` # verify output dir and expand to absolute
+
+echo "Building ref $releaseRef to output directory $outputDir..."
+
+# Clone repository into tempdir and check out specified release ref.
+buildGoPath=`mktemp -d`
+trap "rm -rf $buildGoPath" EXIT
+
+newChain=$buildGoPath/src/chain
+mkdir -p $newChain
+git clone $CHAIN $newChain
+cd $newChain
+git checkout $releaseRef
+
+# Cross-compilation args for cored and corectl
+export GOPATH=$buildGoPath
+export GOOS
+export GOARCH
+
+echo "building cored..."
+
+version=`echo $releaseRef | sed -e s/^cmd\.cored-//` # version is extracted if releaseRef fits cmd.cored-<version> pattern
+commit=`git rev-parse HEAD`
+DATE=${DATE:-`date +%s`} # date can be set via envvar
+ldflags="-X main.buildTag=$version -X main.buildCommit=$commit -X main.buildDate=$DATE"
+
+go build\
+  -tags 'insecure_disable_https_redirect'\
+  -ldflags "$ldflags"\
+  -o $outputDir/cored\
+  chain/cmd/cored
+
+echo "building corectl..."
+
+go build\
+  -o "$outputDir/corectl"\
+  chain/cmd/corectl


### PR DESCRIPTION
build-cored-release compiles or cross-compiles cored and corectl
at the specified ref. Its main use case is within automated build
scripts that generate installer packages.

Usage is as follows:

```
build-cored-release <releaseRef> <outputPath>
```

- releaseRef must be a valid git ref in the locally-cloned repo.
- outputPath must be a valid absolute or relative directory.

The buildTag build variable is set to releaseRef.

Optional parameters are specified via environment variables:

- GOOS
- GOARCH
- DATE: a value for the buildDate build variable. By default, the current time
  is used.