### PR TITLE
wercker.yml: add ruby integration tests

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1.7.3-alpine
 
 RUN apk --no-cache add bash clang git g++ make nodejs openjdk8 python perl \
+    ruby ruby-bigdecimal ruby-bundler ruby-io-console ruby-irb ruby-json \
     && MAVEN_VERSION=3.3.9 \
     && cd /usr/share \
     && wget -q http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -O - | tar xzf - \

--- a/docker/ci/bin/java-tests
+++ b/docker/ci/bin/java-tests
@@ -1,37 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
 set -veou pipefail
 
 : ${DATABASE_URL:?must be set}
-
-# waitForGenerator blocks the script and greps
-# the generator's output for a log message signifying
-# the generator is fully initialized. It will timeout
-# after 5s.
-waitForGenerator() {(
-	set +e
-	start=`date +%s`
-	while [ $(( `date +%s` - $start )) -lt 5 ]; do
-		grep "I am the core leader" $initlog >/dev/null
-		if [[ $? -eq 0 ]]; then
-			break
-		fi
-	done
-)}
 
 # setup cache
 set +e
 mkdir -p $CACHE_DIR
 set -e
 
-# run integration tests
-PATH=$GOPATH/bin:$PATH:$CHAIN/bin
-go install -tags 'insecure_disable_https_redirect' chain/cmd/cored
-go install chain/cmd/corectl
-$GOPATH/bin/corectl config-generator
-initlog=`mktemp`
-$GOPATH/bin/cored 2>&1 | tee $initlog &
-waitForGenerator
+setup-core
 SDKTARGET=chain-test
 cd $CHAIN/sdk/java
 mvn -Dmaven.repo.local=$CACHE_DIR -Djar.finalName=$SDKTARGET integration-test

--- a/docker/ci/bin/ruby-tests
+++ b/docker/ci/bin/ruby-tests
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -veou pipefail
+
+: ${DATABASE_URL:?must be set}
+
+setup-core
+cd $CHAIN/sdk/ruby
+bundle exec rspec

--- a/docker/ci/bin/setup-core
+++ b/docker/ci/bin/setup-core
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -veou pipefail
+
+: ${DATABASE_URL:?must be set}
+
+# waitForGenerator blocks the script and greps
+# the generator's output for a log message signifying
+# the generator is fully initialized. It will timeout
+# after 5s.
+waitForGenerator() {(
+	set +e
+	start=`date +%s`
+	while [ $(( `date +%s` - $start )) -lt 5 ]; do
+		grep "I am the core leader" $initlog >/dev/null
+		if [[ $? -eq 0 ]]; then
+			break
+		fi
+	done
+)}
+
+PATH=$GOPATH/bin:$PATH:$CHAIN/bin
+go install -tags 'insecure_disable_https_redirect' chain/cmd/cored
+go install chain/cmd/corectl
+$GOPATH/bin/corectl config-generator
+initlog=`mktemp`
+$GOPATH/bin/cored 2>&1 | tee $initlog &
+waitForGenerator

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20161118
+box: chaindev/ci:20161122
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 
@@ -46,3 +46,13 @@ java:
         name: jfmt
         code: |
           run-jfmt
+
+ruby:
+  steps:
+    - bundle-install:
+      cwd: $WERCKER_SOURCE_DIR/sdk/ruby
+    - script:
+        name: ruby tests
+        code: |
+          cp -a $WERCKER_SOURCE_DIR $CHAIN
+          DATABASE_URL="postgres://u:p@$POSTGRES_PLV8_PORT_5432_TCP_ADDR:$POSTGRES_PLV8_PORT_5432_TCP_PORT/core-test?sslmode=disable" CACHE_DIR="$WERCKER_CACHE_DIR/maven" ruby-tests


### PR DESCRIPTION
This commit adds a third, concurrent pipeline to
the wercker testing environment. The ruby tests
are run in a separate container with a fresh core.