### PR TITLE
core/migrate: audit account_utxos indexes

### DIFF
--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -14,13 +14,11 @@ import (
 const sampleAccountUTXOs = `
 	INSERT INTO account_utxos
 	(tx_hash, index, asset_id, amount, account_id, control_program_index,
-     control_program, metadata, confirmed_in, block_pos, block_timestamp)
-	VALUES (
+     control_program, confirmed_in) VALUES (
 		'270b725a94429496a178c56b390a89d03f801fe2ee992d90cf4fdf7d7855318e',
 		0,
 		'df1df9d4f66437ab5be715e4d1faeb29d24c80a6dc8276d6a630f05c5f1f7693',
-		1000, 'accEXAMPLE', 1, '\x6a'::bytea, '\x'::bytea, 1, 2, extract(epoch from now())
-	);
+		1000, 'accEXAMPLE', 1, '\x6a'::bytea, 1);
 `
 
 func TestCancelReservation(t *testing.T) {

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -54,4 +54,9 @@ var migrations = []migration{
 			ALTER COLUMN block_pos SET NOT NULL,
 			ALTER COLUMN block_timestamp SET NOT NULL;
 	`},
+	{Name: "2016-11-22.0.account.utxos-indexes.sql", SQL: `
+		DROP INDEX account_utxos_account_id;
+		DROP INDEX account_utxos_account_id_asset_id_tx_hash_idx;
+		CREATE INDEX ON account_utxos (asset_id, account_id, confirmed_in);
+	`},
 }

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -58,5 +58,9 @@ var migrations = []migration{
 		DROP INDEX account_utxos_account_id;
 		DROP INDEX account_utxos_account_id_asset_id_tx_hash_idx;
 		CREATE INDEX ON account_utxos (asset_id, account_id, confirmed_in);
+		ALTER TABLE account_utxos
+			DROP COLUMN metadata,
+			DROP COLUMN block_pos,
+			DROP COLUMN block_timestamp;
 	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -781,17 +781,10 @@ ALTER TABLE ONLY txfeeds
 
 
 --
--- Name: account_utxos_account_id; Type: INDEX; Schema: public; Owner: -
+-- Name: account_utxos_asset_id_account_id_confirmed_in_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX account_utxos_account_id ON account_utxos USING btree (account_id);
-
-
---
--- Name: account_utxos_account_id_asset_id_tx_hash_idx; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX account_utxos_account_id_asset_id_tx_hash_idx ON account_utxos USING btree (account_id, asset_id, tx_hash);
+CREATE INDEX account_utxos_asset_id_account_id_confirmed_in_idx ON account_utxos USING btree (asset_id, account_id, confirmed_in);
 
 
 --
@@ -883,3 +876,4 @@ insert into migrations (filename, hash) values ('2016-11-09.0.utxodb.drop-reserv
 insert into migrations (filename, hash) values ('2016-11-10.0.txdb.drop-pool-txs.sql', 'c52f610d5bd471cde5fbc083681e201f026b0cab89e7beeaa6a071ebbb99ff69');
 insert into migrations (filename, hash) values ('2016-11-16.0.account.drop-cp-id.sql', '149dd9ff2107e12452180bb73716a0985547bae843e5f99e5441717d6ec64a00');
 insert into migrations (filename, hash) values ('2016-11-18.0.account.confirmed-utxos.sql', 'b01e126edfcfe97f94eeda46f5a0eab6752e907104cecf247e90886f92795e94');
+insert into migrations (filename, hash) values ('2016-11.22.0.account.utxos-indexes.sql', 'a6015dfb4070b4fa0fe7c9615101229e81cfd79ad578e807600b6aa50472d710');

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -194,10 +194,7 @@ CREATE TABLE account_utxos (
     account_id text NOT NULL,
     control_program_index bigint NOT NULL,
     control_program bytea NOT NULL,
-    metadata bytea NOT NULL,
-    confirmed_in bigint NOT NULL,
-    block_pos integer NOT NULL,
-    block_timestamp bigint NOT NULL
+    confirmed_in bigint NOT NULL
 );
 
 
@@ -876,4 +873,4 @@ insert into migrations (filename, hash) values ('2016-11-09.0.utxodb.drop-reserv
 insert into migrations (filename, hash) values ('2016-11-10.0.txdb.drop-pool-txs.sql', 'c52f610d5bd471cde5fbc083681e201f026b0cab89e7beeaa6a071ebbb99ff69');
 insert into migrations (filename, hash) values ('2016-11-16.0.account.drop-cp-id.sql', '149dd9ff2107e12452180bb73716a0985547bae843e5f99e5441717d6ec64a00');
 insert into migrations (filename, hash) values ('2016-11-18.0.account.confirmed-utxos.sql', 'b01e126edfcfe97f94eeda46f5a0eab6752e907104cecf247e90886f92795e94');
-insert into migrations (filename, hash) values ('2016-11.22.0.account.utxos-indexes.sql', 'a6015dfb4070b4fa0fe7c9615101229e81cfd79ad578e807600b6aa50472d710');
+insert into migrations (filename, hash) values ('2016-11-22.0.account.utxos-indexes.sql', 'f3ea43f592cb06a36b040f0b0b9626ee9174d26d36abef44e68114d0c0aace98');


### PR DESCRIPTION
Delete unused columns of the account_utxos table.
Delete the old account_utxos indexes and replace with one tailored
specifically for the reservation query. There are only three non-INSERT
queries we perform against the table:

```
DELETE FROM account_utxos
WHERE (tx_hash, index) IN (SELECT unnest($1::text[]), unnest($2::integer[]))
```

```
SELECT tx_hash, index, amount, control_program_index, control_program
FROM account_utxos
WHERE account_id = $1 AND asset_id = $2 AND confirmed_in > $3
```

```
SELECT account_id, asset_id, amount, control_program_index, control_program
FROM account_utxos
WHERE tx_hash = $1 AND index = $2
```

The exact UTXO lookups are already covered by the table's primary key.
We only need one additional index for the 2nd query. This change brings
the 2nd query's query time from:

    Total Minutes: 67.752444
    Average MS: 23.977507
    Calls: 169540

down to:

    Total Minutes: 2.563405
    Average MS: 0.955413
    Calls: 160982