### PR TITLE
protocol/validation: benchmark CheckTxWellFormed

### DIFF
--- a/protocol/validation/bench_test.go
+++ b/protocol/validation/bench_test.go
@@ -11,6 +11,17 @@ import (
 	"chain/protocol/validation"
 )
 
+func BenchmarkValidateTx(b *testing.B) {
+	c := prottest.NewChain(b)
+	tx := prottest.NewIssuanceTx(b, c)
+	for i := 0; i < b.N; i++ {
+		err := validation.CheckTxWellFormed(tx)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkValidateBlock(b *testing.B) {
 	b.StopTimer()
 	ctx := context.Background()


### PR DESCRIPTION
On my machine:

```
BenchmarkValidateTx-8   	   10000	    141048 ns/op
```
