### PR TITLE
protocol/patricia: use pointer instead of raw hash

### DIFF
--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -52,7 +52,7 @@ func Reconstruct(vals []Leaf) (*Tree, error) {
 		}
 
 		var err error
-		t.root, err = t.insert(t.root, key, hash)
+		t.root, err = t.insert(t.root, key, &hash)
 		if err != nil {
 			return nil, err
 		}
@@ -162,11 +162,11 @@ func (t *Tree) Insert(bkey, val []byte) error {
 	}
 
 	var err error
-	t.root, err = t.insert(t.root, key, hash)
+	t.root, err = t.insert(t.root, key, &hash)
 	return err
 }
 
-func (t *Tree) insert(n *node, key []uint8, hash bc.Hash) (*node, error) {
+func (t *Tree) insert(n *node, key []uint8, hash *bc.Hash) (*node, error) {
 	if bytes.Equal(n.key, key) {
 		if !n.isLeaf {
 			return n, errors.Wrap(ErrPrefix)
@@ -175,7 +175,7 @@ func (t *Tree) insert(n *node, key []uint8, hash bc.Hash) (*node, error) {
 		n = &node{
 			isLeaf: true,
 			key:    n.key,
-			hash:   &hash,
+			hash:   hash,
 		}
 		return n, nil
 	}
@@ -204,7 +204,7 @@ func (t *Tree) insert(n *node, key []uint8, hash bc.Hash) (*node, error) {
 	}
 	newNode.children[key[common]] = &node{
 		key:    key,
-		hash:   &hash,
+		hash:   hash,
 		isLeaf: true,
 	}
 	newNode.children[1-key[common]] = n


### PR DESCRIPTION
Passing the raw hash allocates a new hash on every call to insert, which
is itself a recursive call. In a recent run of benchcore, insert
accounted for ~3% of all allocations, about half of which were from
passing the raw hash.

```
benchmark              old ns/op     new ns/op     delta
BenchmarkInserts-8     29747152      26422206      -11.18%

benchmark              old allocs     new allocs     delta
BenchmarkInserts-8     283503         161759         -42.94%

benchmark              old bytes     new bytes     delta
BenchmarkInserts-8     15546252      11647064      -25.08%
```