### PR TITLE
protocol/bc: use pointers for func receivers

### DIFF
--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -355,7 +355,7 @@ func (p Outpoint) String() string {
 
 // WriteTo writes p to w.
 // It assumes w has sticky errors.
-func (p Outpoint) WriteTo(w io.Writer) (int64, error) {
+func (p *Outpoint) WriteTo(w io.Writer) (int64, error) {
 	n, err := w.Write(p.Hash[:])
 	if err != nil {
 		return int64(n), err
@@ -381,7 +381,7 @@ func (a *AssetAmount) readFrom(r io.Reader) (int, error) {
 }
 
 // assumes w has sticky errors
-func (a AssetAmount) writeTo(w io.Writer) {
+func (a *AssetAmount) writeTo(w io.Writer) {
 	w.Write(a.AssetID[:])
 	blockchain.WriteVarint63(w, a.Amount) // TODO(bobg): check and return error
 }

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -414,3 +414,17 @@ func BenchmarkTxOutputWriteToFalse(b *testing.B) {
 		output.writeTo(ew, serRequired)
 	}
 }
+
+func BenchmarkAssetAmountWriteTo(b *testing.B) {
+	aa := AssetAmount{}
+	for i := 0; i < b.N; i++ {
+		aa.writeTo(ioutil.Discard)
+	}
+}
+
+func BenchmarkOutpointWriteTo(b *testing.B) {
+	o := Outpoint{}
+	for i := 0; i < b.N; i++ {
+		o.WriteTo(ioutil.Discard)
+	}
+}


### PR DESCRIPTION
The AssetAmount and Outpoint WriteTo functions were previously declared
on raw structs. Each call to these functions would cause an allocation.
In a recent run of benchcore these two function calls collectively
allocated 4.5% of all objects.

```
benchmark                         old ns/op     new ns/op     delta
BenchmarkAssetAmountWriteTo-8     65.5          38.8          -40.76%
BenchmarkOutpointWriteTo-8        69.0          37.4          -45.80%

benchmark                         old allocs     new allocs     delta
BenchmarkAssetAmountWriteTo-8     1              0              -100.00%
BenchmarkOutpointWriteTo-8        1              0              -100.00%

benchmark                         old bytes     new bytes     delta
BenchmarkAssetAmountWriteTo-8     48            0             -100.00%
BenchmarkOutpointWriteTo-8        48            0             -100.00%
```