### PR TITLE
encoding/bufpool: add CopyBytes

### DIFF
--- a/encoding/bufpool/bufpool.go
+++ b/encoding/bufpool/bufpool.go
@@ -11,6 +11,9 @@ var pool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
 // Get returns an initialized bytes.Buffer object.
 // It is like new(bytes.Buffer) except it uses the free list.
 // The caller should call Put when finished with the returned object.
+// Since Buffer.Bytes() returns the buffer's underlying slice,
+// it is not safe for that slice to escape the caller.
+// If the bytes need to escape, CopyBytes should be used.
 func Get() *bytes.Buffer {
 	return pool.Get().(*bytes.Buffer)
 }
@@ -19,4 +22,14 @@ func Get() *bytes.Buffer {
 func Put(b *bytes.Buffer) {
 	b.Reset()
 	pool.Put(b)
+}
+
+// CopyBytes returns a copy of the bytes contained in the buffer.
+// This slice is safe from updates in the underlying buffer,
+// allowing the buffer to be placed back in the free list.
+func CopyBytes(buf *bytes.Buffer) []byte {
+	b := buf.Bytes()
+	b2 := make([]byte, len(b))
+	copy(b2, b)
+	return b2
 }


### PR DESCRIPTION
It was not clear before that byte slices from pooled buffers could not
escape the caller, so the comment has been updated to emphasize that.
Additionally, a convenience function has been added that returns an
escape-safe byte slice.