### PR TITLE
bin/build-cored-release: use bash interpreter

### DIFF
--- a/bin/build-cored-release
+++ b/bin/build-cored-release
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 usage() {


### PR DESCRIPTION
The ERR signal is specific to bash. This script
fails to run on systems without bash installed.