### PR TITLE
types: New top-level package

### DIFF
--- a/cmd/multitool/multitool.go
+++ b/cmd/multitool/multitool.go
@@ -24,6 +24,7 @@ import (
 	"chain/crypto/ed25519/chainkd"
 	"chain/protocol/bc"
 	"chain/protocol/vm"
+	"chain/types"
 )
 
 // A timed reader times out its Read() operation after a specified
@@ -156,8 +157,8 @@ func mustDecodeHex(s string) []byte {
 	return res
 }
 
-func mustDecodeHash(s string) bc.Hash {
-	var h bc.Hash
+func mustDecodeHash(s string) types.Hash {
+	var h types.Hash
 	err := h.UnmarshalText([]byte(strings.TrimSpace(s)))
 	if err != nil {
 		errorf("error decoding hash: %s", err)
@@ -174,7 +175,7 @@ func assetid(args []string) {
 	initialBlockInp, _ = input(args, 1, usedStdin)
 	issuance := mustDecodeHex(issuanceInp)
 	initialBlock := mustDecodeHash(initialBlockInp)
-	assetID := bc.ComputeAssetID(issuance, initialBlock, 1)
+	assetID := types.ComputeAssetID(issuance, initialBlock, 1, 1)
 	fmt.Println(assetID.String())
 }
 
@@ -502,5 +503,5 @@ func verify(args []string) {
 }
 
 func zerohash(_ []string) {
-	fmt.Println(bc.Hash{}.String())
+	fmt.Println(types.Hash{}.String())
 }

--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -11,9 +11,10 @@ import (
 	"chain/errors"
 	"chain/log"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
-func (m *Manager) NewSpendAction(amt bc.AssetAmount, accountID string, refData chainjson.Map, clientToken *string) txbuilder.Action {
+func (m *Manager) NewSpendAction(amt types.AssetAmount, accountID string, refData chainjson.Map, clientToken *string) txbuilder.Action {
 	return &spendAction{
 		accounts:      m,
 		AssetAmount:   amt,
@@ -31,7 +32,7 @@ func (m *Manager) DecodeSpendAction(data []byte) (txbuilder.Action, error) {
 
 type spendAction struct {
 	accounts *Manager
-	bc.AssetAmount
+	types.AssetAmount
 	AccountID     string        `json:"account_id"`
 	ReferenceData chainjson.Map `json:"reference_data"`
 	ClientToken   *string       `json:"client_token"`
@@ -42,7 +43,7 @@ func (a *spendAction) Build(ctx context.Context, maxTime time.Time, b *txbuilder
 	if a.AccountID == "" {
 		missing = append(missing, "account_id")
 	}
-	if a.AssetID == (bc.AssetID{}) {
+	if a.AssetID == (types.AssetID{}) {
 		missing = append(missing, "asset_id")
 	}
 	if len(missing) > 0 {
@@ -110,8 +111,8 @@ func (m *Manager) DecodeSpendUTXOAction(data []byte) (txbuilder.Action, error) {
 
 type spendUTXOAction struct {
 	accounts *Manager
-	TxHash   *bc.Hash `json:"transaction_id"`
-	TxOut    *uint32  `json:"position"`
+	TxHash   *types.Hash `json:"transaction_id"`
+	TxOut    *uint32     `json:"position"`
 
 	ReferenceData chainjson.Map `json:"reference_data"`
 	ClientToken   *string       `json:"client_token"`
@@ -176,7 +177,7 @@ func utxoToInputs(ctx context.Context, account *signers.Signer, u *utxo, refData
 	return txInput, sigInst, nil
 }
 
-func (m *Manager) NewControlAction(amt bc.AssetAmount, accountID string, refData chainjson.Map) txbuilder.Action {
+func (m *Manager) NewControlAction(amt types.AssetAmount, accountID string, refData chainjson.Map) txbuilder.Action {
 	return &controlAction{
 		accounts:      m,
 		AssetAmount:   amt,
@@ -193,7 +194,7 @@ func (m *Manager) DecodeControlAction(data []byte) (txbuilder.Action, error) {
 
 type controlAction struct {
 	accounts *Manager
-	bc.AssetAmount
+	types.AssetAmount
 	AccountID     string        `json:"account_id"`
 	ReferenceData chainjson.Map `json:"reference_data"`
 }
@@ -203,7 +204,7 @@ func (a *controlAction) Build(ctx context.Context, maxTime time.Time, b *txbuild
 	if a.AccountID == "" {
 		missing = append(missing, "account_id")
 	}
-	if a.AssetID == (bc.AssetID{}) {
+	if a.AssetID == (types.AssetID{}) {
 		missing = append(missing, "asset_id")
 	}
 	if len(missing) > 0 {

--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -19,6 +19,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
 	"chain/testutil"
+	"chain/types"
 )
 
 func TestAccountSourceReserve(t *testing.T) {
@@ -44,7 +45,7 @@ func TestAccountSourceReserve(t *testing.T) {
 	prottest.MakeBlock(t, c)
 	<-pinStore.PinWaiter(account.PinName, c.Height())
 
-	assetAmount1 := bc.AssetAmount{
+	assetAmount1 := types.AssetAmount{
 		AssetID: asset,
 		Amount:  1,
 	}
@@ -133,7 +134,7 @@ func TestAccountSourceReserveIdempotency(t *testing.T) {
 		asset        = coretest.CreateAsset(ctx, t, assets, nil, "", nil)
 		_            = coretest.IssueAssets(ctx, t, c, assets, accounts, asset, 2, accID)
 		_            = coretest.IssueAssets(ctx, t, c, assets, accounts, asset, 2, accID)
-		assetAmount1 = bc.AssetAmount{
+		assetAmount1 = types.AssetAmount{
 			AssetID: asset,
 			Amount:  1,
 		}

--- a/core/account/indexer.go
+++ b/core/account/indexer.go
@@ -11,6 +11,7 @@ import (
 	"chain/errors"
 	"chain/protocol/bc"
 	"chain/protocol/state"
+	"chain/types"
 )
 
 // PinName is used to identify the pin associated with
@@ -67,7 +68,7 @@ func (m *Manager) ProcessBlocks(ctx context.Context) {
 func (m *Manager) indexAccountUTXOs(ctx context.Context, b *bc.Block) error {
 	// Upsert any UTXOs belonging to accounts managed by this Core.
 	outs := make([]*state.Output, 0, len(b.Transactions))
-	blockPositions := make(map[bc.Hash]uint32, len(b.Transactions))
+	blockPositions := make(map[types.Hash]uint32, len(b.Transactions))
 	for i, tx := range b.Transactions {
 		blockPositions[tx.Hash] = uint32(i)
 		for j, out := range tx.Outputs {
@@ -154,7 +155,7 @@ func (m *Manager) loadAccountInfo(ctx context.Context, outs []*state.Output) ([]
 // upsertConfirmedAccountOutputs records the account data for confirmed utxos.
 // If the account utxo already exists (because it's from a local tx), the
 // block confirmation data will in the row will be updated.
-func (m *Manager) upsertConfirmedAccountOutputs(ctx context.Context, outs []*output, pos map[bc.Hash]uint32, block *bc.Block) error {
+func (m *Manager) upsertConfirmedAccountOutputs(ctx context.Context, outs []*output, pos map[types.Hash]uint32, block *bc.Block) error {
 	var (
 		txHash    pq.StringArray
 		index     pg.Uint32s

--- a/core/account/indexer_test.go
+++ b/core/account/indexer_test.go
@@ -10,6 +10,7 @@ import (
 	"chain/protocol/prottest"
 	"chain/protocol/state"
 	"chain/testutil"
+	"chain/types"
 )
 
 func TestLoadAccountInfo(t *testing.T) {
@@ -20,8 +21,8 @@ func TestLoadAccountInfo(t *testing.T) {
 	acc := m.createTestAccount(ctx, t, "", nil)
 	acp := m.createTestControlProgram(ctx, t, acc.ID)
 
-	to1 := bc.NewTxOutput(bc.AssetID{}, 0, acp, nil)
-	to2 := bc.NewTxOutput(bc.AssetID{}, 0, []byte("notfound"), nil)
+	to1 := bc.NewTxOutput(types.AssetID{}, 0, acp, nil)
+	to2 := bc.NewTxOutput(types.AssetID{}, 0, []byte("notfound"), nil)
 
 	outs := []*state.Output{{
 		TxOutput: *to1,
@@ -44,7 +45,7 @@ func TestDeleteUTXOs(t *testing.T) {
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 
-	assetID := bc.AssetID{}
+	assetID := types.AssetID{}
 	acp := m.createTestControlProgram(ctx, t, "")
 
 	block1 := &bc.Block{Transactions: []*bc.Tx{

--- a/core/account/reserve.go
+++ b/core/account/reserve.go
@@ -15,6 +15,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/state"
 	"chain/sync/idempotency"
+	"chain/types"
 )
 
 var (
@@ -36,7 +37,7 @@ var (
 // utxo describes an individual account utxo.
 type utxo struct {
 	bc.Outpoint
-	bc.AssetAmount
+	types.AssetAmount
 	ControlProgram []byte
 
 	AccountID           string
@@ -49,7 +50,7 @@ func (u *utxo) source() source {
 
 // source describes the criteria to use when selecting UTXOs.
 type source struct {
-	AssetID   bc.AssetID
+	AssetID   types.AssetID
 	AccountID string
 }
 
@@ -387,13 +388,13 @@ func findMatchingUTXOs(ctx context.Context, db pg.DB, src source, height uint64)
 	`
 	var utxos []*utxo
 	err := pg.ForQueryRows(ctx, db, q, src.AccountID, src.AssetID, height,
-		func(txHash bc.Hash, index uint32, amount uint64, cpIndex uint64, controlProg []byte) {
+		func(txHash types.Hash, index uint32, amount uint64, cpIndex uint64, controlProg []byte) {
 			utxos = append(utxos, &utxo{
 				Outpoint: bc.Outpoint{
 					Hash:  txHash,
 					Index: index,
 				},
-				AssetAmount: bc.AssetAmount{
+				AssetAmount: types.AssetAmount{
 					Amount:  amount,
 					AssetID: src.AssetID,
 				},

--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -9,6 +9,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
 	"chain/protocol/state"
+	"chain/types"
 )
 
 const sampleAccountUTXOs = `
@@ -31,8 +32,8 @@ func TestCancelReservation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var h bc.Hash
-	var assetID bc.AssetID
+	var h types.Hash
+	var assetID types.AssetID
 	err = h.UnmarshalText([]byte("270b725a94429496a178c56b390a89d03f801fe2ee992d90cf4fdf7d7855318e"))
 	if err != nil {
 		t.Fatal(err)

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -22,6 +22,7 @@ import (
 	"chain/protocol/prottest"
 	"chain/protocol/vm"
 	"chain/testutil"
+	"chain/types"
 )
 
 func TestBuildFinal(t *testing.T) {
@@ -41,7 +42,7 @@ func TestBuildFinal(t *testing.T) {
 	}
 
 	assetID := coretest.CreateAsset(ctx, t, assets, nil, "", nil)
-	assetAmt := bc.AssetAmount{
+	assetAmt := types.AssetAmount{
 		AssetID: assetID,
 		Amount:  100,
 	}
@@ -151,7 +152,7 @@ func TestAccountTransfer(t *testing.T) {
 	}
 
 	assetID := coretest.CreateAsset(ctx, t, assets, nil, "", nil)
-	assetAmt := bc.AssetAmount{
+	assetAmt := types.AssetAmount{
 		AssetID: assetID,
 		Amount:  100,
 	}
@@ -239,7 +240,7 @@ func TestTransfer(t *testing.T) {
 	assetIDStr := assetID.String()
 
 	// Preface: issue some asset for account1ID to transfer to account2ID
-	issueAssetAmount := bc.AssetAmount{
+	issueAssetAmount := types.AssetAmount{
 		AssetID: assetID,
 		Amount:  100,
 	}

--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -11,6 +11,7 @@ import (
 	"chain/errors"
 	"chain/protocol/bc"
 	"chain/protocol/vmutil"
+	"chain/types"
 )
 
 // PinName is used to identify the pin
@@ -22,7 +23,7 @@ const PinName = "asset"
 // If the Core is configured not to provide search services,
 // SaveAnnotatedAsset can be a no-op.
 type Saver interface {
-	SaveAnnotatedAsset(context.Context, bc.AssetID, map[string]interface{}, string) error
+	SaveAnnotatedAsset(context.Context, types.AssetID, map[string]interface{}, string) error
 }
 
 func (reg *Registry) indexAnnotatedAsset(ctx context.Context, a *Asset) error {
@@ -83,7 +84,7 @@ func (reg *Registry) indexAssets(ctx context.Context, b *bc.Block) error {
 	var (
 		assetIDs, definitions pq.StringArray
 		issuancePrograms      pq.ByteaArray
-		seen                  = make(map[bc.AssetID]bool)
+		seen                  = make(map[types.AssetID]bool)
 	)
 	for _, tx := range b.Transactions {
 		for _, in := range tx.Inputs {
@@ -126,9 +127,9 @@ func (reg *Registry) indexAssets(ctx context.Context, b *bc.Block) error {
 			UNION
 		SELECT id FROM assets WHERE first_block_height = $6
 	`
-	var newAssetIDs []bc.AssetID
+	var newAssetIDs []types.AssetID
 	err := pg.ForQueryRows(ctx, reg.db, q, assetIDs, issuancePrograms, definitions, b.Time(), reg.initialBlockHash, b.Height,
-		func(assetID bc.AssetID) { newAssetIDs = append(newAssetIDs, assetID) })
+		func(assetID types.AssetID) { newAssetIDs = append(newAssetIDs, assetID) })
 	if err != nil {
 		return errors.Wrap(err, "error indexing non-local assets")
 	}

--- a/core/asset/block_test.go
+++ b/core/asset/block_test.go
@@ -10,13 +10,14 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
 	"chain/testutil"
+	"chain/types"
 )
 
 const def = `{"currency":"USD"}`
 
-type fakeSaver func(context.Context, bc.AssetID, map[string]interface{}, string) error
+type fakeSaver func(context.Context, types.AssetID, map[string]interface{}, string) error
 
-func (f fakeSaver) SaveAnnotatedAsset(ctx context.Context, assetID bc.AssetID, obj map[string]interface{}, sortID string) error {
+func (f fakeSaver) SaveAnnotatedAsset(ctx context.Context, assetID types.AssetID, obj map[string]interface{}, sortID string) error {
 	return f(ctx, assetID, obj, sortID)
 }
 
@@ -68,8 +69,8 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	}
 	remoteAssetID := b.Transactions[0].Inputs[0].AssetID()
 
-	var assetsSaved []bc.AssetID
-	r.indexer = fakeSaver(func(ctx context.Context, assetID bc.AssetID, obj map[string]interface{}, sortID string) error {
+	var assetsSaved []types.AssetID
+	r.indexer = fakeSaver(func(ctx context.Context, assetID types.AssetID, obj map[string]interface{}, sortID string) error {
 		assetsSaved = append(assetsSaved, assetID)
 		return nil
 	})
@@ -78,8 +79,8 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	r.indexAssets(ctx, b)
 
 	// Ensure that the annotated asset got saved to the query indexer.
-	if !reflect.DeepEqual(assetsSaved, []bc.AssetID{remoteAssetID}) {
-		t.Errorf("saved annotated assets got %#v, want %#v", assetsSaved, []bc.AssetID{remoteAssetID})
+	if !reflect.DeepEqual(assetsSaved, []types.AssetID{remoteAssetID}) {
+		t.Errorf("saved annotated assets got %#v, want %#v", assetsSaved, []types.AssetID{remoteAssetID})
 	}
 
 	// Ensure that the asset was saved to the `assets` table.

--- a/core/asset/builder.go
+++ b/core/asset/builder.go
@@ -12,9 +12,10 @@ import (
 	chainjson "chain/encoding/json"
 	"chain/errors"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
-func (reg *Registry) NewIssueAction(assetAmount bc.AssetAmount, referenceData chainjson.Map) txbuilder.Action {
+func (reg *Registry) NewIssueAction(assetAmount types.AssetAmount, referenceData chainjson.Map) txbuilder.Action {
 	return &issueAction{
 		assets:        reg,
 		AssetAmount:   assetAmount,
@@ -30,12 +31,12 @@ func (reg *Registry) DecodeIssueAction(data []byte) (txbuilder.Action, error) {
 
 type issueAction struct {
 	assets *Registry
-	bc.AssetAmount
+	types.AssetAmount
 	ReferenceData chainjson.Map `json:"reference_data"`
 }
 
 func (a *issueAction) Build(ctx context.Context, maxTime time.Time, builder *txbuilder.TemplateBuilder) error {
-	if a.AssetID == (bc.AssetID{}) {
+	if a.AssetID == (types.AssetID{}) {
 		return txbuilder.MissingFieldsError("asset_id")
 	}
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -23,6 +23,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/mempool"
 	"chain/protocol/state"
+	"chain/types"
 )
 
 const (
@@ -38,12 +39,12 @@ var (
 
 // Config encapsulates Core-level, persistent configuration options.
 type Config struct {
-	ID                   string  `json:"id"`
-	IsSigner             bool    `json:"is_signer"`
-	IsGenerator          bool    `json:"is_generator"`
-	BlockchainID         bc.Hash `json:"blockchain_id"`
-	GeneratorURL         string  `json:"generator_url"`
-	GeneratorAccessToken string  `json:"generator_access_token"`
+	ID                   string     `json:"id"`
+	IsSigner             bool       `json:"is_signer"`
+	IsGenerator          bool       `json:"is_generator"`
+	BlockchainID         types.Hash `json:"blockchain_id"`
+	GeneratorURL         string     `json:"generator_url"`
+	GeneratorAccessToken string     `json:"generator_access_token"`
 	ConfiguredAt         time.Time
 	BlockPub             string        `json:"block_pub"`
 	Signers              []BlockSigner `json:"block_signer_urls"`

--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -16,6 +16,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/state"
 	"chain/testutil"
+	"chain/types"
 )
 
 func CreatePins(ctx context.Context, t testing.TB, s *pin.Store) {
@@ -37,7 +38,7 @@ func CreateAccount(ctx context.Context, t testing.TB, accounts *account.Manager,
 	return acc.ID
 }
 
-func CreateAsset(ctx context.Context, t testing.TB, assets *asset.Registry, def map[string]interface{}, alias string, tags map[string]interface{}) bc.AssetID {
+func CreateAsset(ctx context.Context, t testing.TB, assets *asset.Registry, def map[string]interface{}, alias string, tags map[string]interface{}) types.AssetID {
 	keys := []string{testutil.TestXPub.String()}
 	asset, err := assets.Define(ctx, keys, 1, def, alias, tags, nil)
 	if err != nil {
@@ -46,12 +47,12 @@ func CreateAsset(ctx context.Context, t testing.TB, assets *asset.Registry, def 
 	return asset.AssetID
 }
 
-func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, assets *asset.Registry, accounts *account.Manager, assetID bc.AssetID, amount uint64, accountID string) state.Output {
-	assetAmount := bc.AssetAmount{AssetID: assetID, Amount: amount}
+func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, assets *asset.Registry, accounts *account.Manager, assetID types.AssetID, amount uint64, accountID string) state.Output {
+	assetAmount := types.AssetAmount{AssetID: assetID, Amount: amount}
 
 	tpl, err := txbuilder.Build(ctx, nil, []txbuilder.Action{
 		assets.NewIssueAction(assetAmount, nil), // does not support reference data
-		accounts.NewControlAction(bc.AssetAmount{AssetID: assetID, Amount: amount}, accountID, nil),
+		accounts.NewControlAction(types.AssetAmount{AssetID: assetID, Amount: amount}, accountID, nil),
 	}, time.Now().Add(time.Minute))
 	if err != nil {
 		testutil.FatalErr(t, err)

--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -17,6 +17,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
 	"chain/testutil"
+	"chain/types"
 )
 
 func TestMockHSM(t *testing.T) {
@@ -55,10 +56,10 @@ func TestMockHSM(t *testing.T) {
 	asset1ID := coretest.CreateAsset(ctx, t, assets, assetDef1, "", nil)
 	asset2ID := coretest.CreateAsset(ctx, t, assets, assetDef2, "", nil)
 
-	issueSrc1 := txbuilder.Action(assets.NewIssueAction(bc.AssetAmount{AssetID: asset1ID, Amount: 100}, nil))
-	issueSrc2 := txbuilder.Action(assets.NewIssueAction(bc.AssetAmount{AssetID: asset2ID, Amount: 200}, nil))
-	issueDest1 := accounts.NewControlAction(bc.AssetAmount{AssetID: asset1ID, Amount: 100}, acct1.ID, nil)
-	issueDest2 := accounts.NewControlAction(bc.AssetAmount{AssetID: asset2ID, Amount: 200}, acct2.ID, nil)
+	issueSrc1 := txbuilder.Action(assets.NewIssueAction(types.AssetAmount{AssetID: asset1ID, Amount: 100}, nil))
+	issueSrc2 := txbuilder.Action(assets.NewIssueAction(types.AssetAmount{AssetID: asset2ID, Amount: 200}, nil))
+	issueDest1 := accounts.NewControlAction(types.AssetAmount{AssetID: asset1ID, Amount: 100}, acct1.ID, nil)
+	issueDest2 := accounts.NewControlAction(types.AssetAmount{AssetID: asset2ID, Amount: 200}, acct2.ID, nil)
 	tmpl, err := txbuilder.Build(ctx, nil, []txbuilder.Action{issueSrc1, issueSrc2, issueDest1, issueDest2}, time.Now().Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)
@@ -73,10 +74,10 @@ func TestMockHSM(t *testing.T) {
 	prottest.MakeBlock(t, c)
 	<-pinStore.PinWaiter(account.PinName, c.Height())
 
-	xferSrc1 := accounts.NewSpendAction(bc.AssetAmount{AssetID: asset1ID, Amount: 10}, acct1.ID, nil, nil)
-	xferSrc2 := accounts.NewSpendAction(bc.AssetAmount{AssetID: asset2ID, Amount: 20}, acct2.ID, nil, nil)
-	xferDest1 := accounts.NewControlAction(bc.AssetAmount{AssetID: asset2ID, Amount: 20}, acct1.ID, nil)
-	xferDest2 := accounts.NewControlAction(bc.AssetAmount{AssetID: asset1ID, Amount: 10}, acct2.ID, nil)
+	xferSrc1 := accounts.NewSpendAction(types.AssetAmount{AssetID: asset1ID, Amount: 10}, acct1.ID, nil, nil)
+	xferSrc2 := accounts.NewSpendAction(types.AssetAmount{AssetID: asset2ID, Amount: 20}, acct2.ID, nil, nil)
+	xferDest1 := accounts.NewControlAction(types.AssetAmount{AssetID: asset2ID, Amount: 20}, acct1.ID, nil)
+	xferDest2 := accounts.NewControlAction(types.AssetAmount{AssetID: asset1ID, Amount: 10}, acct2.ID, nil)
 	tmpl, err = txbuilder.Build(ctx, nil, []txbuilder.Action{xferSrc1, xferSrc2, xferDest1, xferDest2}, time.Now().Add(time.Minute))
 	if err != nil {
 		t.Fatal(err)

--- a/core/query/assets.go
+++ b/core/query/assets.go
@@ -9,11 +9,11 @@ import (
 
 	"chain/core/query/filter"
 	"chain/errors"
-	"chain/protocol/bc"
+	"chain/types"
 )
 
 // SaveAnnotatedAsset saves an annotated asset to the query indexes.
-func (ind *Indexer) SaveAnnotatedAsset(ctx context.Context, assetID bc.AssetID, asset map[string]interface{}, sortID string) error {
+func (ind *Indexer) SaveAnnotatedAsset(ctx context.Context, assetID types.AssetID, asset map[string]interface{}, sortID string) error {
 	b, err := json.Marshal(asset)
 	if err != nil {
 		return errors.Wrap(err)

--- a/core/query/index_test.go
+++ b/core/query/index_test.go
@@ -10,6 +10,7 @@ import (
 	"chain/protocol"
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
+	"chain/types"
 )
 
 func TestIndexBlock(t *testing.T) {
@@ -42,8 +43,8 @@ func TestAnnotatedTxs(t *testing.T) {
 	indexer := NewIndexer(db, &protocol.Chain{}, nil)
 	b := &bc.Block{
 		Transactions: []*bc.Tx{
-			{Hash: bc.Hash{0: 0x01}},
-			{Hash: bc.Hash{0: 0x02}},
+			{Hash: types.Hash{0: 0x01}},
+			{Hash: types.Hash{0: 0x02}},
 		},
 	}
 	txs, err := indexer.insertAnnotatedTxs(ctx, b)

--- a/core/query/outputs_test.go
+++ b/core/query/outputs_test.go
@@ -11,6 +11,7 @@ import (
 	"chain/database/pg/pgtest"
 	"chain/protocol"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 func TestDecodeOutputsAfter(t *testing.T) {
@@ -140,7 +141,7 @@ func TestConstructOutputsQuery(t *testing.T) {
 func TestQueryOutputs(t *testing.T) {
 	type (
 		assetAccountAmount struct {
-			bc.AssetAmount
+			types.AssetAmount
 			AccountID string
 		}
 		testcase struct {
@@ -169,7 +170,7 @@ func TestQueryOutputs(t *testing.T) {
 			values: []interface{}{asset1.AssetID.String()},
 			when:   time2,
 			want: []assetAccountAmount{
-				{bc.AssetAmount{AssetID: asset1.AssetID, Amount: 867}, acct1.ID},
+				{types.AssetAmount{AssetID: asset1.AssetID, Amount: 867}, acct1.ID},
 			},
 		},
 		{
@@ -177,7 +178,7 @@ func TestQueryOutputs(t *testing.T) {
 			values: []interface{}{"USD"},
 			when:   time2,
 			want: []assetAccountAmount{
-				{bc.AssetAmount{AssetID: asset1.AssetID, Amount: 867}, acct1.ID},
+				{types.AssetAmount{AssetID: asset1.AssetID, Amount: 867}, acct1.ID},
 			},
 		},
 		{
@@ -190,7 +191,7 @@ func TestQueryOutputs(t *testing.T) {
 			values: []interface{}{asset2.AssetID.String()},
 			when:   time2,
 			want: []assetAccountAmount{
-				{bc.AssetAmount{AssetID: asset2.AssetID, Amount: 100}, acct1.ID},
+				{types.AssetAmount{AssetID: asset2.AssetID, Amount: 100}, acct1.ID},
 			},
 		},
 		{
@@ -204,8 +205,8 @@ func TestQueryOutputs(t *testing.T) {
 			values: []interface{}{acct1.ID},
 			when:   time2,
 			want: []assetAccountAmount{
-				{bc.AssetAmount{AssetID: asset2.AssetID, Amount: 100}, acct1.ID},
-				{bc.AssetAmount{AssetID: asset1.AssetID, Amount: 867}, acct1.ID},
+				{types.AssetAmount{AssetID: asset2.AssetID, Amount: 100}, acct1.ID},
+				{types.AssetAmount{AssetID: asset1.AssetID, Amount: 867}, acct1.ID},
 			},
 		},
 		{
@@ -225,7 +226,7 @@ func TestQueryOutputs(t *testing.T) {
 			values: []interface{}{asset1.AssetID.String(), acct1.ID},
 			when:   time2,
 			want: []assetAccountAmount{
-				{bc.AssetAmount{AssetID: asset1.AssetID, Amount: 867}, acct1.ID},
+				{types.AssetAmount{AssetID: asset1.AssetID, Amount: 867}, acct1.ID},
 			},
 		},
 		{

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -22,6 +22,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/mempool"
 	"chain/protocol/prottest"
+	"chain/types"
 )
 
 // TestRecovery tests end-to-end blockchain recovery from an exit
@@ -66,10 +67,10 @@ func TestRecovery(t *testing.T) {
 
 	// Submit a transfer between Alice and Bob but don't publish it in a block.
 	coretest.Transfer(ctx, t, c, []txbuilder.Action{
-		accounts.NewControlAction(bc.AssetAmount{AssetID: usd, Amount: 1}, alice, nil),
-		accounts.NewControlAction(bc.AssetAmount{AssetID: apple, Amount: 1}, bob, nil),
-		accounts.NewSpendAction(bc.AssetAmount{AssetID: usd, Amount: 1}, bob, nil, nil),
-		accounts.NewSpendAction(bc.AssetAmount{AssetID: apple, Amount: 1}, alice, nil, nil),
+		accounts.NewControlAction(types.AssetAmount{AssetID: usd, Amount: 1}, alice, nil),
+		accounts.NewControlAction(types.AssetAmount{AssetID: apple, Amount: 1}, bob, nil),
+		accounts.NewSpendAction(types.AssetAmount{AssetID: usd, Amount: 1}, bob, nil, nil),
+		accounts.NewSpendAction(types.AssetAmount{AssetID: apple, Amount: 1}, alice, nil, nil),
 	})
 
 	poolTxs, err := pool.Dump(ctx)

--- a/core/rpc.go
+++ b/core/rpc.go
@@ -8,7 +8,7 @@ import (
 	chainjson "chain/encoding/json"
 	"chain/errors"
 	"chain/net/http/httpjson"
-	"chain/protocol/bc"
+	"chain/types"
 )
 
 // getBlockRPC returns the block at the requested height.
@@ -40,9 +40,9 @@ func (h *Handler) getBlocksRPC(ctx context.Context, afterHeight uint64) ([]chain
 }
 
 type snapshotInfoResp struct {
-	Height       uint64  `json:"height"`
-	Size         uint64  `json:"size"`
-	BlockchainID bc.Hash `json:"blockchain_id"`
+	Height       uint64     `json:"height"`
+	Size         uint64     `json:"size"`
+	BlockchainID types.Hash `json:"blockchain_id"`
 }
 
 func (h *Handler) getSnapshotInfoRPC(ctx context.Context) (resp snapshotInfoResp, err error) {

--- a/core/transact.go
+++ b/core/transact.go
@@ -16,6 +16,7 @@ import (
 	"chain/net/http/reqid"
 	"chain/protocol"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 var defaultTxTTL = 5 * time.Minute
@@ -119,7 +120,7 @@ func (h *Handler) submitSingle(ctx context.Context, tpl *txbuilder.Template, wai
 //
 // If the tx has already been submitted, it returns the existing
 // height.
-func recordSubmittedTx(ctx context.Context, db pg.DB, txHash bc.Hash, currentHeight uint64) (uint64, error) {
+func recordSubmittedTx(ctx context.Context, db pg.DB, txHash types.Hash, currentHeight uint64) (uint64, error) {
 	const insertQ = `
 		INSERT INTO submitted_txs (tx_hash, height) VALUES($1, $2)
 		ON CONFLICT DO NOTHING

--- a/core/transact_test.go
+++ b/core/transact_test.go
@@ -15,6 +15,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
 	"chain/testutil"
+	"chain/types"
 )
 
 func TestAccountTransferSpendChange(t *testing.T) {
@@ -34,7 +35,7 @@ func TestAccountTransferSpendChange(t *testing.T) {
 	}
 
 	assetID := coretest.CreateAsset(ctx, t, assets, nil, "", nil)
-	assetAmt := bc.AssetAmount{
+	assetAmt := types.AssetAmount{
 		AssetID: assetID,
 		Amount:  100,
 	}
@@ -79,13 +80,13 @@ func TestRecordSubmittedTxs(t *testing.T) {
 	dbtx := pgtest.NewTx(t)
 
 	testCases := []struct {
-		hash   bc.Hash
+		hash   types.Hash
 		height uint64
 		want   uint64
 	}{
-		{hash: bc.Hash{0x01}, height: 2, want: 2},
-		{hash: bc.Hash{0x02}, height: 3, want: 3},
-		{hash: bc.Hash{0x01}, height: 3, want: 2},
+		{hash: types.Hash{0x01}, height: 2, want: 2},
+		{hash: types.Hash{0x02}, height: 3, want: 3},
+		{hash: types.Hash{0x01}, height: 3, want: 2},
 	}
 
 	for i, tc := range testCases {

--- a/core/txbuilder/actions.go
+++ b/core/txbuilder/actions.go
@@ -7,6 +7,7 @@ import (
 
 	"chain/encoding/json"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 func DecodeControlProgramAction(data []byte) (Action, error) {
@@ -16,7 +17,7 @@ func DecodeControlProgramAction(data []byte) (Action, error) {
 }
 
 type controlProgramAction struct {
-	bc.AssetAmount
+	types.AssetAmount
 	Program       json.HexBytes `json:"control_program"`
 	ReferenceData json.Map      `json:"reference_data"`
 }
@@ -26,7 +27,7 @@ func (a *controlProgramAction) Build(ctx context.Context, maxTime time.Time, b *
 	if len(a.Program) == 0 {
 		missing = append(missing, "control_program")
 	}
-	if a.AssetID == (bc.AssetID{}) {
+	if a.AssetID == (types.AssetID{}) {
 		missing = append(missing, "asset_id")
 	}
 	if len(missing) > 0 {

--- a/core/txbuilder/constraint.go
+++ b/core/txbuilder/constraint.go
@@ -5,6 +5,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/vm"
 	"chain/protocol/vmutil"
+	"chain/types"
 )
 
 // Constraint types express a constraint on an input of a proposed
@@ -84,9 +85,9 @@ func (r refdataConstraint) code() []byte {
 // at the given index, optionally with the given refdatahash.
 type payConstraint struct {
 	Index int
-	bc.AssetAmount
+	types.AssetAmount
 	Program     []byte
-	RefDataHash *bc.Hash
+	RefDataHash *types.Hash
 }
 
 func (p payConstraint) code() []byte {

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -23,6 +23,7 @@ import (
 	"chain/protocol/prottest"
 	"chain/protocol/state"
 	"chain/testutil"
+	"chain/types"
 )
 
 func TestSighashCheck(t *testing.T) {
@@ -45,7 +46,7 @@ func TestSighashCheck(t *testing.T) {
 	prottest.MakeBlock(t, info.Chain)
 	<-info.pinStore.PinWaiter(account.PinName, info.Chain.Height())
 
-	assetAmount := bc.AssetAmount{
+	assetAmount := types.AssetAmount{
 		AssetID: info.asset.AssetID,
 		Amount:  1,
 	}
@@ -113,7 +114,7 @@ func TestConflictingTxsInPool(t *testing.T) {
 	dumpBlocks(ctx, t, db)
 	<-info.pinStore.PinWaiter(account.PinName, info.Chain.Height())
 
-	assetAmount := bc.AssetAmount{
+	assetAmount := types.AssetAmount{
 		AssetID: info.asset.AssetID,
 		Amount:  10,
 	}
@@ -220,7 +221,7 @@ func dumpTab(ctx context.Context, t *testing.T, db pg.DB, q string) {
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var hash bc.Hash
+		var hash types.Hash
 		var tx bc.TxData
 		err = rows.Scan(&hash, &tx)
 		if err != nil {
@@ -243,7 +244,7 @@ func dumpBlocks(ctx context.Context, t *testing.T, db pg.DB) {
 	defer rows.Close()
 	for rows.Next() {
 		var height uint64
-		var hash bc.Hash
+		var hash types.Hash
 		err = rows.Scan(&height, &hash)
 		if err != nil {
 			t.Fatal(err)
@@ -365,7 +366,7 @@ func bootdb(ctx context.Context, db *sql.DB, t testing.TB) (*testInfo, error) {
 }
 
 func issue(ctx context.Context, t testing.TB, info *testInfo, destAcctID string, amount uint64) (*bc.Tx, error) {
-	assetAmount := bc.AssetAmount{
+	assetAmount := types.AssetAmount{
 		AssetID: info.asset.AssetID,
 		Amount:  amount,
 	}
@@ -382,7 +383,7 @@ func issue(ctx context.Context, t testing.TB, info *testInfo, destAcctID string,
 }
 
 func transfer(ctx context.Context, t testing.TB, info *testInfo, srcAcctID, destAcctID string, amount uint64) (*bc.Tx, error) {
-	assetAmount := bc.AssetAmount{
+	assetAmount := types.AssetAmount{
 		AssetID: info.asset.AssetID,
 		Amount:  amount,
 	}

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -11,6 +11,7 @@ import (
 	"chain/errors"
 	"chain/math/checked"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 var (
@@ -93,7 +94,7 @@ func Sign(ctx context.Context, tpl *Template, xpubs []string, signFn SignFunc) e
 }
 
 func checkBlankCheck(tx *bc.TxData) error {
-	assetMap := make(map[bc.AssetID]int64)
+	assetMap := make(map[types.AssetID]int64)
 	var ok bool
 	for _, in := range tx.Inputs {
 		asset := in.AssetID() // AssetID() is calculated for IssuanceInputs, so grab once

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -7,6 +7,7 @@ import (
 
 	"chain/errors"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 // Template represents a partially- or fully-signed transaction.
@@ -30,7 +31,7 @@ type Template struct {
 	sigHasher *bc.SigHasher
 }
 
-func (t *Template) Hash(idx int) bc.Hash {
+func (t *Template) Hash(idx int) types.Hash {
 	if t.sigHasher == nil {
 		t.sigHasher = bc.NewSigHasher(t.Transaction)
 	}
@@ -40,13 +41,13 @@ func (t *Template) Hash(idx int) bc.Hash {
 // SigningInstruction gives directions for signing inputs in a TxTemplate.
 type SigningInstruction struct {
 	Position int `json:"position"`
-	bc.AssetAmount
+	types.AssetAmount
 	WitnessComponents []WitnessComponent `json:"witness_components,omitempty"`
 }
 
 func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 	var pre struct {
-		bc.AssetAmount
+		types.AssetAmount
 		Position          int `json:"position"`
 		WitnessComponents []struct {
 			Type string

--- a/core/txbuilder/witness.go
+++ b/core/txbuilder/witness.go
@@ -7,9 +7,9 @@ import (
 	"chain/crypto/sha3pool"
 	chainjson "chain/encoding/json"
 	"chain/errors"
-	"chain/protocol/bc"
 	"chain/protocol/vm"
 	"chain/protocol/vmutil"
+	"chain/types"
 )
 
 // SignFunc is the function passed into Sign that produces
@@ -187,7 +187,7 @@ func buildSigProgram(tpl *Template, index int) []byte {
 		if len(out.ReferenceData) > 0 {
 			var h [32]byte
 			sha3pool.Sum256(h[:], out.ReferenceData)
-			c.RefDataHash = (*bc.Hash)(&h)
+			c.RefDataHash = (*types.Hash)(&h)
 		}
 		constraints = append(constraints, c)
 	}

--- a/core/txbuilder/witness_test.go
+++ b/core/txbuilder/witness_test.go
@@ -11,16 +11,17 @@ import (
 	chainjson "chain/encoding/json"
 	"chain/protocol/bc"
 	"chain/protocol/vm"
+	"chain/types"
 )
 
 func TestInferConstraints(t *testing.T) {
 	tpl := &Template{
 		Transaction: &bc.TxData{
 			Inputs: []*bc.TxInput{
-				bc.NewSpendInput(bc.Hash{}, 1, nil, bc.AssetID{}, 123, nil, []byte{1}),
+				bc.NewSpendInput(types.Hash{}, 1, nil, types.AssetID{}, 123, nil, []byte{1}),
 			},
 			Outputs: []*bc.TxOutput{
-				bc.NewTxOutput(bc.AssetID{}, 123, []byte{10, 11, 12}, nil),
+				bc.NewTxOutput(types.AssetID{}, 123, []byte{10, 11, 12}, nil),
 			},
 			MinTime: 1,
 			MaxTime: 2,
@@ -39,8 +40,8 @@ func TestInferConstraints(t *testing.T) {
 
 func TestWitnessJSON(t *testing.T) {
 	si := &SigningInstruction{
-		AssetAmount: bc.AssetAmount{
-			AssetID: bc.AssetID{0xff},
+		AssetAmount: types.AssetAmount{
+			AssetID: types.AssetID{0xff},
 			Amount:  21,
 		},
 		Position: 17,

--- a/core/txdb/snapshot.go
+++ b/core/txdb/snapshot.go
@@ -9,9 +9,9 @@ import (
 	"chain/database/pg"
 	"chain/database/sql"
 	"chain/errors"
-	"chain/protocol/bc"
 	"chain/protocol/patricia"
 	"chain/protocol/state"
+	"chain/types"
 )
 
 // DecodeSnapshot decodes a snapshot from the Chain Core's binary,
@@ -35,7 +35,7 @@ func DecodeSnapshot(data []byte) (*state.Snapshot, error) {
 
 	issuances := make(state.PriorIssuances, len(storedSnapshot.Issuances))
 	for _, issuance := range storedSnapshot.Issuances {
-		var hash bc.Hash
+		var hash types.Hash
 		copy(hash[:], issuance.Hash)
 		issuances[hash] = issuance.ExpiryMs
 	}

--- a/core/txdb/snapshot_test.go
+++ b/core/txdb/snapshot_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"chain/database/pg/pgtest"
-	"chain/protocol/bc"
 	"chain/protocol/state"
+	"chain/types"
 )
 
 type pair struct {
@@ -25,8 +25,8 @@ func TestReadWriteStateSnapshot(t *testing.T) {
 		inserts          []pair
 		deletes          []string
 		lookups          []pair
-		newIssuances     map[bc.Hash]uint64
-		deletedIssuances []bc.Hash
+		newIssuances     map[types.Hash]uint64
+		deletedIssuances []types.Hash
 	}{
 		{ // add a single k/v pair
 			inserts: []pair{
@@ -35,8 +35,8 @@ func TestReadWriteStateSnapshot(t *testing.T) {
 					hash: []byte{0x01},
 				},
 			},
-			newIssuances: map[bc.Hash]uint64{
-				bc.Hash{0x01}: 1000,
+			newIssuances: map[types.Hash]uint64{
+				types.Hash{0x01}: 1000,
 			},
 		},
 		{ // empty changeset
@@ -57,13 +57,13 @@ func TestReadWriteStateSnapshot(t *testing.T) {
 				{key: "sup", hash: []byte{0x02}},
 				{key: "dup2", hash: []byte{0x03}},
 			},
-			newIssuances: map[bc.Hash]uint64{
-				bc.Hash{0x02}: 2000,
+			newIssuances: map[types.Hash]uint64{
+				types.Hash{0x02}: 2000,
 			},
 		},
 		{ // delete one pair
 			deletes:          []string{"sup"},
-			deletedIssuances: []bc.Hash{bc.Hash{0x02}},
+			deletedIssuances: []types.Hash{types.Hash{0x02}},
 		},
 		{ // insert and delete at the same time
 			inserts: []pair{
@@ -157,7 +157,7 @@ func benchmarkStoreSnapshot(nodes, issuances int, b *testing.B) {
 	}
 
 	for i := 0; i < issuances; i++ {
-		var h bc.Hash
+		var h types.Hash
 		_, err := r.Read(h[:])
 		if err != nil {
 			b.Fatal(err)

--- a/core/txdb/txdb_test.go
+++ b/core/txdb/txdb_test.go
@@ -10,6 +10,7 @@ import (
 	"chain/database/sql"
 	"chain/errors"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 func TestGetBlock(t *testing.T) {
@@ -36,11 +37,11 @@ func TestGetBlock(t *testing.T) {
 			Version:           1,
 			Height:            1,
 			PreviousBlockHash: [32]byte{'1', '2', '3'},
-			TransactionsMerkleRoot: bc.Hash{
+			TransactionsMerkleRoot: types.Hash{
 				'A', 'B', 'C', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 			},
-			AssetsMerkleRoot: bc.Hash{
+			AssetsMerkleRoot: types.Hash{
 				'X', 'Y', 'Z', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 			},

--- a/protocol/bc/block.go
+++ b/protocol/bc/block.go
@@ -12,6 +12,7 @@ import (
 	"chain/encoding/blockchain"
 	"chain/encoding/bufpool"
 	"chain/errors"
+	"chain/types"
 )
 
 const (
@@ -130,7 +131,7 @@ type BlockHeader struct {
 	Height uint64
 
 	// Hash of the previous block in the block chain.
-	PreviousBlockHash Hash
+	PreviousBlockHash types.Hash
 
 	// Time of the block in milliseconds.
 	// Must grow monotonically and can be equal
@@ -142,12 +143,12 @@ type BlockHeader struct {
 	// TransactionsMerkleRoot is the root hash of the Merkle binary hash
 	// tree formed by the transaction witness hashes of all transactions
 	// included in the block.
-	TransactionsMerkleRoot Hash
+	TransactionsMerkleRoot types.Hash
 
 	// AssetsMerkleRoot is the root hash of the Merkle Patricia Tree of
 	// the set of unspent outputs with asset version 1 after applying
 	// the block.
-	AssetsMerkleRoot Hash
+	AssetsMerkleRoot types.Hash
 
 	// ConsensusProgram is the predicate for validating the next block.
 	ConsensusProgram []byte
@@ -182,7 +183,7 @@ func (bh *BlockHeader) Value() (driver.Value, error) {
 }
 
 // Hash returns complete hash of the block header.
-func (bh *BlockHeader) Hash() Hash {
+func (bh *BlockHeader) Hash() types.Hash {
 	h := sha3pool.Get256()
 	bh.WriteTo(h) // error is impossible
 	var v [32]byte
@@ -194,7 +195,7 @@ func (bh *BlockHeader) Hash() Hash {
 // HashForSig returns a hash of the block header without witness.
 // This hash is used for signing the block and verifying the
 // signature.
-func (bh *BlockHeader) HashForSig() Hash {
+func (bh *BlockHeader) HashForSig() types.Hash {
 	h := sha3pool.Get256()
 	bh.WriteForSigTo(h) // error is impossible
 	var v [32]byte

--- a/protocol/bc/block_test.go
+++ b/protocol/bc/block_test.go
@@ -2,6 +2,7 @@ package bc
 
 import (
 	"bytes"
+	"chain/types"
 	"encoding/hex"
 	"encoding/json"
 	"reflect"
@@ -22,7 +23,7 @@ func TestMarshalBlock(t *testing.T) {
 			NewTx(TxData{
 				Version: 1,
 				Outputs: []*TxOutput{
-					NewTxOutput(AssetID{}, 1, nil, nil),
+					NewTxOutput(types.AssetID{}, 1, nil, nil),
 				},
 			}),
 		}}

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 
 	"chain/errors"
+	"chain/types"
 )
 
 func TestTransaction(t *testing.T) {
@@ -18,7 +19,7 @@ func TestTransaction(t *testing.T) {
 	initialBlockHashHex := "03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d"
 	initialBlockHash := mustDecodeHash(initialBlockHashHex)
 
-	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1)
+	assetID := types.ComputeAssetID(issuanceScript, initialBlockHash, 1, 1)
 
 	cases := []struct {
 		tx          *Tx
@@ -54,7 +55,7 @@ func TestTransaction(t *testing.T) {
 					NewIssuanceInput([]byte{10, 9, 8}, 1000000000000, []byte("input"), initialBlockHash, issuanceScript, [][]byte{[]byte{1, 2, 3}}),
 				},
 				Outputs: []*TxOutput{
-					NewTxOutput(AssetID{}, 1000000000000, []byte{1}, []byte("output")),
+					NewTxOutput(types.AssetID{}, 1000000000000, []byte{1}, []byte("output")),
 				},
 				MinTime:       0,
 				MaxTime:       0,
@@ -100,11 +101,11 @@ func TestTransaction(t *testing.T) {
 			tx: NewTx(TxData{
 				Version: 1,
 				Inputs: []*TxInput{
-					NewSpendInput(mustDecodeHash("dd385f6fe25d91d8c1bd0fa58951ad56b0c5229dcc01f61d9f9e8b9eb92d3292"), 0, nil, AssetID{}, 1000000000000, []byte{1}, []byte("input")),
+					NewSpendInput(mustDecodeHash("dd385f6fe25d91d8c1bd0fa58951ad56b0c5229dcc01f61d9f9e8b9eb92d3292"), 0, nil, types.AssetID{}, 1000000000000, []byte{1}, []byte("input")),
 				},
 				Outputs: []*TxOutput{
-					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1), 600000000000, []byte{1}, nil),
-					NewTxOutput(ComputeAssetID(issuanceScript, initialBlockHash, 1), 400000000000, []byte{2}, nil),
+					NewTxOutput(types.ComputeAssetID(issuanceScript, initialBlockHash, 1, 1), 600000000000, []byte{1}, nil),
+					NewTxOutput(types.ComputeAssetID(issuanceScript, initialBlockHash, 1, 1), 400000000000, []byte{2}, nil),
 				},
 				MinTime:       1492590000,
 				MaxTime:       1492590591,
@@ -194,21 +195,21 @@ func TestHasIssuance(t *testing.T) {
 		want bool
 	}{{
 		tx: &TxData{
-			Inputs: []*TxInput{NewIssuanceInput(nil, 0, nil, Hash{}, nil, nil)},
+			Inputs: []*TxInput{NewIssuanceInput(nil, 0, nil, types.Hash{}, nil, nil)},
 		},
 		want: true,
 	}, {
 		tx: &TxData{
 			Inputs: []*TxInput{
-				NewSpendInput(Hash{}, 0, nil, AssetID{}, 0, nil, nil),
-				NewIssuanceInput(nil, 0, nil, Hash{}, nil, nil),
+				NewSpendInput(types.Hash{}, 0, nil, types.AssetID{}, 0, nil, nil),
+				NewIssuanceInput(nil, 0, nil, types.Hash{}, nil, nil),
 			},
 		},
 		want: true,
 	}, {
 		tx: &TxData{
 			Inputs: []*TxInput{
-				NewSpendInput(Hash{}, 0, nil, AssetID{}, 0, nil, nil),
+				NewSpendInput(types.Hash{}, 0, nil, types.AssetID{}, 0, nil, nil),
 			},
 		},
 		want: false,
@@ -297,12 +298,12 @@ func TestOutpointWriteErr(t *testing.T) {
 }
 
 func TestTxHashForSig(t *testing.T) {
-	assetID := ComputeAssetID([]byte{1}, mustDecodeHash("03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d"), 1)
+	assetID := types.ComputeAssetID([]byte{1}, mustDecodeHash("03deff1d4319d67baa10a6d26c1fea9c3e8d30e33474efee1a610a9bb49d758d"), 1, 1)
 	tx := &TxData{
 		Version: 1,
 		Inputs: []*TxInput{
-			NewSpendInput(mustDecodeHash("d250fa36f2813ddb8aed0fc66790ee58121bcbe88909bf88be12083d45320151"), 0, [][]byte{[]byte{1}}, AssetID{}, 0, nil, []byte("input1")),
-			NewSpendInput(mustDecodeHash("d250fa36f2813ddb8aed0fc66790ee58121bcbe88909bf88be12083d45320151"), 1, [][]byte{[]byte{2}}, AssetID{}, 0, nil, nil),
+			NewSpendInput(mustDecodeHash("d250fa36f2813ddb8aed0fc66790ee58121bcbe88909bf88be12083d45320151"), 0, [][]byte{[]byte{1}}, types.AssetID{}, 0, nil, []byte("input1")),
+			NewSpendInput(mustDecodeHash("d250fa36f2813ddb8aed0fc66790ee58121bcbe88909bf88be12083d45320151"), 1, [][]byte{[]byte{2}}, types.AssetID{}, 0, nil, nil),
 		},
 		Outputs: []*TxOutput{
 			NewTxOutput(assetID, 1000000000000, []byte{3}, nil),
@@ -364,8 +365,8 @@ func BenchmarkTxWriteToFalse(b *testing.B) {
 func BenchmarkTxWriteToTrue200(b *testing.B) {
 	tx := &Tx{}
 	for i := 0; i < 200; i++ {
-		tx.Inputs = append(tx.Inputs, NewSpendInput(Hash{}, 0, nil, AssetID{}, 0, nil, nil))
-		tx.Outputs = append(tx.Outputs, NewTxOutput(AssetID{}, 0, nil, nil))
+		tx.Inputs = append(tx.Inputs, NewSpendInput(types.Hash{}, 0, nil, types.AssetID{}, 0, nil, nil))
+		tx.Outputs = append(tx.Outputs, NewTxOutput(types.AssetID{}, 0, nil, nil))
 	}
 	for i := 0; i < b.N; i++ {
 		tx.writeTo(ioutil.Discard, 0)
@@ -375,8 +376,8 @@ func BenchmarkTxWriteToTrue200(b *testing.B) {
 func BenchmarkTxWriteToFalse200(b *testing.B) {
 	tx := &Tx{}
 	for i := 0; i < 200; i++ {
-		tx.Inputs = append(tx.Inputs, NewSpendInput(Hash{}, 0, nil, AssetID{}, 0, nil, nil))
-		tx.Outputs = append(tx.Outputs, NewTxOutput(AssetID{}, 0, nil, nil))
+		tx.Inputs = append(tx.Inputs, NewSpendInput(types.Hash{}, 0, nil, types.AssetID{}, 0, nil, nil))
+		tx.Outputs = append(tx.Outputs, NewTxOutput(types.AssetID{}, 0, nil, nil))
 	}
 	for i := 0; i < b.N; i++ {
 		tx.writeTo(ioutil.Discard, serRequired)
@@ -384,7 +385,7 @@ func BenchmarkTxWriteToFalse200(b *testing.B) {
 }
 
 func BenchmarkTxInputWriteToTrue(b *testing.B) {
-	input := NewSpendInput(Hash{}, 0, nil, AssetID{}, 0, nil, nil)
+	input := NewSpendInput(types.Hash{}, 0, nil, types.AssetID{}, 0, nil, nil)
 	ew := errors.NewWriter(ioutil.Discard)
 	for i := 0; i < b.N; i++ {
 		input.writeTo(ew, 0)
@@ -392,7 +393,7 @@ func BenchmarkTxInputWriteToTrue(b *testing.B) {
 }
 
 func BenchmarkTxInputWriteToFalse(b *testing.B) {
-	input := NewSpendInput(Hash{}, 0, nil, AssetID{}, 0, nil, nil)
+	input := NewSpendInput(types.Hash{}, 0, nil, types.AssetID{}, 0, nil, nil)
 	ew := errors.NewWriter(ioutil.Discard)
 	for i := 0; i < b.N; i++ {
 		input.writeTo(ew, serRequired)
@@ -400,7 +401,7 @@ func BenchmarkTxInputWriteToFalse(b *testing.B) {
 }
 
 func BenchmarkTxOutputWriteToTrue(b *testing.B) {
-	output := NewTxOutput(AssetID{}, 0, nil, nil)
+	output := NewTxOutput(types.AssetID{}, 0, nil, nil)
 	ew := errors.NewWriter(ioutil.Discard)
 	for i := 0; i < b.N; i++ {
 		output.writeTo(ew, 0)
@@ -408,7 +409,7 @@ func BenchmarkTxOutputWriteToTrue(b *testing.B) {
 }
 
 func BenchmarkTxOutputWriteToFalse(b *testing.B) {
-	output := NewTxOutput(AssetID{}, 0, nil, nil)
+	output := NewTxOutput(types.AssetID{}, 0, nil, nil)
 	ew := errors.NewWriter(ioutil.Discard)
 	for i := 0; i < b.N; i++ {
 		output.writeTo(ew, serRequired)
@@ -416,9 +417,9 @@ func BenchmarkTxOutputWriteToFalse(b *testing.B) {
 }
 
 func BenchmarkAssetAmountWriteTo(b *testing.B) {
-	aa := AssetAmount{}
+	aa := types.AssetAmount{}
 	for i := 0; i < b.N; i++ {
-		aa.writeTo(ioutil.Discard)
+		aa.WriteTo(ioutil.Discard)
 	}
 }
 

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -7,6 +7,7 @@ import (
 
 	"chain/encoding/blockchain"
 	"chain/encoding/bufpool"
+	"chain/types"
 )
 
 // TODO(bobg): Review serialization/deserialization logic for
@@ -20,17 +21,17 @@ type (
 	}
 
 	OutputCommitment struct {
-		AssetAmount
+		types.AssetAmount
 		VMVersion      uint64
 		ControlProgram []byte
 	}
 )
 
-func NewTxOutput(assetID AssetID, amount uint64, controlProgram, referenceData []byte) *TxOutput {
+func NewTxOutput(assetID types.AssetID, amount uint64, controlProgram, referenceData []byte) *TxOutput {
 	return &TxOutput{
 		AssetVersion: 1,
 		OutputCommitment: OutputCommitment{
-			AssetAmount: AssetAmount{
+			AssetAmount: types.AssetAmount{
 				AssetID: assetID,
 				Amount:  amount,
 			},
@@ -75,7 +76,7 @@ func (oc *OutputCommitment) readFrom(r io.Reader, txVersion, assetVersion uint64
 	}
 
 	rb := bytes.NewBuffer(b)
-	n1, err := oc.AssetAmount.readFrom(rb)
+	n1, err := oc.AssetAmount.ReadFrom(rb)
 	if err != nil {
 		return n, err
 	}
@@ -105,8 +106,8 @@ func (to *TxOutput) writeTo(w io.Writer, serflags byte) {
 	blockchain.WriteVarstr31(w, nil)
 }
 
-func (to *TxOutput) witnessHash() Hash {
-	return emptyHash
+func (to *TxOutput) witnessHash() types.Hash {
+	return types.EmptyHash
 }
 
 func (to *TxOutput) WriteCommitment(w io.Writer) {
@@ -117,7 +118,7 @@ func (oc *OutputCommitment) writeTo(w io.Writer, assetVersion uint64) {
 	b := bufpool.Get()
 	defer bufpool.Put(b)
 	if assetVersion == 1 {
-		oc.AssetAmount.writeTo(b)
+		oc.AssetAmount.WriteTo(b)
 		blockchain.WriteVarint63(b, oc.VMVersion) // TODO(bobg): check and return error
 		blockchain.WriteVarstr31(b, oc.ControlProgram)
 	}

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -13,6 +13,7 @@ import (
 	"chain/protocol/memstore"
 	"chain/protocol/state"
 	"chain/testutil"
+	"chain/types"
 )
 
 func TestGetBlock(t *testing.T) {
@@ -51,7 +52,7 @@ func TestGetBlock(t *testing.T) {
 
 func TestNoTimeTravel(t *testing.T) {
 	ctx := context.Background()
-	c, err := NewChain(ctx, bc.Hash{}, memstore.New(), mempool.New(), nil)
+	c, err := NewChain(ctx, types.Hash{}, memstore.New(), mempool.New(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +134,7 @@ func TestGenerateBlock(t *testing.T) {
 	c, b1 := newTestChain(t, now)
 
 	initialBlockHash := b1.Hash()
-	assetID := bc.ComputeAssetID(nil, initialBlockHash, 1)
+	assetID := types.ComputeAssetID(nil, initialBlockHash, 1, 1)
 
 	txs := []*bc.Tx{
 		bc.NewTx(bc.TxData{
@@ -176,7 +177,7 @@ func TestGenerateBlock(t *testing.T) {
 	}
 
 	// TODO(bobg): verify these hashes are correct
-	var wantTxRoot, wantAssetsRoot bc.Hash
+	var wantTxRoot, wantAssetsRoot types.Hash
 	copy(wantTxRoot[:], mustDecodeHex("d0e593c846d7b189bd3e2f55e680016b14989329af1c5e388ff246caedf04bd3"))
 	copy(wantAssetsRoot[:], mustDecodeHex("903d9a10ece41f86b7c2cf23c25b09c2086b321d6d63e2ec7fc7405f84121542"))
 

--- a/protocol/mempool/mempool.go
+++ b/protocol/mempool/mempool.go
@@ -11,18 +11,19 @@ import (
 
 	"chain/log"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 // MemPool satisfies the protocol.Pool interface.
 type MemPool struct {
 	mu     sync.Mutex
 	pool   []*bc.Tx // in topological order
-	hashes map[bc.Hash]bool
+	hashes map[types.Hash]bool
 }
 
 // New returns a new MemPool.
 func New() *MemPool {
-	return &MemPool{hashes: make(map[bc.Hash]bool)}
+	return &MemPool{hashes: make(map[types.Hash]bool)}
 }
 
 // Insert adds a new pending tx to the pending tx pool.
@@ -45,7 +46,7 @@ func (m *MemPool) Dump(ctx context.Context) ([]*bc.Tx, error) {
 	m.mu.Lock()
 	txs := m.pool
 	m.pool = nil
-	m.hashes = make(map[bc.Hash]bool)
+	m.hashes = make(map[types.Hash]bool)
 	m.mu.Unlock()
 
 	if !isTopSorted(txs) {

--- a/protocol/mempool/sort.go
+++ b/protocol/mempool/sort.go
@@ -1,19 +1,22 @@
 package mempool
 
-import "chain/protocol/bc"
+import (
+	"chain/protocol/bc"
+	"chain/types"
+)
 
 func topSort(txs []*bc.Tx) []*bc.Tx {
 	if len(txs) == 1 {
 		return txs
 	}
 
-	nodes := make(map[bc.Hash]*bc.Tx)
+	nodes := make(map[types.Hash]*bc.Tx)
 	for _, tx := range txs {
 		nodes[tx.Hash] = tx
 	}
 
-	incomingEdges := make(map[bc.Hash]int)
-	children := make(map[bc.Hash][]bc.Hash)
+	incomingEdges := make(map[types.Hash]int)
+	children := make(map[types.Hash][]types.Hash)
 	for node, tx := range nodes {
 		for _, in := range tx.Inputs {
 			if in.IsIssuance() {
@@ -21,7 +24,7 @@ func topSort(txs []*bc.Tx) []*bc.Tx {
 			}
 			if prev := in.Outpoint().Hash; nodes[prev] != nil {
 				if children[prev] == nil {
-					children[prev] = make([]bc.Hash, 0, 1)
+					children[prev] = make([]types.Hash, 0, 1)
 				}
 				children[prev] = append(children[prev], node)
 				incomingEdges[node]++
@@ -29,7 +32,7 @@ func topSort(txs []*bc.Tx) []*bc.Tx {
 		}
 	}
 
-	var s []bc.Hash
+	var s []types.Hash
 	for node := range nodes {
 		if incomingEdges[node] == 0 {
 			s = append(s, node)
@@ -60,8 +63,8 @@ func topSort(txs []*bc.Tx) []*bc.Tx {
 }
 
 func isTopSorted(txs []*bc.Tx) bool {
-	exists := make(map[bc.Hash]bool)
-	seen := make(map[bc.Hash]bool)
+	exists := make(map[types.Hash]bool)
+	seen := make(map[types.Hash]bool)
 	for _, tx := range txs {
 		exists[tx.Hash] = true
 	}

--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -16,7 +16,7 @@ import (
 
 	"chain/crypto/sha3pool"
 	"chain/errors"
-	"chain/protocol/bc"
+	"chain/types"
 )
 
 // ErrPrefix is returned from Insert or Delete if
@@ -37,7 +37,7 @@ type Tree struct {
 // value inserted into the patricia tree.
 type Leaf struct {
 	Key  []byte
-	Hash bc.Hash
+	Hash types.Hash
 }
 
 // Reconstruct builds a tree with the provided leaf nodes.
@@ -115,7 +115,7 @@ func (t *Tree) Contains(bkey, val []byte) bool {
 	key := bitKey(bkey)
 	n := t.lookup(t.root, key)
 
-	var hash bc.Hash
+	var hash types.Hash
 	h := sha3pool.Get256()
 	h.Write(leafPrefix)
 	h.Write(val[:])
@@ -149,7 +149,7 @@ func (t *Tree) lookup(n *node, key []uint8) *node {
 func (t *Tree) Insert(bkey, val []byte) error {
 	key := bitKey(bkey)
 
-	var hash bc.Hash
+	var hash types.Hash
 	h := sha3pool.Get256()
 	h.Write(leafPrefix)
 	h.Write(val)
@@ -166,7 +166,7 @@ func (t *Tree) Insert(bkey, val []byte) error {
 	return err
 }
 
-func (t *Tree) insert(n *node, key []uint8, hash *bc.Hash) (*node, error) {
+func (t *Tree) insert(n *node, key []uint8, hash *types.Hash) (*node, error) {
 	if bytes.Equal(n.key, key) {
 		if !n.isLeaf {
 			return n, errors.Wrap(ErrPrefix)
@@ -258,10 +258,10 @@ func (t *Tree) delete(n *node, key []uint8) (*node, error) {
 }
 
 // RootHash returns the merkle root of the tree.
-func (t *Tree) RootHash() bc.Hash {
+func (t *Tree) RootHash() types.Hash {
 	root := t.root
 	if root == nil {
-		return bc.Hash{}
+		return types.Hash{}
 	}
 	return root.Hash()
 }
@@ -306,7 +306,7 @@ func commonPrefixLen(a, b []uint8) int {
 // node is a leaf or branch node in a tree
 type node struct {
 	key      []uint8
-	hash     *bc.Hash
+	hash     *types.Hash
 	isLeaf   bool
 	children [2]*node
 }
@@ -316,7 +316,7 @@ type node struct {
 func (n *node) Key() []byte { return byteKey(n.key) }
 
 // Hash will return the hash for this node.
-func (n *node) Hash() bc.Hash {
+func (n *node) Hash() types.Hash {
 	n.calcHash()
 	return *n.hash
 }
@@ -333,7 +333,7 @@ func (n *node) calcHash() {
 		h.Write(c.hash[:])
 	}
 
-	var hash bc.Hash
+	var hash types.Hash
 	h.Read(hash[:])
 	n.hash = &hash
 	sha3pool.Put256(h)

--- a/protocol/patricia/patricia_test.go
+++ b/protocol/patricia/patricia_test.go
@@ -1,6 +1,7 @@
 package patricia
 
 import (
+	"chain/types"
 	"fmt"
 	"log"
 	"math/rand"
@@ -11,8 +12,6 @@ import (
 	"testing/quick"
 
 	"golang.org/x/crypto/sha3"
-
-	"chain/protocol/bc"
 )
 
 func BenchmarkInserts(b *testing.B) {
@@ -495,7 +494,7 @@ func TestByteKey(t *testing.T) {
 	}
 }
 
-func makeVals(num int) (vals [][]byte, hashes []bc.Hash) {
+func makeVals(num int) (vals [][]byte, hashes []types.Hash) {
 	for i := 0; i < num; i++ {
 		v := sha3.Sum256([]byte{byte(i)})
 		vals = append(vals, v[:])
@@ -547,19 +546,19 @@ func bools(lit string) []uint8 {
 	return append(b[:31*8], b[32*8-len(lit):]...)
 }
 
-func hashForNonLeaf(a, b bc.Hash) bc.Hash {
+func hashForNonLeaf(a, b types.Hash) types.Hash {
 	d := []byte{0x01}
 	d = append(d, a[:]...)
 	d = append(d, b[:]...)
 	return sha3.Sum256(d)
 }
 
-func hashPtr(h bc.Hash) *bc.Hash {
+func hashPtr(h types.Hash) *types.Hash {
 	return &h
 }
 
 func mustDecodeHash(s string) []byte {
-	var h bc.Hash
+	var h types.Hash
 	err := h.UnmarshalText([]byte(strings.TrimSpace(s)))
 	if err != nil {
 		log.Fatalf("error decoding hash: %s", err)

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -54,6 +54,7 @@ import (
 	"chain/log"
 	"chain/protocol/bc"
 	"chain/protocol/state"
+	"chain/types"
 )
 
 // maxCachedValidatedTxs is the max number of validated txs to cache.
@@ -101,7 +102,7 @@ type Pool interface {
 // validation logic from package validation to decide what
 // objects can be safely stored.
 type Chain struct {
-	InitialBlockHash  bc.Hash
+	InitialBlockHash  types.Hash
 	MaxIssuanceWindow time.Duration // only used by generators
 
 	state struct {
@@ -126,7 +127,7 @@ type pendingSnapshot struct {
 }
 
 // NewChain returns a new Chain using store as the underlying storage.
-func NewChain(ctx context.Context, initialBlockHash bc.Hash, store Store, pool Pool, heights <-chan uint64) (*Chain, error) {
+func NewChain(ctx context.Context, initialBlockHash types.Hash, store Store, pool Pool, heights <-chan uint64) (*Chain, error) {
 	c := &Chain{
 		InitialBlockHash: initialBlockHash,
 		store:            store,

--- a/protocol/state/snapshot.go
+++ b/protocol/state/snapshot.go
@@ -2,13 +2,13 @@
 package state
 
 import (
-	"chain/protocol/bc"
 	"chain/protocol/patricia"
+	"chain/types"
 )
 
 // PriorIssuances maps an "issuance hash" to the time (in Unix millis)
 // at which it should expire from the issuance memory.
-type PriorIssuances map[bc.Hash]uint64
+type PriorIssuances map[types.Hash]uint64
 
 // Snapshot encompasses a snapshot of entire blockchain state. It
 // consists of a patricia state tree and the issuances memory.

--- a/protocol/tx.go
+++ b/protocol/tx.go
@@ -9,6 +9,7 @@ import (
 	"chain/errors"
 	"chain/protocol/bc"
 	"chain/protocol/validation"
+	"chain/types"
 )
 
 // AddTx inserts tx into the set of "pending" transactions available
@@ -60,7 +61,7 @@ type prevalidatedTxsCache struct {
 	lru *lru.Cache
 }
 
-func (c *prevalidatedTxsCache) lookup(txID bc.Hash) (err error, ok bool) {
+func (c *prevalidatedTxsCache) lookup(txID types.Hash) (err error, ok bool) {
 	c.mu.Lock()
 	v, ok := c.lru.Get(txID)
 	c.mu.Unlock()
@@ -73,7 +74,7 @@ func (c *prevalidatedTxsCache) lookup(txID bc.Hash) (err error, ok bool) {
 	return v.(error), ok
 }
 
-func (c *prevalidatedTxsCache) cache(txID bc.Hash, err error) {
+func (c *prevalidatedTxsCache) cache(txID types.Hash, err error) {
 	c.mu.Lock()
 	c.lru.Add(txID, err)
 	c.mu.Unlock()

--- a/protocol/tx_test.go
+++ b/protocol/tx_test.go
@@ -16,6 +16,7 @@ import (
 	"chain/protocol/vm"
 	"chain/protocol/vmutil"
 	"chain/testutil"
+	"chain/types"
 )
 
 func TestIdempotentAddTx(t *testing.T) {
@@ -104,14 +105,14 @@ func (d testDest) controlProgram() ([]byte, error) {
 }
 
 type testAsset struct {
-	bc.AssetID
+	types.AssetID
 	testDest
 }
 
 func newAsset(t testing.TB) *testAsset {
 	dest := newDest(t)
 	cp, _ := dest.controlProgram()
-	assetID := bc.ComputeAssetID(cp, bc.Hash{}, 1)
+	assetID := types.ComputeAssetID(cp, types.Hash{}, 1, 1)
 
 	return &testAsset{
 		AssetID:  assetID,
@@ -131,7 +132,7 @@ func issue(t testing.TB, asset *testAsset, dest *testDest, amount uint64) (*bc.T
 	tx := &bc.TxData{
 		Version: bc.CurrentTransactionVersion,
 		Inputs: []*bc.TxInput{
-			bc.NewIssuanceInput([]byte{1}, amount, nil, bc.Hash{}, assetCP, nil),
+			bc.NewIssuanceInput([]byte{1}, amount, nil, types.Hash{}, assetCP, nil),
 		},
 		Outputs: []*bc.TxOutput{
 			bc.NewTxOutput(asset.AssetID, amount, destCP, nil),

--- a/protocol/validation/block.go
+++ b/protocol/validation/block.go
@@ -14,6 +14,7 @@ import (
 	"chain/protocol/state"
 	"chain/protocol/vm"
 	"chain/protocol/vmutil"
+	"chain/types"
 )
 
 // Errors returned by the block validation functions.
@@ -32,7 +33,7 @@ var (
 // See $CHAIN/protocol/doc/spec/validation.md#accept-block.
 // It evaluates the prevBlock's consensus program,
 // then calls ValidateBlock.
-func ValidateBlockForAccept(ctx context.Context, snapshot *state.Snapshot, initialBlockHash bc.Hash, prevBlock, block *bc.Block, validateTx func(*bc.Tx) error) error {
+func ValidateBlockForAccept(ctx context.Context, snapshot *state.Snapshot, initialBlockHash types.Hash, prevBlock, block *bc.Block, validateTx func(*bc.Tx) error) error {
 	if prevBlock != nil {
 		ok, err := vm.VerifyBlockHeader(&prevBlock.BlockHeader, block)
 		if err == nil && !ok {
@@ -57,7 +58,7 @@ func ValidateBlockForAccept(ctx context.Context, snapshot *state.Snapshot, initi
 // See $CHAIN/protocol/doc/spec/validation.md#validate-block.
 // Note that it does not execute prevBlock's consensus program.
 // (See ValidateBlockForAccept for that.)
-func ValidateBlock(ctx context.Context, snapshot *state.Snapshot, initialBlockHash bc.Hash, prevBlock, block *bc.Block, validateTx func(*bc.Tx) error) error {
+func ValidateBlock(ctx context.Context, snapshot *state.Snapshot, initialBlockHash types.Hash, prevBlock, block *bc.Block, validateTx func(*bc.Tx) error) error {
 
 	var g errgroup.Group
 	// Do all of the unparallelizable work, plus validating the block

--- a/protocol/validation/block_test.go
+++ b/protocol/validation/block_test.go
@@ -8,6 +8,7 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/state"
 	"chain/protocol/vm"
+	"chain/types"
 )
 
 // emptyMerkleRoot is the SHA3-256 of "".
@@ -28,7 +29,7 @@ func TestValidateBlockHeader(t *testing.T) {
 	}{{
 		desc: "bad prev block hash",
 		header: bc.BlockHeader{
-			PreviousBlockHash:      bc.Hash{},
+			PreviousBlockHash:      types.Hash{},
 			TransactionsMerkleRoot: emptyMerkleRoot,
 			Height:                 2,
 			Witness:                [][]byte{{0x04}},

--- a/protocol/validation/merkle.go
+++ b/protocol/validation/merkle.go
@@ -5,6 +5,7 @@ import (
 
 	"chain/crypto/sha3pool"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 var (
@@ -14,7 +15,7 @@ var (
 
 // CalcMerkleRoot creates a merkle tree from a slice of transactions
 // and returns the root hash of the tree.
-func CalcMerkleRoot(transactions []*bc.Tx) (root bc.Hash) {
+func CalcMerkleRoot(transactions []*bc.Tx) (root types.Hash) {
 	switch {
 	case len(transactions) == 0:
 		sha3pool.Sum256(root[:], nil)

--- a/protocol/validation/merkle_test.go
+++ b/protocol/validation/merkle_test.go
@@ -7,12 +7,13 @@ import (
 
 	"chain/protocol/bc"
 	"chain/protocol/vm"
+	"chain/types"
 )
 
 func TestCalcMerkleRoot(t *testing.T) {
 	cases := []struct {
 		witnesses [][][]byte
-		want      bc.Hash
+		want      types.Hash
 	}{{
 		witnesses: [][][]byte{
 			[][]byte{
@@ -71,9 +72,9 @@ func TestCalcMerkleRoot(t *testing.T) {
 }
 
 func TestDuplicateLeaves(t *testing.T) {
-	var initialBlockHash bc.Hash
+	var initialBlockHash types.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1)
+	assetID := types.ComputeAssetID(trueProg, initialBlockHash, 1, 1)
 	txs := make([]*bc.Tx, 6)
 	for i := uint64(0); i < 6; i++ {
 		now := []byte(time.Now().String())
@@ -98,9 +99,9 @@ func TestDuplicateLeaves(t *testing.T) {
 }
 
 func TestAllDuplicateLeaves(t *testing.T) {
-	var initialBlockHash bc.Hash
+	var initialBlockHash types.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1)
+	assetID := types.ComputeAssetID(trueProg, initialBlockHash, 1, 1)
 	now := []byte(time.Now().String())
 	issuanceInp := bc.NewIssuanceInput(now, 1, nil, initialBlockHash, trueProg, nil)
 
@@ -124,8 +125,8 @@ func TestAllDuplicateLeaves(t *testing.T) {
 	}
 }
 
-func mustParseHash(s string) bc.Hash {
-	h, err := bc.ParseHash(s)
+func mustParseHash(s string) types.Hash {
+	h, err := types.ParseHash(s)
 	if err != nil {
 		panic(err)
 	}

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -12,6 +12,7 @@ import (
 	"chain/protocol/state"
 	"chain/protocol/vm"
 	"chain/protocol/vmutil"
+	"chain/types"
 )
 
 var (
@@ -31,7 +32,7 @@ var (
 // to the pool.
 //
 // ConfirmTx must not mutate the snapshot or the block.
-func ConfirmTx(snapshot *state.Snapshot, initialBlockHash bc.Hash, block *bc.Block, tx *bc.Tx) error {
+func ConfirmTx(snapshot *state.Snapshot, initialBlockHash types.Hash, block *bc.Block, tx *bc.Tx) error {
 	if block.Version == 1 && tx.Version != 1 {
 		return errors.WithDetailf(ErrBadTx, "unknown transaction version %d for block version 1", tx.Version)
 	}
@@ -125,7 +126,7 @@ func CheckTxWellFormed(tx *bc.Tx) error {
 	// Check that each input commitment appears only once. Also check that sums
 	// of inputs and outputs balance, and check that both input and output sums
 	// are less than 2^63 so that they don't overflow their int64 representation.
-	parity := make(map[bc.AssetID]int64)
+	parity := make(map[types.AssetID]int64)
 	commitments := make(map[string]int)
 
 	for i, txin := range tx.Inputs {

--- a/protocol/validation/tx_test.go
+++ b/protocol/validation/tx_test.go
@@ -10,12 +10,13 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/state"
 	"chain/protocol/vm"
+	"chain/types"
 )
 
 func TestUniqueIssuance(t *testing.T) {
-	var initialBlockHash bc.Hash
+	var initialBlockHash types.Hash
 	trueProg := []byte{byte(vm.OP_TRUE)}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1)
+	assetID := types.ComputeAssetID(trueProg, initialBlockHash, 1, 1)
 	now := time.Now()
 	issuanceInp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, trueProg, nil)
 
@@ -88,7 +89,7 @@ func TestUniqueIssuance(t *testing.T) {
 	}
 
 	true2Prog := []byte{byte(vm.OP_TRUE), byte(vm.OP_TRUE)}
-	asset2ID := bc.ComputeAssetID(true2Prog, initialBlockHash, 1)
+	asset2ID := types.ComputeAssetID(true2Prog, initialBlockHash, 1, 1)
 	issuance2Inp := bc.NewIssuanceInput(nil, 1, nil, initialBlockHash, true2Prog, nil)
 
 	// Transaction with empty nonce does not get added to issuance memory
@@ -167,12 +168,12 @@ func TestUniqueIssuance(t *testing.T) {
 }
 
 func TestTxWellFormed(t *testing.T) {
-	var initialBlockHash bc.Hash
+	var initialBlockHash types.Hash
 	issuanceProg := []byte{1}
-	aid1 := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1)
-	aid2 := bc.AssetID([32]byte{2})
-	txhash1 := bc.Hash{10}
-	txhash2 := bc.Hash{11}
+	aid1 := types.ComputeAssetID(issuanceProg, initialBlockHash, 1, 1)
+	aid2 := types.AssetID([32]byte{2})
+	txhash1 := types.Hash{10}
+	txhash2 := types.Hash{11}
 	trueProg := []byte{byte(vm.OP_TRUE)}
 
 	testCases := []struct {
@@ -235,7 +236,7 @@ func TestTxWellFormed(t *testing.T) {
 			tx: bc.TxData{
 				Version: 1,
 				Inputs: []*bc.TxInput{
-					bc.NewSpendInput(bc.Hash{}, 0, nil, aid1, 1000, nil, nil),
+					bc.NewSpendInput(types.Hash{}, 0, nil, aid1, 1000, nil, nil),
 				},
 				Outputs: []*bc.TxOutput{
 					bc.NewTxOutput(aid1, 1000, nil, nil),
@@ -279,7 +280,7 @@ func TestTxWellFormed(t *testing.T) {
 				MinTime: 2,
 				MaxTime: 1,
 				Inputs: []*bc.TxInput{
-					bc.NewSpendInput(bc.Hash{}, 0, nil, aid1, 1000, nil, nil),
+					bc.NewSpendInput(types.Hash{}, 0, nil, aid1, 1000, nil, nil),
 				},
 				Outputs: []*bc.TxOutput{
 					bc.NewTxOutput(aid1, 1000, nil, nil),
@@ -295,7 +296,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      1,
@@ -308,7 +309,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -328,7 +329,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      1,
@@ -341,7 +342,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -361,7 +362,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 2,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      1,
@@ -374,7 +375,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -394,7 +395,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      1,
@@ -407,7 +408,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 2,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -427,7 +428,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      2,
@@ -440,7 +441,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -460,7 +461,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      2,
@@ -473,7 +474,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      2,
@@ -493,7 +494,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      1,
@@ -506,7 +507,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -527,7 +528,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 2,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      1,
@@ -540,7 +541,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -561,7 +562,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      1,
@@ -574,7 +575,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 2,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -595,7 +596,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      2,
@@ -608,7 +609,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -628,7 +629,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      1,
@@ -641,7 +642,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      2,
@@ -662,7 +663,7 @@ func TestTxWellFormed(t *testing.T) {
 						AssetVersion: 1,
 						TypedInput: &bc.SpendInput{
 							OutputCommitment: bc.OutputCommitment{
-								AssetAmount: bc.AssetAmount{
+								AssetAmount: types.AssetAmount{
 									Amount: 1,
 								},
 								VMVersion:      1,
@@ -675,7 +676,7 @@ func TestTxWellFormed(t *testing.T) {
 					{
 						AssetVersion: 1,
 						OutputCommitment: bc.OutputCommitment{
-							AssetAmount: bc.AssetAmount{
+							AssetAmount: types.AssetAmount{
 								Amount: 1,
 							},
 							VMVersion:      1,
@@ -702,9 +703,9 @@ func TestTxWellFormed(t *testing.T) {
 }
 
 func TestValidateInvalidIssuances(t *testing.T) {
-	var initialBlockHash bc.Hash
+	var initialBlockHash types.Hash
 	issuanceProg := []byte{1}
-	aid := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1)
+	aid := types.ComputeAssetID(issuanceProg, initialBlockHash, 1, 1)
 	now := time.Now()
 
 	wrongInitialBlockHash := initialBlockHash

--- a/protocol/vm/crypto_test.go
+++ b/protocol/vm/crypto_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 func TestCheckSig(t *testing.T) {
@@ -86,7 +87,7 @@ func TestCheckSig(t *testing.T) {
 
 func TestCryptoOps(t *testing.T) {
 	tx := bc.NewTx(bc.TxData{
-		Inputs:  []*bc.TxInput{bc.NewSpendInput(bc.Hash{}, 0, nil, bc.AssetID{}, 5, nil, nil)},
+		Inputs:  []*bc.TxInput{bc.NewSpendInput(types.Hash{}, 0, nil, types.AssetID{}, 5, nil, nil)},
 		Outputs: []*bc.TxOutput{},
 	})
 

--- a/protocol/vm/introspection_test.go
+++ b/protocol/vm/introspection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 func TestNextProgram(t *testing.T) {
@@ -86,11 +87,11 @@ func TestBlockTime(t *testing.T) {
 }
 
 func TestOutpointAndNonceOp(t *testing.T) {
-	var zeroHash bc.Hash
+	var zeroHash types.Hash
 	nonce := []byte{36, 37, 38}
 	tx := bc.NewTx(bc.TxData{
 		Inputs: []*bc.TxInput{
-			bc.NewSpendInput(zeroHash, 0, nil, bc.AssetID{1}, 5, []byte("spendprog"), []byte("ref")),
+			bc.NewSpendInput(zeroHash, 0, nil, types.AssetID{1}, 5, []byte("spendprog"), []byte("ref")),
 			bc.NewIssuanceInput(nonce, 6, nil, zeroHash, []byte("issueprog"), nil),
 		},
 	})
@@ -150,15 +151,15 @@ func TestIntrospectionOps(t *testing.T) {
 	tx := bc.NewTx(bc.TxData{
 		ReferenceData: []byte("txref"),
 		Inputs: []*bc.TxInput{
-			bc.NewSpendInput(bc.Hash{}, 0, nil, bc.AssetID{1}, 5, []byte("spendprog"), []byte("ref")),
-			bc.NewIssuanceInput(nil, 6, nil, bc.Hash{}, []byte("issueprog"), nil),
+			bc.NewSpendInput(types.Hash{}, 0, nil, types.AssetID{1}, 5, []byte("spendprog"), []byte("ref")),
+			bc.NewIssuanceInput(nil, 6, nil, types.Hash{}, []byte("issueprog"), nil),
 		},
 		Outputs: []*bc.TxOutput{
-			bc.NewTxOutput(bc.AssetID{3}, 8, []byte("wrongprog"), nil),
-			bc.NewTxOutput(bc.AssetID{3}, 8, []byte("controlprog"), nil),
-			bc.NewTxOutput(bc.AssetID{2}, 8, []byte("controlprog"), nil),
-			bc.NewTxOutput(bc.AssetID{2}, 7, []byte("controlprog"), nil),
-			bc.NewTxOutput(bc.AssetID{2}, 7, []byte("controlprog"), []byte("outref")),
+			bc.NewTxOutput(types.AssetID{3}, 8, []byte("wrongprog"), nil),
+			bc.NewTxOutput(types.AssetID{3}, 8, []byte("controlprog"), nil),
+			bc.NewTxOutput(types.AssetID{2}, 8, []byte("controlprog"), nil),
+			bc.NewTxOutput(types.AssetID{2}, 7, []byte("controlprog"), nil),
+			bc.NewTxOutput(types.AssetID{2}, 7, []byte("controlprog"), []byte("outref")),
 		},
 		MinTime: 0,
 		MaxTime: 20,

--- a/protocol/vm/vm_test.go
+++ b/protocol/vm/vm_test.go
@@ -11,6 +11,7 @@ import (
 
 	"chain/errors"
 	"chain/protocol/bc"
+	"chain/types"
 )
 
 type tracebuf struct {
@@ -181,10 +182,10 @@ func TestVerifyTxInput(t *testing.T) {
 		wantErr error
 	}{{
 		input: bc.NewSpendInput(
-			bc.Hash{},
+			types.Hash{},
 			0,
 			[][]byte{{2}, {3}},
-			bc.AssetID{},
+			types.AssetID{},
 			1,
 			[]byte{byte(OP_ADD), byte(OP_5), byte(OP_NUMEQUAL)},
 			nil,
@@ -195,7 +196,7 @@ func TestVerifyTxInput(t *testing.T) {
 			nil,
 			1,
 			nil,
-			bc.Hash{},
+			types.Hash{},
 			[]byte{byte(OP_ADD), byte(OP_5), byte(OP_NUMEQUAL)},
 			[][]byte{{2}, {3}},
 		),
@@ -221,7 +222,7 @@ func TestVerifyTxInput(t *testing.T) {
 			nil,
 			1,
 			nil,
-			bc.Hash{},
+			types.Hash{},
 			[]byte{byte(OP_ADD), byte(OP_5), byte(OP_NUMEQUAL)},
 			[][]byte{make([]byte, 50001)},
 		),
@@ -452,7 +453,7 @@ func TestVerifyTxInputQuickCheck(t *testing.T) {
 			}
 		}()
 		tx := bc.NewTx(bc.TxData{
-			Inputs: []*bc.TxInput{bc.NewSpendInput(bc.Hash{}, 0, witnesses, bc.AssetID{}, 10, program, nil)},
+			Inputs: []*bc.TxInput{bc.NewSpendInput(types.Hash{}, 0, witnesses, types.AssetID{}, 10, program, nil)},
 		})
 		verifyTxInput(tx, 0)
 		return true

--- a/types/asset.go
+++ b/types/asset.go
@@ -1,13 +1,12 @@
-package bc
+package types
 
 import (
 	"database/sql/driver"
+	"io"
 
 	"chain/crypto/sha3pool"
 	"chain/encoding/blockchain"
 )
-
-const assetVersion = 1
 
 // AssetID is the Hash256 of the issuance script for the asset and the
 // initial block of the chain where it appears.
@@ -22,7 +21,7 @@ func (a *AssetID) Scan(b interface{}) error     { return (*Hash)(a).Scan(b) }
 
 // ComputeAssetID computes the asset ID of the asset defined by
 // the given issuance program and initial block hash.
-func ComputeAssetID(issuanceProgram []byte, initialHash [32]byte, vmVersion uint64) (assetID AssetID) {
+func ComputeAssetID(issuanceProgram []byte, initialHash [32]byte, assetVersion, vmVersion uint64) (assetID AssetID) {
 	h := sha3pool.Get256()
 	defer sha3pool.Put256(h)
 	h.Write(initialHash[:])
@@ -31,4 +30,29 @@ func ComputeAssetID(issuanceProgram []byte, initialHash [32]byte, vmVersion uint
 	blockchain.WriteVarstr31(h, issuanceProgram) // TODO(bobg): check and return error
 	h.Read(assetID[:])
 	return assetID
+}
+
+type AssetAmount struct {
+	AssetID AssetID `json:"asset_id"`
+	Amount  uint64  `json:"amount"`
+}
+
+// assumes r has sticky errors
+func (a *AssetAmount) ReadFrom(r io.Reader) (int, error) {
+	n1, err := io.ReadFull(r, a.AssetID[:])
+	if err != nil {
+		return n1, err
+	}
+	var n2 int
+	a.Amount, n2, err = blockchain.ReadVarint63(r)
+	return n1 + n2, err
+}
+
+func (a *AssetAmount) WriteTo(w io.Writer) error {
+	_, err := w.Write(a.AssetID[:])
+	if err != nil {
+		return err
+	}
+	_, err = blockchain.WriteVarint63(w, a.Amount)
+	return err
 }

--- a/types/asset_test.go
+++ b/types/asset_test.go
@@ -1,6 +1,7 @@
-package bc
+package types
 
 import (
+	"encoding/hex"
 	"testing"
 
 	"golang.org/x/crypto/sha3"
@@ -9,7 +10,7 @@ import (
 func TestComputeAssetID(t *testing.T) {
 	issuanceScript := []byte{1}
 	initialBlockHash := mustDecodeHash("dd506f5d4c3f904d3d4b3c3be597c9198c6193ffd14a28570e4a923ce40cf9e5")
-	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1)
+	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1, 1)
 
 	unhashed := append([]byte{}, initialBlockHash[:]...)
 	unhashed = append(unhashed, 0x01) // assetVersion
@@ -32,6 +33,17 @@ func BenchmarkComputeAssetID(b *testing.B) {
 	)
 
 	for i := 0; i < b.N; i++ {
-		assetIDSink = ComputeAssetID(issuanceScript, initialBlockHash, 1)
+		assetIDSink = ComputeAssetID(issuanceScript, initialBlockHash, 1, 1)
 	}
+}
+
+func mustDecodeHash(hash string) (h [32]byte) {
+	if len(hash) != hex.EncodedLen(len(h)) {
+		panic("wrong length hash")
+	}
+	_, err := hex.Decode(h[:], []byte(hash))
+	if err != nil {
+		panic(err)
+	}
+	return h
 }

--- a/types/hash.go
+++ b/types/hash.go
@@ -1,4 +1,4 @@
-package bc
+package types
 
 import (
 	"bytes"
@@ -19,7 +19,7 @@ import (
 // typically passed as values, not as pointers.
 type Hash [32]byte
 
-var emptyHash = sha3.Sum256(nil)
+var EmptyHash = sha3.Sum256(nil)
 
 // String returns the bytes of h encoded in hex.
 func (h Hash) String() string {
@@ -97,12 +97,13 @@ func ParseHash(s string) (h Hash, err error) {
 	return h, errors.Wrap(err, "decode hex")
 }
 
-func writeFastHash(w io.Writer, d []byte) {
+func WriteFastHash(w io.Writer, d []byte) error {
 	if len(d) == 0 {
-		blockchain.WriteVarstr31(w, nil)
-		return
+		_, err := blockchain.WriteVarstr31(w, nil)
+		return err
 	}
 	var h [32]byte
 	sha3pool.Sum256(h[:], d)
-	blockchain.WriteVarstr31(w, h[:])
+	_, err := blockchain.WriteVarstr31(w, h[:])
+	return err
 }


### PR DESCRIPTION
This moves the types `Hash`, `AssetID`, and `AssetAmount` from the `protocol/bc` package to a new package (whose name is admittedly weak, suggestions welcome) in order to prevent a circular dependency when some other upcoming changes land.

It also requires callers to pass both the asset version and the vm version to `ComputeAssetID`, also in anticipation of upcoming changes.