### PR TITLE
encoding/bufpool: add bytes.Buffer pool

### DIFF
--- a/encoding/bufpool/bufpool.go
+++ b/encoding/bufpool/bufpool.go
@@ -1,0 +1,22 @@
+// Package bufpool is a freelist for bytes.Buffer objects.
+package bufpool
+
+import (
+	"bytes"
+	"sync"
+)
+
+var pool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
+
+// Get returns an initialized bytes.Buffer object.
+// It is like new(bytes.Buffer) except it uses the free list.
+// The caller should call Put when finished with the returned object.
+func Get() *bytes.Buffer {
+	return pool.Get().(*bytes.Buffer)
+}
+
+// Put resets the buffer and adds it to the freelist.
+func Put(b *bytes.Buffer) {
+	b.Reset()
+	pool.Put(b)
+}

--- a/protocol/bc/block.go
+++ b/protocol/bc/block.go
@@ -10,6 +10,7 @@ import (
 
 	"chain/crypto/sha3pool"
 	"chain/encoding/blockchain"
+	"chain/encoding/bufpool"
 	"chain/errors"
 )
 
@@ -33,7 +34,8 @@ type Block struct {
 // This guarantees that blocks will get deserialized correctly
 // when being parsed from HTTP requests.
 func (b *Block) MarshalText() ([]byte, error) {
-	buf := new(bytes.Buffer)
+	buf := bufpool.Get()
+	defer bufpool.Put(buf)
 	_, err := b.WriteTo(buf)
 	if err != nil {
 		return nil, err

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -8,6 +8,7 @@ import (
 
 	"chain/crypto/sha3pool"
 	"chain/encoding/blockchain"
+	"chain/encoding/bufpool"
 )
 
 type (
@@ -281,12 +282,13 @@ func (t *TxInput) readFrom(r io.Reader, txVersion uint64) (err error) {
 // assumes w has sticky errors
 func (t TxInput) writeTo(w io.Writer, serflags uint8) {
 	blockchain.WriteVarint63(w, t.AssetVersion) // TODO(bobg): check and return error
-	buf := new(bytes.Buffer)
+	buf := bufpool.Get()
+	defer bufpool.Put(buf)
 	t.WriteInputCommitment(buf)
 	blockchain.WriteVarstr31(w, buf.Bytes())
 	blockchain.WriteVarstr31(w, t.ReferenceData)
 	if serflags&SerWitness != 0 {
-		buf := new(bytes.Buffer)
+		buf.Reset()
 		t.writeInputWitness(buf)
 		blockchain.WriteVarstr31(w, buf.Bytes())
 	}

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"chain/encoding/blockchain"
+	"chain/encoding/bufpool"
 )
 
 // TODO(bobg): Review serialization/deserialization logic for
@@ -113,7 +114,8 @@ func (to TxOutput) WriteCommitment(w io.Writer) {
 }
 
 func (oc OutputCommitment) writeTo(w io.Writer, assetVersion uint64) {
-	b := new(bytes.Buffer)
+	b := bufpool.Get()
+	defer bufpool.Put(b)
 	if assetVersion == 1 {
 		oc.AssetAmount.writeTo(b)
 		blockchain.WriteVarint63(b, oc.VMVersion) // TODO(bobg): check and return error


### PR DESCRIPTION
Many of the allocations in the protocol package come from creating byte
buffers. These buffers can use sync.Pool to reduce allocations.

In a recent run of benchcore, TxInput.writeTo and
OutputCommitment.writeTo in particular had many allocations from
initializing byte buffers.