### PR TITLE
encoding/bufpool: add bytes.Buffer pool

### DIFF
--- a/encoding/bufpool/bufpool.go
+++ b/encoding/bufpool/bufpool.go
@@ -1,0 +1,22 @@
+// Package bufpool is a freelist for bytes.Buffer objects.
+package bufpool
+
+import (
+	"bytes"
+	"sync"
+)
+
+var pool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
+
+// GetBuffer returns an initialized bytes.Buffer object.
+// It is like new(bytes.Buffer) except it uses the free list.
+// The caller should call PutBuffer when finished with the returned object.
+func GetBuffer() *bytes.Buffer {
+	return pool.Get().(*bytes.Buffer)
+}
+
+// PutBuffer resets the buffer and adds it to the freelist.
+func PutBuffer(b *bytes.Buffer) {
+	b.Reset()
+	pool.Put(b)
+}

--- a/protocol/bc/block.go
+++ b/protocol/bc/block.go
@@ -10,6 +10,7 @@ import (
 
 	"chain/crypto/sha3pool"
 	"chain/encoding/blockchain"
+	"chain/encoding/bufpool"
 	"chain/errors"
 )
 
@@ -33,7 +34,8 @@ type Block struct {
 // This guarantees that blocks will get deserialized correctly
 // when being parsed from HTTP requests.
 func (b *Block) MarshalText() ([]byte, error) {
-	buf := new(bytes.Buffer)
+	buf := bufpool.GetBuffer()
+	defer bufpool.PutBuffer(buf)
 	_, err := b.WriteTo(buf)
 	if err != nil {
 		return nil, err
@@ -65,7 +67,8 @@ func (b *Block) Scan(val interface{}) error {
 
 // Value fulfills the sql.driver.Valuer interface.
 func (b *Block) Value() (driver.Value, error) {
-	buf := new(bytes.Buffer)
+	buf := bufpool.GetBuffer()
+	defer bufpool.PutBuffer(buf)
 	_, err := b.WriteTo(buf)
 	if err != nil {
 		return nil, err
@@ -171,7 +174,8 @@ func (bh *BlockHeader) Scan(val interface{}) error {
 }
 
 func (bh *BlockHeader) Value() (driver.Value, error) {
-	buf := new(bytes.Buffer)
+	buf := bufpool.GetBuffer()
+	defer bufpool.PutBuffer(buf)
 	_, err := bh.WriteTo(buf)
 	if err != nil {
 		return nil, err

--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -10,6 +10,7 @@ import (
 
 	"chain/crypto/sha3pool"
 	"chain/encoding/blockchain"
+	"chain/encoding/bufpool"
 	"chain/errors"
 )
 
@@ -102,7 +103,8 @@ func (tx *TxData) Scan(val interface{}) error {
 }
 
 func (tx *TxData) Value() (driver.Value, error) {
-	b := new(bytes.Buffer)
+	b := bufpool.GetBuffer()
+	defer bufpool.PutBuffer(b)
 	_, err := tx.WriteTo(b)
 	if err != nil {
 		return nil, err

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -8,6 +8,7 @@ import (
 
 	"chain/crypto/sha3pool"
 	"chain/encoding/blockchain"
+	"chain/encoding/bufpool"
 )
 
 type (
@@ -289,7 +290,8 @@ func (t TxInput) writeTo(w io.Writer, serflags uint8) {
 }
 
 func (t TxInput) InputCommitmentBytes() []byte {
-	inputCommitment := new(bytes.Buffer)
+	inputCommitment := bufpool.GetBuffer()
+	defer bufpool.PutBuffer(inputCommitment)
 	if t.AssetVersion == 1 {
 		switch inp := t.TypedInput.(type) {
 		case *IssuanceInput:
@@ -309,7 +311,8 @@ func (t TxInput) InputCommitmentBytes() []byte {
 }
 
 func (t TxInput) inputWitnessBytes() []byte {
-	inputWitness := new(bytes.Buffer)
+	inputWitness := bufpool.GetBuffer()
+	defer bufpool.PutBuffer(inputWitness)
 	if t.AssetVersion == 1 {
 		var arguments [][]byte
 		switch inp := t.TypedInput.(type) {

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"chain/encoding/blockchain"
+	"chain/encoding/bufpool"
 )
 
 // TODO(bobg): Review serialization/deserialization logic for
@@ -115,7 +116,8 @@ func (to TxOutput) Commitment() []byte {
 }
 
 func (oc OutputCommitment) writeTo(w io.Writer, assetVersion uint64) {
-	b := new(bytes.Buffer)
+	b := bufpool.GetBuffer()
+	defer bufpool.PutBuffer(b)
 	if assetVersion == 1 {
 		oc.AssetAmount.writeTo(b)
 		blockchain.WriteVarint63(b, oc.VMVersion) // TODO(bobg): check and return error


### PR DESCRIPTION
Many of the allocations in the protocol package come from creating byte
buffers. These buffers can use sync.Pool to reduce allocations. In a
recent run of benchcore, InputCommitmentBytes, inputWitnessBytes, and
OutputCommitment.writeTo in particular had many allocations from
initializing byte buffers.