### PR TITLE
protocol/validation: optimize CalcMerkleRoot

### DIFF
--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -209,26 +209,26 @@ func (tx *TxData) Hash() Hash {
 // WitnessHash is the combined hash of the
 // transactions hash and signature data hash.
 // It is used to compute the TxRoot of a block.
-func (tx *TxData) WitnessHash() Hash {
-	var b bytes.Buffer
+func (tx *TxData) WitnessHash() (hash Hash) {
+	hasher := sha3pool.Get256()
+	defer sha3pool.Put256(hasher)
 
 	txhash := tx.Hash()
-	b.Write(txhash[:])
+	hasher.Write(txhash[:])
 
-	blockchain.WriteVarint31(&b, uint64(len(tx.Inputs))) // TODO(bobg): check and return error
+	blockchain.WriteVarint31(hasher, uint64(len(tx.Inputs))) // TODO(bobg): check and return error
 	for _, txin := range tx.Inputs {
 		h := txin.WitnessHash()
-		b.Write(h[:])
+		hasher.Write(h[:])
 	}
 
-	blockchain.WriteVarint31(&b, uint64(len(tx.Outputs))) // TODO(bobg): check and return error
+	blockchain.WriteVarint31(hasher, uint64(len(tx.Outputs))) // TODO(bobg): check and return error
 	for _, txout := range tx.Outputs {
 		h := txout.WitnessHash()
-		b.Write(h[:])
+		hasher.Write(h[:])
 	}
 
-	var hash Hash
-	sha3pool.Sum256(hash[:], b.Bytes())
+	hasher.Read(hash[:])
 	return hash
 }
 


### PR DESCRIPTION
Avoid unneccessary allocs in CalcMerkleRoot by using a pool of sha3
hashers and writing directly to the hasher instead of an intermediary
byte slice.

```
benchmark                     old ns/op     new ns/op     delta
BenchmarkValidateBlock-4      212996        206962        -2.83%
BenchmarkCalcMerkleRoot-4     53375679      46489514      -12.90%

benchmark                     old allocs     new allocs     delta
BenchmarkValidateBlock-4      115            113            -1.74%
BenchmarkCalcMerkleRoot-4     115036         90009          -21.76%

benchmark                     old bytes     new bytes     delta
BenchmarkValidateBlock-4      8183          7064          -13.67%
BenchmarkCalcMerkleRoot-4     13860092      3212794       -76.82%
```