### PR TITLE
core/asset: use singleflight for lookups

### DIFF
--- a/cmd/benchcore/main.go
+++ b/cmd/benchcore/main.go
@@ -70,10 +70,10 @@ var instanceConfigs = map[string]instanceConfig{
 	"default": instanceConfig{
 		AMI:                     "ami-40d28157", // Ubuntu LTS 16.04
 		InstanceType:            "m3.xlarge",
-		CoredMaxDBConns:         "1000",
+		CoredMaxDBConns:         "500",
 		PostgresAMI:             "ami-2ef48339", // Ubuntu Server 16.04 LTS (HVM), SSD Volume Type
 		PostgresInstanceType:    "i2.xlarge",
-		MaxConnections:          1030,
+		MaxConnections:          530,
 		SharedBuffers:           "15GB",
 		EffectiveCacheSize:      "45GB", // ~3/4 total mem
 		WorkMem:                 "32MB",
@@ -85,10 +85,10 @@ var instanceConfigs = map[string]instanceConfig{
 	"max": instanceConfig{
 		AMI:                     "ami-2ef48339", // Ubuntu Server 16.04 LTS (HVM), SSD Volume Type
 		InstanceType:            "m4.16xlarge",
-		CoredMaxDBConns:         "1000",
+		CoredMaxDBConns:         "500",
 		PostgresAMI:             "ami-2ef48339", // Ubuntu Server 16.04 LTS (HVM), SSD Volume Type
 		PostgresInstanceType:    "i2.4xlarge",
-		MaxConnections:          1030,
+		MaxConnections:          530,
 		SharedBuffers:           "30GB",
 		EffectiveCacheSize:      "85GB", // ~3/4 total mem
 		WorkMem:                 "64MB",

--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -23,7 +23,7 @@ import (
 	"chain/protocol/vmutil"
 )
 
-const maxAccountCache = 100
+const maxAccountCache = 1000
 
 var ErrDuplicateAlias = errors.New("duplicate account alias")
 

--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -131,8 +131,7 @@ func (reg *Registry) findByID(ctx context.Context, id bc.AssetID) (*Asset, error
 	}
 
 	untypedAsset, err := reg.idGroup.Do(id.String(), func() (interface{}, error) {
-		asset, err := assetQuery(ctx, reg.db, "assets.id=$1", id)
-		return asset, err
+		return assetQuery(ctx, reg.db, "assets.id=$1", id)
 	})
 	if err != nil {
 		return nil, err

--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/golang/groupcache/lru"
+	"github.com/golang/groupcache/singleflight"
 	"github.com/lib/pq"
 
 	"chain/core/pin"
@@ -24,7 +25,7 @@ import (
 	"chain/protocol/vmutil"
 )
 
-const maxAssetCache = 100
+const maxAssetCache = 1000
 
 var ErrDuplicateAlias = errors.New("duplicate asset alias")
 
@@ -46,6 +47,9 @@ type Registry struct {
 	indexer          Saver
 	initialBlockHash bc.Hash
 	pinStore         *pin.Store
+
+	idGroup    singleflight.Group
+	aliasGroup singleflight.Group
 
 	cacheMu    sync.Mutex
 	cache      *lru.Cache
@@ -125,10 +129,16 @@ func (reg *Registry) findByID(ctx context.Context, id bc.AssetID) (*Asset, error
 	if ok {
 		return cached.(*Asset), nil
 	}
-	asset, err := assetQuery(ctx, reg.db, "assets.id=$1", id)
+
+	untypedAsset, err := reg.idGroup.Do(id.String(), func() (interface{}, error) {
+		asset, err := assetQuery(ctx, reg.db, "assets.id=$1", id)
+		return asset, err
+	})
 	if err != nil {
 		return nil, err
 	}
+
+	asset := untypedAsset.(*Asset)
 	reg.cacheMu.Lock()
 	reg.cache.Add(id, asset)
 	reg.cacheMu.Unlock()
@@ -144,12 +154,19 @@ func (reg *Registry) FindByAlias(ctx context.Context, alias string) (*Asset, err
 	if ok {
 		return reg.findByID(ctx, cachedID.(bc.AssetID))
 	}
-	a, err := assetQuery(ctx, reg.db, "assets.alias=$1", alias)
+
+	untypedAsset, err := reg.aliasGroup.Do(alias, func() (interface{}, error) {
+		asset, err := assetQuery(ctx, reg.db, "assets.alias=$1", alias)
+		return asset, err
+	})
 	if err != nil {
 		return nil, err
 	}
+
+	a := untypedAsset.(*Asset)
 	reg.cacheMu.Lock()
 	reg.aliasCache.Add(alias, a.AssetID)
+	reg.cache.Add(a.AssetID, a)
 	reg.cacheMu.Unlock()
 	return a, nil
 


### PR DESCRIPTION
Use singleflight for asset lookups and bump the size of the asset
and account caches. In one 500,000 transaction benchmark, there were
~600,000 asset lookups. This reduces it to ~50,000 asset lookups.

Also, now we have less contention for DB connections and can reduce our
max connections.