### PR TITLE
protocol/bc: take a writer instead of returning bytes

### DIFF
--- a/protocol/bc/hash.go
+++ b/protocol/bc/hash.go
@@ -6,10 +6,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"golang.org/x/crypto/sha3"
 
 	"chain/crypto/sha3pool"
+	"chain/encoding/blockchain"
 	"chain/errors"
 )
 
@@ -95,11 +97,12 @@ func ParseHash(s string) (h Hash, err error) {
 	return h, errors.Wrap(err, "decode hex")
 }
 
-func fastHash(d []byte) []byte {
+func writeFastHash(w io.Writer, d []byte) {
 	if len(d) == 0 {
-		return nil
+		blockchain.WriteVarstr31(w, nil)
+		return
 	}
 	var h [32]byte
 	sha3pool.Sum256(h[:], d)
-	return h[:]
+	blockchain.WriteVarstr31(w, h[:])
 }

--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -391,7 +391,6 @@ func writeRefData(w io.Writer, data []byte, serflags byte) {
 	if serflags&SerMetadata != 0 {
 		blockchain.WriteVarstr31(w, data) // TODO(bobg): check and return error
 	} else {
-		h := fastHash(data)
-		blockchain.WriteVarstr31(w, h)
+		writeFastHash(w, data)
 	}
 }

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -108,10 +108,8 @@ func (to TxOutput) WitnessHash() Hash {
 	return emptyHash
 }
 
-func (to TxOutput) Commitment() []byte {
-	var buf bytes.Buffer
-	to.OutputCommitment.writeTo(&buf, to.AssetVersion)
-	return buf.Bytes()
+func (to TxOutput) WriteCommitment(w io.Writer) {
+	to.OutputCommitment.writeTo(w, to.AssetVersion)
 }
 
 func (oc OutputCommitment) writeTo(w io.Writer, assetVersion uint64) {

--- a/protocol/state/outputs.go
+++ b/protocol/state/outputs.go
@@ -42,9 +42,15 @@ func OutputKey(o bc.Outpoint) (bkey []byte) {
 	return b.Bytes()
 }
 
+func outputBytes(o *Output) []byte {
+	var b bytes.Buffer
+	o.WriteCommitment(&b)
+	return b.Bytes()
+}
+
 // OutputTreeItem returns the key of an output in the state tree,
 // as well as the output commitment (a second []byte) for Inserts
 // into the state tree.
 func OutputTreeItem(o *Output) (bkey, commitment []byte) {
-	return OutputKey(o.Outpoint), o.Commitment()
+	return OutputKey(o.Outpoint), outputBytes(o)
 }


### PR DESCRIPTION
This allows for more finely controlled allocations, and serves as
preparation for future updates where byte buffers can be reused.