### PR TITLE
core/txbuilder: add explicit retire action

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -99,6 +99,7 @@ func (h *Handler) init() {
 		"control_account":                h.Accounts.DecodeControlAction,
 		"control_program":                txbuilder.DecodeControlProgramAction,
 		"issue":                          h.Assets.DecodeIssueAction,
+		"retire":                         txbuilder.DecodeRetireAction,
 		"spend_account":                  h.Accounts.DecodeSpendAction,
 		"spend_account_unspent_output":   h.Accounts.DecodeSpendUTXOAction,
 		"set_transaction_reference_data": txbuilder.DecodeSetTxRefDataAction,

--- a/core/txbuilder/actions.go
+++ b/core/txbuilder/actions.go
@@ -70,6 +70,17 @@ type retireAction struct {
 }
 
 func (a *retireAction) Build(ctx context.Context, maxTime time.Time, b *TemplateBuilder) error {
+	var missing []string
+	if a.AssetID == (bc.AssetID{}) {
+		missing = append(missing, "asset_id")
+	}
+	if a.Amount == 0 {
+		missing = append(missing, "amount")
+	}
+	if len(missing) > 0 {
+		return MissingFieldsError(missing...)
+	}
+
 	out := bc.NewTxOutput(a.AssetID, a.Amount, retirementProgram, a.ReferenceData)
 	return b.AddOutput(out)
 }

--- a/dashboard/src/features/transactions/actions.js
+++ b/dashboard/src/features/transactions/actions.js
@@ -42,12 +42,7 @@ function preprocessTransaction(formParams) {
       }
     })
 
-    // HACK: Check for retire actions and replace with OP_FAIL control programs.
     // TODO: update JS SDK to support Java SDK builder style.
-    if (a.type == 'retire_asset') {
-      a.type = 'control_program'
-      a.control_program = '6a' // OP_FAIL hex byte
-    }
 
     try {
       a.reference_data = parseNonblankJSON(a.reference_data)

--- a/dashboard/src/features/transactions/components/New/FormActionItem.jsx
+++ b/dashboard/src/features/transactions/components/New/FormActionItem.jsx
@@ -13,7 +13,7 @@ const SPEND_ACCOUNT_KEY = 'spend_account'
 const SPEND_UNSPENT_KEY = 'spend_account_unspent_output'
 const CONTROL_ACCOUNT_KEY = 'control_account'
 const CONTROL_PROGRAM_KEY = 'control_program'
-const RETIRE_ASSET_KEY = 'retire_asset'
+const RETIRE_ASSET_KEY = 'retire'
 const TRANSACTION_REFERENCE_DATA = 'set_transaction_reference_data'
 
 const actionLabels = {

--- a/dashboard/src/features/transactions/components/New/New.jsx
+++ b/dashboard/src/features/transactions/components/New/New.jsx
@@ -125,7 +125,7 @@ class Form extends React.Component {
                 <MenuItem eventKey='spend_account_unspent_output'>Spend unspent output</MenuItem>
                 <MenuItem eventKey='control_account'>Control with account</MenuItem>
                 <MenuItem eventKey='control_program'>Control with program</MenuItem>
-                <MenuItem eventKey='retire_asset'>Retire</MenuItem>
+                <MenuItem eventKey='retire'>Retire</MenuItem>
                 <MenuItem eventKey='set_transaction_reference_data'>Set transaction reference data</MenuItem>
               </DropdownButton>
             </div>

--- a/sdk/java/src/main/java/com/chain/api/ControlProgram.java
+++ b/sdk/java/src/main/java/com/chain/api/ControlProgram.java
@@ -20,14 +20,6 @@ public class ControlProgram {
   public String controlProgram;
 
   /**
-   * Generates hex representation of a "retire" control program.
-   * @return hex-encoded "retire" program
-   */
-  public static String retireProgram() {
-    return "6a";
-  }
-
-  /**
    * Creates a batch of control programs.
    * @param client client object which makes requests to core
    * @param programs list of control program builder objects

--- a/sdk/java/src/main/java/com/chain/api/Transaction.java
+++ b/sdk/java/src/main/java/com/chain/api/Transaction.java
@@ -927,8 +927,7 @@ public class Transaction {
        * Default constructor defines the action type as "control_program"
        */
       public Retire() {
-        this.put("type", "control_program");
-        this.put("control_program", ControlProgram.retireProgram());
+        this.put("type", "retire");
       }
 
       /**

--- a/sdk/ruby/lib/chain/transaction.rb
+++ b/sdk/ruby/lib/chain/transaction.rb
@@ -439,10 +439,7 @@ module Chain
       # @option params [Integer] :amount Amount of the asset to be retired.
       # @return [Builder]
       def retire(params)
-        add_action(params.merge(
-          type: :control_program,
-          control_program: '6a'
-        ))
+        add_action(params.merge(type: :retire))
       end
     end
 


### PR DESCRIPTION
Add an explicit retire action instead of using the `control_program`
action and specifying the `OP_FAIL` program. This provides more
flexibility as our implementation of retirement changes.