### PR TITLE
protocol/bc: add input program accessor

### DIFF
--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -93,14 +93,14 @@ func (reg *Registry) indexAssets(ctx context.Context, b *bc.Block) error {
 			if seen[in.AssetID()] {
 				continue
 			}
-			definition, err := definitionFromProgram(in.IssuanceProgram())
+			definition, err := definitionFromProgram(in.Program())
 			if err != nil {
 				continue
 			}
 			seen[in.AssetID()] = true
 			assetIDs = append(assetIDs, in.AssetID().String())
 			definitions = append(definitions, string(definition))
-			issuancePrograms = append(issuancePrograms, in.IssuanceProgram())
+			issuancePrograms = append(issuancePrograms, in.Program())
 		}
 	}
 	if len(assetIDs) == 0 {

--- a/core/query/annotated.go
+++ b/core/query/annotated.go
@@ -46,11 +46,11 @@ func transactionInput(in *bc.TxInput) map[string]interface{} {
 	}
 	if in.IsIssuance() {
 		obj["type"] = "issue"
-		obj["issuance_program"] = hex.EncodeToString(in.IssuanceProgram())
+		obj["issuance_program"] = hex.EncodeToString(in.Program())
 	} else {
 		outpoint := in.Outpoint()
 		obj["type"] = "spend"
-		obj["control_program"] = hex.EncodeToString(in.ControlProgram())
+		obj["control_program"] = hex.EncodeToString(in.Program())
 		obj["spent_output"] = map[string]interface{}{
 			"transaction_id": outpoint.Hash.String(),
 			"position":       outpoint.Index,

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -121,20 +121,6 @@ func (t *TxInput) VMVersion() uint64 {
 	return t.TypedInput.vmVersion()
 }
 
-func (t *TxInput) ControlProgram() []byte {
-	if si, ok := t.TypedInput.(*SpendInput); ok {
-		return si.ControlProgram
-	}
-	return nil
-}
-
-func (t *TxInput) IssuanceProgram() []byte {
-	if ii, ok := t.TypedInput.(*IssuanceInput); ok {
-		return ii.IssuanceProgram
-	}
-	return nil
-}
-
 func (t *TxInput) Arguments() [][]byte {
 	switch inp := t.TypedInput.(type) {
 	case *IssuanceInput:

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -20,6 +20,8 @@ type (
 
 	TypedInput interface {
 		IsIssuance() bool
+		Program() []byte
+		vmVersion() uint64
 	}
 
 	SpendInput struct {
@@ -113,6 +115,10 @@ func (t *TxInput) Amount() uint64 {
 	}
 	si := t.TypedInput.(*SpendInput)
 	return si.Amount
+}
+
+func (t *TxInput) VMVersion() uint64 {
+	return t.TypedInput.vmVersion()
 }
 
 func (t *TxInput) ControlProgram() []byte {
@@ -347,10 +353,13 @@ func (t *TxInput) Outpoint() (o Outpoint) {
 	return o
 }
 
-func (si *SpendInput) IsIssuance() bool { return false }
+func (si *SpendInput) IsIssuance() bool  { return false }
+func (si *SpendInput) Program() []byte   { return si.ControlProgram }
+func (si *SpendInput) vmVersion() uint64 { return si.VMVersion }
 
-func (ii *IssuanceInput) IsIssuance() bool { return true }
-
+func (ii *IssuanceInput) IsIssuance() bool  { return true }
+func (ii *IssuanceInput) Program() []byte   { return ii.IssuanceProgram }
+func (ii *IssuanceInput) vmVersion() uint64 { return ii.VMVersion }
 func (ii *IssuanceInput) AssetID() AssetID {
 	return ComputeAssetID(ii.IssuanceProgram, ii.InitialBlock, ii.VMVersion)
 }

--- a/protocol/state/outputs.go
+++ b/protocol/state/outputs.go
@@ -27,7 +27,7 @@ func NewOutput(o bc.TxOutput, p bc.Outpoint) *Output {
 // excludes reference data).
 func Prevout(in *bc.TxInput) *Output {
 	assetAmount := in.AssetAmount()
-	t := bc.NewTxOutput(assetAmount.AssetID, assetAmount.Amount, in.ControlProgram(), nil)
+	t := bc.NewTxOutput(assetAmount.AssetID, assetAmount.Amount, in.Program(), nil)
 	return &Output{
 		Outpoint: in.Outpoint(),
 		TxOutput: *t,

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -222,13 +222,7 @@ func CheckTxWellFormed(tx *bc.Tx) error {
 		}
 		if err != nil {
 			input := tx.Inputs[i]
-			var program []byte
-			if input.IsIssuance() {
-				program = input.IssuanceProgram()
-			} else {
-				program = input.ControlProgram()
-			}
-			scriptStr, e := vm.Disassemble(program)
+			scriptStr, e := vm.Disassemble(input.Program())
 			if e != nil {
 				scriptStr = "disassembly failed: " + e.Error()
 			}

--- a/protocol/vm/introspection.go
+++ b/protocol/vm/introspection.go
@@ -118,16 +118,7 @@ func opProgram(vm *virtualMachine) error {
 		return err
 	}
 
-	var prog []byte
-	inp := vm.tx.Inputs[vm.inputIndex]
-	switch inp := inp.TypedInput.(type) {
-	case *bc.IssuanceInput:
-		prog = inp.IssuanceProgram
-	case *bc.SpendInput:
-		prog = inp.ControlProgram
-	}
-
-	return vm.push(prog, true)
+	return vm.push(vm.tx.Inputs[vm.inputIndex].Program(), true)
 }
 
 func opMinTime(vm *virtualMachine) error {

--- a/protocol/vm/vm.go
+++ b/protocol/vm/vm.go
@@ -55,20 +55,8 @@ func verifyTxInput(tx *bc.Tx, inputIndex int) (bool, error) {
 
 	txinput := tx.Inputs[inputIndex]
 
-	var program []byte
-	switch inp := txinput.TypedInput.(type) {
-	case *bc.IssuanceInput:
-		if inp.VMVersion != 1 {
-			return false, ErrUnsupportedVM
-		}
-		program = inp.IssuanceProgram
-	case *bc.SpendInput:
-		if inp.VMVersion != 1 {
-			return false, ErrUnsupportedVM
-		}
-		program = inp.ControlProgram
-	default:
-		return false, ErrUnsupportedTx
+	if txinput.VMVersion() != 1 {
+		return false, ErrUnsupportedVM
 	}
 
 	vm := virtualMachine{
@@ -76,7 +64,7 @@ func verifyTxInput(tx *bc.Tx, inputIndex int) (bool, error) {
 		inputIndex: inputIndex,
 		sigHasher:  bc.NewSigHasher(&tx.TxData),
 
-		program:  program,
+		program:  txinput.Program(),
 		runLimit: initialRunLimit,
 	}
 

--- a/protocol/vm/vm_test.go
+++ b/protocol/vm/vm_test.go
@@ -228,7 +228,7 @@ func TestVerifyTxInput(t *testing.T) {
 		wantErr: ErrRunLimitExceeded,
 	}, {
 		input:   &bc.TxInput{},
-		wantErr: ErrUnsupportedTx,
+		wantErr: ErrUnexpected,
 	}}
 
 	for i, c := range cases {


### PR DESCRIPTION
In general, callers do not care which type of input returned the program.
Make a generic program accessor to return the correct program based on type.