### PR TITLE
protocol/patricia: avoid allocs in node.Hash

### DIFF
--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -317,23 +317,24 @@ func (n *node) Key() []byte { return byteKey(n.key) }
 
 // Hash will return the hash for this node.
 func (n *node) Hash() bc.Hash {
-	if n.hash != nil {
-		return *n.hash
-	}
-	hash := hashChildren(n.children)
-	n.hash = &hash
-	return hash
+	n.calcHash()
+	return *n.hash
 }
 
-func hashChildren(children [2]*node) (hash bc.Hash) {
-	h := sha3pool.Get256()
-	h.Write(interiorPrefix)
-	for _, c := range children {
-		childHash := c.Hash()
-		h.Write(childHash[:])
+func (n *node) calcHash() {
+	if n.hash != nil {
+		return
 	}
 
+	h := sha3pool.Get256()
+	h.Write(interiorPrefix)
+	for _, c := range n.children {
+		c.calcHash()
+		h.Write(c.hash[:])
+	}
+
+	var hash bc.Hash
 	h.Read(hash[:])
+	n.hash = &hash
 	sha3pool.Put256(h)
-	return hash
 }

--- a/protocol/patricia/patricia_test.go
+++ b/protocol/patricia/patricia_test.go
@@ -35,6 +35,27 @@ func BenchmarkInserts(b *testing.B) {
 	}
 }
 
+func BenchmarkInsertsRootHash(b *testing.B) {
+	const nodes = 10000
+	for i := 0; i < b.N; i++ {
+		r := rand.New(rand.NewSource(12345))
+		tr := new(Tree)
+		for j := 0; j < nodes; j++ {
+			var h [32]byte
+			_, err := r.Read(h[:])
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			err = tr.Insert(h[:], h[:])
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		tr.RootHash()
+	}
+}
+
 func TestRootHashBug(t *testing.T) {
 	tr := new(Tree)
 


### PR DESCRIPTION
Use pointers to child node's hashes instead of copying the hash when
computing a parent's hash.

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkInserts-4             31313382      30315774      -3.19%
BenchmarkInsertsRootHash-4     46718420      39971009      -14.44%

benchmark                      old allocs     new allocs     delta
BenchmarkInserts-4             161755         161755         +0.00%
BenchmarkInsertsRootHash-4     201784         171776         -14.87%

benchmark                      old bytes     new bytes     delta
BenchmarkInserts-4             11642779      11642829      +0.00%
BenchmarkInsertsRootHash-4     12932730      11970821      -7.44%
```