### PR TITLE
docs/protocol: add serialization/deserialization to VM

### DIFF
--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -167,6 +167,8 @@ All items on the data and alt stacks are binary strings. Some instructions accep
 
 In the stack diagrams accompanying the definition of each operation, `x` and `y` denote [numbers](#vm-number), `m` and `n` denote non-negative [numbers](#vm-number), and `p` and `q` denote [booleans](#vm-boolean). If coercion fails (or if stack items designated as `m` or `n` coerce to negative numbers), the operation fails.
 
+The maximum length of a string on the VM stack is 65535 bytes.
+
 ### VM String
 
 An ordered sequence of 0 or more bytes.
@@ -269,7 +271,7 @@ Opcode **0x4c** is followed by a 1-byte length prefix encoding a length `n`, the
 
 Opcode **0x4d** is followed by a 2-byte little-endian length prefix encoding a length `n`, then `n` bytes of data to push (supports up to 65535 bytes).
 
-Opcode **0x4e** is followed by a 4-byte little-endian length prefix encoding a length `n`, then `n` bytes of data to push (supports up to 4294967295 bytes).
+Opcode **0x4e** is disabled and causes execution to fail.
 
 Each of these operations fails if they are not followed by the expected number of bytes of data.
 


### PR DESCRIPTION
The VM currently does not have low-level support for manipulation of lists, which makes it very difficult to fully support many desirable high-level language features in Ivy (including not only lists, but also transaction introspection, structs, signature programs, merklized paths, and generic `checkMultiSig`).

The proposed changes define a (bytelength-delimited) serialization format for lists in the VM, and include the four opcodes that I think would be necessary to support these features: 

1. `PACK`: converts a list of stack items into a single list.
2. `UNPACK`: takes a list and pushes each of its items onto the stack.
3. `ELEMENT`: gets the `i`th element of a list.
4. `SLICE`: gets a portion of a list by index; this one is less critical but would be a nice feature. 

For safety, `UNPACK` takes the length of the list as an argument, and `ELEMENT` and `SLICE` check the entire list for validity (not just the portion needed to pick out the element or elements).

I think it's worth adding this to VM1 rather than waiting for VM2 (which will likely support a more efficient implementation of lists), partly for the obvious reason that it would allow us to use these features sooner, but also because it would help us get some experience that would allow us to better design those parts of VM2 (as well as Ivy).