### PR TITLE
protocol/bc: use pointer receivers

### DIFF
--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -88,7 +88,7 @@ func NewIssuanceInput(nonce []byte, amount uint64, referenceData []byte, initial
 	}
 }
 
-func (t TxInput) AssetAmount() AssetAmount {
+func (t *TxInput) AssetAmount() AssetAmount {
 	if ii, ok := t.TypedInput.(*IssuanceInput); ok {
 		return AssetAmount{
 			AssetID: ii.AssetID(),
@@ -99,7 +99,7 @@ func (t TxInput) AssetAmount() AssetAmount {
 	return si.AssetAmount
 }
 
-func (t TxInput) AssetID() AssetID {
+func (t *TxInput) AssetID() AssetID {
 	if ii, ok := t.TypedInput.(*IssuanceInput); ok {
 		return ii.AssetID()
 	}
@@ -107,7 +107,7 @@ func (t TxInput) AssetID() AssetID {
 	return si.AssetID
 }
 
-func (t TxInput) Amount() uint64 {
+func (t *TxInput) Amount() uint64 {
 	if ii, ok := t.TypedInput.(*IssuanceInput); ok {
 		return ii.Amount
 	}
@@ -115,21 +115,21 @@ func (t TxInput) Amount() uint64 {
 	return si.Amount
 }
 
-func (t TxInput) ControlProgram() []byte {
+func (t *TxInput) ControlProgram() []byte {
 	if si, ok := t.TypedInput.(*SpendInput); ok {
 		return si.ControlProgram
 	}
 	return nil
 }
 
-func (t TxInput) IssuanceProgram() []byte {
+func (t *TxInput) IssuanceProgram() []byte {
 	if ii, ok := t.TypedInput.(*IssuanceInput); ok {
 		return ii.IssuanceProgram
 	}
 	return nil
 }
 
-func (t TxInput) Arguments() [][]byte {
+func (t *TxInput) Arguments() [][]byte {
 	switch inp := t.TypedInput.(type) {
 	case *IssuanceInput:
 		return inp.Arguments
@@ -280,7 +280,7 @@ func (t *TxInput) readFrom(r io.Reader, txVersion uint64) (err error) {
 }
 
 // assumes w has sticky errors
-func (t TxInput) writeTo(w io.Writer, serflags uint8) {
+func (t *TxInput) writeTo(w io.Writer, serflags uint8) {
 	blockchain.WriteVarint63(w, t.AssetVersion) // TODO(bobg): check and return error
 	buf := bufpool.Get()
 	defer bufpool.Put(buf)
@@ -294,7 +294,7 @@ func (t TxInput) writeTo(w io.Writer, serflags uint8) {
 	}
 }
 
-func (t TxInput) WriteInputCommitment(w io.Writer) {
+func (t *TxInput) WriteInputCommitment(w io.Writer) {
 	if t.AssetVersion == 1 {
 		switch inp := t.TypedInput.(type) {
 		case *IssuanceInput:
@@ -312,7 +312,7 @@ func (t TxInput) WriteInputCommitment(w io.Writer) {
 	}
 }
 
-func (t TxInput) writeInputWitness(w io.Writer) {
+func (t *TxInput) writeInputWitness(w io.Writer) {
 	if t.AssetVersion == 1 {
 		var arguments [][]byte
 		switch inp := t.TypedInput.(type) {
@@ -331,7 +331,7 @@ func (t TxInput) writeInputWitness(w io.Writer) {
 	}
 }
 
-func (t TxInput) WitnessHash() Hash {
+func (t *TxInput) WitnessHash() Hash {
 	var h Hash
 	sha := sha3pool.Get256()
 	defer sha3pool.Put256(sha)
@@ -340,17 +340,17 @@ func (t TxInput) WitnessHash() Hash {
 	return h
 }
 
-func (t TxInput) Outpoint() (o Outpoint) {
+func (t *TxInput) Outpoint() (o Outpoint) {
 	if si, ok := t.TypedInput.(*SpendInput); ok {
 		o = si.Outpoint
 	}
 	return o
 }
 
-func (si SpendInput) IsIssuance() bool { return false }
+func (si *SpendInput) IsIssuance() bool { return false }
 
-func (ii IssuanceInput) IsIssuance() bool { return true }
+func (ii *IssuanceInput) IsIssuance() bool { return true }
 
-func (ii IssuanceInput) AssetID() AssetID {
+func (ii *IssuanceInput) AssetID() AssetID {
 	return ComputeAssetID(ii.IssuanceProgram, ii.InitialBlock, ii.VMVersion)
 }

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -105,15 +105,15 @@ func (to *TxOutput) writeTo(w io.Writer, serflags byte) {
 	blockchain.WriteVarstr31(w, nil)
 }
 
-func (to TxOutput) WitnessHash() Hash {
+func (to *TxOutput) WitnessHash() Hash {
 	return emptyHash
 }
 
-func (to TxOutput) WriteCommitment(w io.Writer) {
+func (to *TxOutput) WriteCommitment(w io.Writer) {
 	to.OutputCommitment.writeTo(w, to.AssetVersion)
 }
 
-func (oc OutputCommitment) writeTo(w io.Writer, assetVersion uint64) {
+func (oc *OutputCommitment) writeTo(w io.Writer, assetVersion uint64) {
 	b := bufpool.Get()
 	defer bufpool.Put(b)
 	if assetVersion == 1 {


### PR DESCRIPTION
Sometimes function calls can cause allocations when they are on raw
structs instead of pointers. All functions in the bc package have been
changed to use a pointer unless they need to be on raw structs.

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkTxWriteToTrue200-8         260925        217921        -16.48%
BenchmarkTxWriteToFalse200-8        271812        231314        -14.90%
BenchmarkTxInputWriteToTrue-8       822           659           -19.83%
BenchmarkTxInputWriteToFalse-8      901           763           -15.32%
BenchmarkTxOutputWriteToTrue-8      549           486           -11.48%
BenchmarkTxOutputWriteToFalse-8     551           447           -18.87%

benchmark                           old allocs     new allocs   delta
BenchmarkTxWriteToTrue200-8         602            202          -66.45%
BenchmarkTxWriteToFalse200-8        602            202          -66.45%
BenchmarkTxInputWriteToTrue-8       2              1            -50.00%
BenchmarkTxInputWriteToFalse-8      2              1            -50.00%
BenchmarkTxOutputWriteToTrue-8      1              0            -100.00%
BenchmarkTxOutputWriteToFalse-8     1              0            -100.00%

benchmark                           old bytes     new bytes     delta
BenchmarkTxWriteToTrue200-8         32355         320           -99.01%
BenchmarkTxWriteToFalse200-8        32355         327           -98.99%
BenchmarkTxInputWriteToTrue-8       81            1             -98.77%
BenchmarkTxInputWriteToFalse-8      81            1             -98.77%
BenchmarkTxOutputWriteToTrue-8      80            0             -100.00%
BenchmarkTxOutputWriteToFalse-8     80            0             -100.00%
```