### PR TITLE
core: tweak submitted_txs

### DIFF
--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -67,4 +67,9 @@ var migrations = []migration{
 		DROP INDEX annotated_txs_data;
 		CREATE INDEX ON annotated_txs USING GIN (data jsonb_path_ops);
 	`},
+	{Name: "2016-11-28.0.core.submitted-txs-hash.sql", SQL: `
+		ALTER TABLE submitted_txs
+			ALTER COLUMN tx_id SET DATA TYPE bytea USING decode(tx_id,'hex');
+		ALTER TABLE submitted_txs RENAME COLUMN tx_id TO tx_hash;
+	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -503,7 +503,7 @@ CREATE TABLE snapshots (
 --
 
 CREATE TABLE submitted_txs (
-    tx_id text NOT NULL,
+    tx_hash bytea NOT NULL,
     height bigint NOT NULL,
     submitted_at timestamp without time zone DEFAULT now() NOT NULL
 );
@@ -750,7 +750,7 @@ ALTER TABLE ONLY snapshots
 --
 
 ALTER TABLE ONLY submitted_txs
-    ADD CONSTRAINT submitted_txs_pkey PRIMARY KEY (tx_id);
+    ADD CONSTRAINT submitted_txs_pkey PRIMARY KEY (tx_hash);
 
 
 --
@@ -875,3 +875,4 @@ insert into migrations (filename, hash) values ('2016-11-16.0.account.drop-cp-id
 insert into migrations (filename, hash) values ('2016-11-18.0.account.confirmed-utxos.sql', 'b01e126edfcfe97f94eeda46f5a0eab6752e907104cecf247e90886f92795e94');
 insert into migrations (filename, hash) values ('2016-11-22.0.account.utxos-indexes.sql', 'f3ea43f592cb06a36b040f0b0b9626ee9174d26d36abef44e68114d0c0aace98');
 insert into migrations (filename, hash) values ('2016-11-23.0.query.jsonb-path-ops.sql', 'adb15b9a6b7b223a17dbfd5f669e44c500b343568a563f87e1ae67ba0f938d55');
+insert into migrations (filename, hash) values ('2016-11-28.0.core.submitted-txs-hash.sql', 'cabbd7fd79a2b672b2d3c854783bde3b8245fe666c50261c3335a0c0501ff2ea');

--- a/core/transact_test.go
+++ b/core/transact_test.go
@@ -83,21 +83,9 @@ func TestRecordSubmittedTxs(t *testing.T) {
 		height uint64
 		want   uint64
 	}{
-		{
-			hash:   bc.Hash{0x01},
-			height: 2,
-			want:   2,
-		},
-		{
-			hash:   bc.Hash{0x02},
-			height: 3,
-			want:   3,
-		},
-		{
-			hash:   bc.Hash{0x01},
-			height: 3,
-			want:   2,
-		},
+		{hash: bc.Hash{0x01}, height: 2, want: 2},
+		{hash: bc.Hash{0x02}, height: 3, want: 3},
+		{hash: bc.Hash{0x01}, height: 3, want: 2},
 	}
 
 	for i, tc := range testCases {

--- a/core/transact_test.go
+++ b/core/transact_test.go
@@ -73,3 +73,40 @@ func TestAccountTransferSpendChange(t *testing.T) {
 		t.Errorf("len(b.Transactions) = %d, want 1", len(b.Transactions))
 	}
 }
+
+func TestRecordSubmittedTxs(t *testing.T) {
+	ctx := context.Background()
+	dbtx := pgtest.NewTx(t)
+
+	testCases := []struct {
+		hash   bc.Hash
+		height uint64
+		want   uint64
+	}{
+		{
+			hash:   bc.Hash{0x01},
+			height: 2,
+			want:   2,
+		},
+		{
+			hash:   bc.Hash{0x02},
+			height: 3,
+			want:   3,
+		},
+		{
+			hash:   bc.Hash{0x01},
+			height: 3,
+			want:   2,
+		},
+	}
+
+	for i, tc := range testCases {
+		got, err := recordSubmittedTx(ctx, dbtx, tc.hash, tc.height)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != tc.want {
+			t.Errorf("%d: got %d want %d for hash %s", i, got, tc.want, tc.hash)
+		}
+	}
+}


### PR DESCRIPTION
* Split the submitted_txs insert/select into two separate queries. In the vast
majority of calls, only the insert should be needed.
* Rename tx_id to tx_hash to match other tables (ex, annotated_txs,
annotated_outputs, account_utxos).
* Convert tx_hash from text to bytea.