### PR TITLE
core: fix Handler.init when unconfigured

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -137,7 +137,9 @@ func (h *Handler) init() {
 	m.Handle("/list-unspent-outputs", needConfig(h.listUnspentOutputs))
 	m.Handle("/reset", needConfig(h.reset))
 
-	m.Handle(networkRPCPrefix+"submit", needConfig(h.Submitter.Submit))
+	m.Handle(networkRPCPrefix+"submit", needConfig(func(ctx context.Context, tx *bc.Tx) error {
+		return h.Submitter.Submit(ctx, tx)
+	}))
 	m.Handle(networkRPCPrefix+"get-blocks", needConfig(h.getBlocksRPC)) // DEPRECATED: use get-block instead
 	m.Handle(networkRPCPrefix+"get-block", needConfig(h.getBlockRPC))
 	m.Handle(networkRPCPrefix+"get-snapshot-info", needConfig(h.getSnapshotInfoRPC))


### PR DESCRIPTION
If the Core is unconfigured, Submitter will be nil. Instead, wrap the
Submit call in a closure so that if the Core is unconfigured, we won't
try to access the Submitter's Submit method until we're processing a
request (and we shouldn't then either because requests will
be caught by the needConfig middleware).

The bug was introduced in #316.