### PR TITLE
cmd/benchcore: bump max_wal_size

### DIFF
--- a/cmd/benchcore/main.go
+++ b/cmd/benchcore/main.go
@@ -78,7 +78,7 @@ var instanceConfigs = map[string]instanceConfig{
 		EffectiveCacheSize:      "45GB", // ~3/4 total mem
 		WorkMem:                 "32MB",
 		MaintenanceWorkMem:      "512MB",
-		MaxWALSize:              "2GB",
+		MaxWALSize:              "4GB",
 		WALBuffers:              "64MB",
 		LogMinDurationStatement: 2000,
 	},
@@ -93,7 +93,7 @@ var instanceConfigs = map[string]instanceConfig{
 		EffectiveCacheSize:      "85GB", // ~3/4 total mem
 		WorkMem:                 "64MB",
 		MaintenanceWorkMem:      "1GB",
-		MaxWALSize:              "4GB",
+		MaxWALSize:              "8GB",
 		WALBuffers:              "64MB",
 		LogMinDurationStatement: 2000,
 	},


### PR DESCRIPTION
When we got rid of some noise from the Postgres logs of one of our
benchmarks, I noticed these log statements:

```
2016-11-30 01:58:50.302 UTC,,,6515,,583e2dcb.1973,21,,2016-11-30
01:39:23 UTC,,0,LOG,00000,"checkpoints are occurring too frequently (19
seconds apart)",,"Consider increasing the configuration parameter
""max_wal_size"".",,,,,,,""
2016-11-30 01:59:10.443 UTC,,,6515,,583e2dcb.1973,22,,2016-11-30
01:39:23 UTC,,0,LOG,00000,"checkpoints are occurring too frequently (20
seconds apart)",,"Consider increasing the configuration parameter
""max_wal_size"".",,,,,,,""
2016-11-30 01:59:28.654 UTC,,,6515,,583e2dcb.1973,23,,2016-11-30
01:39:23 UTC,,0,LOG,00000,"checkpoints are occurring too frequently (18
seconds apart)",,"Consider increasing the configuration parameter
""max_wal_size"".",,,,,,,""
```