### PR TITLE
dashboard: expose version in core status page

### DIFF
--- a/dashboard/src/features/core/components/Index/Index.jsx
+++ b/dashboard/src/features/core/components/Index/Index.jsx
@@ -71,8 +71,8 @@ class Index extends React.Component {
                 <td>{this.props.core.configuredAt}</td>
               </tr>
               <tr>
-                <td className={styles.row_label}>Build:</td>
-                <td><code>{this.props.core.buildCommit}</code></td>
+                <td className={styles.row_label}>Version:</td>
+                <td><code>{this.props.core.version}</code></td>
               </tr>
               <tr>
                 <td colSpan={2}><hr /></td>

--- a/dashboard/src/features/core/reducers.js
+++ b/dashboard/src/features/core/reducers.js
@@ -206,6 +206,8 @@ const snapshot = (state = null, action) => {
   return state
 }
 
+const version = (state, action) => coreConfigReducer('version', state, 'N/A', action)
+
 export default combineReducers({
   blockchainId,
   blockHeight,
@@ -231,4 +233,5 @@ export default combineReducers({
   snapshot,
   syncEstimates,
   validToken,
+  version,
 })


### PR DESCRIPTION
This commit replaces the build commit display with a version display, which is much more friendly to the user.