### PR TITLE
cmd/cored: use fixed version string for cored and expose via API

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -51,6 +51,7 @@ import (
 const (
 	httpReadTimeout  = 2 * time.Minute
 	httpWriteTimeout = time.Hour
+	latestVersion    = "1.0.1"
 )
 
 var (
@@ -82,9 +83,15 @@ var (
 )
 
 func init() {
-	version := "?"
+	var version string
 	if strings.HasPrefix(buildTag, "cmd.cored-") {
-		version = strings.TrimPrefix(buildTag, "cmd.cored-")
+		// build tag with cmd.cored- prefix indicates official release
+		version = latestVersion
+	} else if buildTag != "?" {
+		version = latestVersion + "-" + buildTag
+	} else {
+		// -dev suffix indicates intermediate, non-release build
+		version = latestVersion + "-dev"
 	}
 
 	expvar.NewString("prod").Set(prod)

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/kr/secureheader"
@@ -81,7 +82,13 @@ var (
 )
 
 func init() {
+	version := "?"
+	if strings.HasPrefix(buildTag, "cmd.cored-") {
+		version = strings.TrimPrefix(buildTag, "cmd.cored-")
+	}
+
 	expvar.NewString("prod").Set(prod)
+	expvar.NewString("version").Set(version)
 	expvar.NewString("buildtag").Set(buildTag)
 	expvar.NewString("builddate").Set(buildDate)
 	expvar.NewString("buildcommit").Set(buildCommit)

--- a/core/core.go
+++ b/core/core.go
@@ -97,6 +97,7 @@ func (h *Handler) leaderInfo(ctx context.Context) (map[string]interface{}, error
 		}
 	}
 
+	version := json.RawMessage(expvar.Get("version").String())
 	buildCommit := json.RawMessage(expvar.Get("buildcommit").String())
 	buildDate := json.RawMessage(expvar.Get("builddate").String())
 
@@ -114,6 +115,7 @@ func (h *Handler) leaderInfo(ctx context.Context) (map[string]interface{}, error
 		"is_production":                     isProduction(),
 		"network_rpc_version":               networkRPCVersion,
 		"core_id":                           h.Config.ID,
+		"version":                           &version,
 		"build_commit":                      &buildCommit,
 		"build_date":                        &buildDate,
 		"health":                            h.health(),

--- a/docs/internal/api-spec.swagger.yml
+++ b/docs/internal/api-spec.swagger.yml
@@ -990,6 +990,9 @@ definitions:
       core_id:
         type: string
         description: The unique ID of the core, generated at configuration.
+      version:
+        type: string
+        description: The release version of cored, the Chain Core server binary.
       build_commit:
         type: string
         description: The commit SHA of the core source code, at which the core


### PR DESCRIPTION
This commit exposes the most recent release version of `cored` via the /info endpoint.

The version string reported by the API takes on slightly differing formats depending on the build tag:

- `MAJOR.MINOR.BUILD`: if the build tag begins with `cmd.cored-`. This prefix denotes an official release.
- `MAJOR.MINOR.BUILD-<build tag>`: if any other non-blank build tag was provided
- `MAJOR.MINOR.BUILD-dev`: if the build tag is empty

This commit also moves the canonical `cored` version from Git tags to a value in the source itself. While this denormalizes the version across Git tags and the source code (worth nothing: this condition is shared by all other releasable packages, such as SDKs and installers), it means that `cored` version updates can be tracked reliably using Git history. Moreover, it allows intermediate builds (i.e., non-official releases and development builds) to report the most recent version via the client API, which is useful information in general.