### PR TITLE
protocol/bc: use precomputed hash in WitnessHash

### DIFF
--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -209,22 +209,21 @@ func (tx *TxData) Hash() Hash {
 // WitnessHash is the combined hash of the
 // transactions hash and signature data hash.
 // It is used to compute the TxRoot of a block.
-func (tx *TxData) WitnessHash() (hash Hash) {
+func (tx *Tx) WitnessHash() (hash Hash) {
 	hasher := sha3pool.Get256()
 	defer sha3pool.Put256(hasher)
 
-	txhash := tx.Hash()
-	hasher.Write(txhash[:])
+	hasher.Write(tx.Hash[:])
 
 	blockchain.WriteVarint31(hasher, uint64(len(tx.Inputs))) // TODO(bobg): check and return error
 	for _, txin := range tx.Inputs {
-		h := txin.WitnessHash()
+		h := txin.witnessHash()
 		hasher.Write(h[:])
 	}
 
 	blockchain.WriteVarint31(hasher, uint64(len(tx.Outputs))) // TODO(bobg): check and return error
 	for _, txout := range tx.Outputs {
-		h := txout.WitnessHash()
+		h := txout.witnessHash()
 		hasher.Write(h[:])
 	}
 

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -331,7 +331,7 @@ func (t *TxInput) writeInputWitness(w io.Writer) {
 	}
 }
 
-func (t *TxInput) WitnessHash() Hash {
+func (t *TxInput) witnessHash() Hash {
 	var h Hash
 	sha := sha3pool.Get256()
 	defer sha3pool.Put256(sha)

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -105,7 +105,7 @@ func (to *TxOutput) writeTo(w io.Writer, serflags byte) {
 	blockchain.WriteVarstr31(w, nil)
 }
 
-func (to *TxOutput) WitnessHash() Hash {
+func (to *TxOutput) witnessHash() Hash {
 	return emptyHash
 }
 

--- a/protocol/validation/merkle_test.go
+++ b/protocol/validation/merkle_test.go
@@ -51,18 +51,16 @@ func TestCalcMerkleRoot(t *testing.T) {
 	for _, c := range cases {
 		var txs []*bc.Tx
 		for _, wit := range c.witnesses {
-			txs = append(txs, &bc.Tx{
-				TxData: bc.TxData{
-					Inputs: []*bc.TxInput{
-						&bc.TxInput{
-							AssetVersion: 1,
-							TypedInput: &bc.SpendInput{
-								Arguments: wit,
-							},
+			txs = append(txs, bc.NewTx(bc.TxData{
+				Inputs: []*bc.TxInput{
+					&bc.TxInput{
+						AssetVersion: 1,
+						TypedInput: &bc.SpendInput{
+							Arguments: wit,
 						},
 					},
 				},
-			})
+			}))
 		}
 		got := CalcMerkleRoot(txs)
 		if !bytes.Equal(got[:], c.want[:]) {


### PR DESCRIPTION
Rather than declaring WitnessHash on TxData, which needs to compute its
hash, declare it on Tx, which has a precomputed hash already available.

```
benchmark                     old ns/op     new ns/op     delta
BenchmarkCalcMerkleRoot-8     38432421      22408414      -41.69%

benchmark                     old allocs     new allocs     delta
BenchmarkCalcMerkleRoot-8     85011          45001          -47.06%

benchmark                     old bytes     new bytes     delta
BenchmarkCalcMerkleRoot-8     2814474       1441447       -48.78%
```