### PR TITLE
protocol/validation: use state.OutputKey for deleting

### DIFF
--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -257,7 +257,7 @@ func ApplyTx(snapshot *state.Snapshot, tx *bc.Tx) error {
 		}
 
 		// Remove the consumed output from the state tree.
-		prevoutKey, _ := state.OutputTreeItem(state.Prevout(in))
+		prevoutKey := state.OutputKey(in.Outpoint())
 		err := snapshot.Tree.Delete(prevoutKey)
 		if err != nil {
 			return err


### PR DESCRIPTION
The state.OutputKey function should be preferred over
state.OutputTreeItem where the value hash isn't needed. It avoids
unnecessarily serializing the output commitment.