### PR TITLE
all: use testutil.FatalErr

### DIFF
--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -15,7 +15,6 @@ import (
 	"chain/core/txbuilder"
 	"chain/database/pg"
 	"chain/database/pg/pgtest"
-	"chain/errors"
 	"chain/protocol/bc"
 	"chain/protocol/mempool"
 	"chain/protocol/prottest"
@@ -55,8 +54,7 @@ func TestAccountSourceReserve(t *testing.T) {
 	var builder txbuilder.TemplateBuilder
 	err := source.Build(ctx, time.Now().Add(time.Minute), &builder)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 	tpl, err := builder.Build()
 	if err != nil {
@@ -107,8 +105,7 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 	var builder txbuilder.TemplateBuilder
 	err := source.Build(ctx, time.Now().Add(time.Minute), &builder)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 	tpl, err := builder.Build()
 	if err != nil {
@@ -163,8 +160,7 @@ func TestAccountSourceReserveIdempotency(t *testing.T) {
 
 		err := source.Build(ctx, time.Now().Add(time.Minute), &builder)
 		if err != nil {
-			t.Log(errors.Stack(err))
-			t.Fatal(err)
+			testutil.FatalErr(t, err)
 		}
 		tpl, err := builder.Build()
 		if err != nil {

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -253,16 +253,14 @@ func TestTransfer(t *testing.T) {
 		handler.Accounts.NewControlAction(issueAssetAmount, account1ID, nil),
 	}, time.Now().Add(time.Minute))
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	coretest.SignTxTemplate(t, ctx, txTemplate, nil)
 
 	err = txbuilder.FinalizeTx(ctx, c, p, bc.NewTx(*txTemplate.Transaction))
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	// Make a block so that UTXOs from the above tx are available to spend.
@@ -280,26 +278,22 @@ func TestTransfer(t *testing.T) {
 	var buildReq buildRequest
 	err = json.Unmarshal([]byte(buildReqStr), &buildReq)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	buildResult, err := handler.build(ctx, []*buildRequest{&buildReq})
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 	jsonResult, err := json.MarshalIndent(buildResult, "", "  ")
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	var parsedResult []map[string]interface{}
 	err = json.Unmarshal(jsonResult, &parsedResult)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 	if len(parsedResult) != 1 {
 		t.Errorf("expected build result to have length 1, got %d", len(parsedResult))
@@ -307,8 +301,7 @@ func TestTransfer(t *testing.T) {
 	toSign := inspectTemplate(t, parsedResult[0], account2ID)
 	txTemplate, err = toTxTemplate(ctx, toSign)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 	coretest.SignTxTemplate(t, ctx, txTemplate, &testutil.TestXPrv)
 	_, err = handler.submitSingle(ctx, txTemplate, "none")
@@ -326,25 +319,21 @@ func TestTransfer(t *testing.T) {
 	buildReqStr = fmt.Sprintf(buildReqFmt, assetAlias, account2Alias, assetAlias, account1Alias)
 	err = json.Unmarshal([]byte(buildReqStr), &buildReq)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	buildResult, err = handler.build(ctx, []*buildRequest{&buildReq})
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 	jsonResult, err = json.MarshalIndent(buildResult, "", "  ")
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	err = json.Unmarshal(jsonResult, &parsedResult)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 	if len(parsedResult) != 1 {
 		t.Errorf("expected build result to have length 1, got %d", len(parsedResult))
@@ -353,8 +342,7 @@ func TestTransfer(t *testing.T) {
 	txTemplate, err = toTxTemplate(ctx, toSign)
 	coretest.SignTxTemplate(t, ctx, txTemplate, &testutil.TestXPrv)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 	_, err = handler.submitSingle(ctx, txTemplate, "none")
 	if err != nil && errors.Root(err) != context.DeadlineExceeded {

--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -11,7 +11,6 @@ import (
 	"chain/core/pin"
 	"chain/core/txbuilder"
 	"chain/crypto/ed25519/chainkd"
-	"chain/errors"
 	"chain/protocol"
 	"chain/protocol/bc"
 	"chain/protocol/state"
@@ -73,8 +72,7 @@ func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuild
 func Transfer(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuilder.Submitter, actions []txbuilder.Action) *bc.Tx {
 	template, err := txbuilder.Build(ctx, nil, actions, time.Now().Add(time.Minute))
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	SignTxTemplate(t, ctx, template, &testutil.TestXPrv)
@@ -82,8 +80,7 @@ func Transfer(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuilder.
 	tx := bc.NewTx(*template.Transaction)
 	err = txbuilder.FinalizeTx(ctx, c, s, tx)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	return tx

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -66,8 +66,7 @@ func TestBuild(t *testing.T) {
 	expiryTime := time.Now().Add(time.Minute)
 	got, err := Build(ctx, nil, actions, expiryTime)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	want := &Template{
@@ -164,7 +163,7 @@ func TestMaterializeWitnesses(t *testing.T) {
 
 	err = materializeWitnesses(tpl)
 	if err != nil {
-		t.Fatal(withStack(err))
+		testutil.FatalErr(t, err)
 	}
 
 	got := tpl.Transaction.Inputs[0].Arguments()
@@ -245,7 +244,7 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 	}}
 	err = materializeWitnesses(tpl)
 	if err != nil {
-		t.Fatal(withStack(err))
+		testutil.FatalErr(t, err)
 	}
 	got := tpl.Transaction.Inputs[0].Arguments()
 	if !reflect.DeepEqual(got, want) {
@@ -260,20 +259,12 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 	component.Sigs = []json.HexBytes{sig1, sig2}
 	err = materializeWitnesses(tpl)
 	if err != nil {
-		t.Fatal(withStack(err))
+		testutil.FatalErr(t, err)
 	}
 	got = tpl.Transaction.Inputs[0].Arguments()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got input witness %v, want input witness %v", got, want)
 	}
-}
-
-func withStack(err error) string {
-	s := err.Error()
-	for _, frame := range errors.Stack(err) {
-		s += "\n" + frame.String()
-	}
-	return s
 }
 
 func mustDecodeHex(str string) []byte {

--- a/core/txdb/txdb_test.go
+++ b/core/txdb/txdb_test.go
@@ -10,6 +10,7 @@ import (
 	"chain/database/sql"
 	"chain/errors"
 	"chain/protocol/bc"
+	"chain/testutil"
 )
 
 func TestGetBlock(t *testing.T) {
@@ -87,14 +88,12 @@ func TestInsertBlock(t *testing.T) {
 	}
 	err := NewStore(dbtx).SaveBlock(ctx, blk)
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 
 	// block in database
 	_, err = getBlockByHash(ctx, dbtx, blk.Hash().String())
 	if err != nil {
-		t.Log(errors.Stack(err))
-		t.Fatal(err)
+		testutil.FatalErr(t, err)
 	}
 }

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"chain/errors"
 	"chain/protocol/bc"
 	"chain/protocol/mempool"
 	"chain/protocol/memstore"
@@ -166,8 +165,7 @@ func TestGenerateBlock(t *testing.T) {
 	for _, tx := range txs {
 		err := p.Submit(ctx, tx)
 		if err != nil {
-			t.Log(errors.Stack(err))
-			t.Fatal(err)
+			testutil.FatalErr(t, err)
 		}
 	}
 


### PR DESCRIPTION
Replace uses of:
```
t.Log(errors.Stack(err))
t.Fatal(err)
```

with:
```
testutil.FatalErr(t, err)
```