### PR TITLE
docs/protocol: remove block witness from under the block ID

### DIFF
--- a/docs/protocol/papers/whitepaper.md
+++ b/docs/protocol/papers/whitepaper.md
@@ -150,7 +150,7 @@ The `CHECKOUTPUT` instruction provides functionality similar to the `CHECKOUTPUT
 
 [/sidenote]
 
-The protocol also specifies several *block introspection* instructions (`BLOCKSIGHASH`, `NEXTPROGRAM`). These instructions can only be used in consensus programs (since transactions must be capable of being validated independently of the block header).
+The protocol also specifies several *block introspection* instructions (`BLOCKHASH`, `NEXTPROGRAM`). These instructions can only be used in consensus programs (since transactions must be capable of being validated independently of the block header).
 
 #### Control flow
 
@@ -172,7 +172,7 @@ The Chain Protocol’s approach to federated consensus is similar to one describ
 
 [/sidenote]
 
-A consensus program specifies a set of N public keys and uses the `CHECKMULTISIG` and `BLOCKSIGHASH` instructions to confirm that the block witness includes M valid signatures on the block hash (where M and N are parameters of the algorithm).
+A consensus program specifies a set of N public keys and uses the `CHECKMULTISIG` and `BLOCKHASH` instructions to confirm that the block witness includes M valid signatures on the block hash (where M and N are parameters of the algorithm).
 
 Each public key corresponds to a block signer. Block signers should never sign two different blocks with the same height. As long as no more than 2M - N - 1 block signers violate this rule, the blockchain cannot be forked.
 

--- a/docs/protocol/specifications/consensus.md
+++ b/docs/protocol/specifications/consensus.md
@@ -181,8 +181,8 @@ See also the note in the [Make Block](#make-block) algorithm.
         3. Every [input witness](data.md#transaction-input-witness) must contain only the fields defined in this version of the protocol (no additional data included).
         4. Every [output witness](data.md#transaction-output-witness) must be empty.
 6. Check that the block's timestamp is less than 2 minutes after the system time. If it is not, halt and return nothing.
-7. Compute the [block signature hash](data.md#block-signature-hash) for the block.
-8. Sign the signature hash with the signing key, yielding a [signature](data.md#signature).
+7. Compute the [block hash](data.md#block-id) for the block.
+8. Sign the hash with the signing key, yielding a [signature](data.md#signature).
 9. Replace the last signed block with the input block.
 10. Return the signature.
 

--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -17,7 +17,6 @@
   * [Block Commitment](#block-commitment)
   * [Block Witness](#block-witness)
   * [Block ID](#block-id)
-  * [Block Signature Hash](#block-signature-hash)
   * [Transaction](#transaction)
   * [Transaction Common Fields](#transaction-common-fields)
   * [Transaction Common Witness](#transaction-common-witness)
@@ -134,7 +133,7 @@ Non-zero **higher bits** and value 0x02 are reserved for future use.
 
 Serialization Flags Examples | Description
 -----------------------------|---------------------------
-0000 0000                    | Block with neither witness nor transactions. Used in [block signature hash](#block-signature-hash).
+0000 0000                    | Block with neither witness nor transactions. Used in [block ID](#block-id).
 0000 0001                    | Block with witness but without transactions. Also called a “[block header](#block-header)”.
 0000 0011                    | Block with both witness and transactions. Also called simply a “[block](#block)”.
 0000 0010                    | Reserved for future use.
@@ -172,17 +171,13 @@ Program Arguments Count | varint31      | Number of [program arguments](#program
 Program Arguments       | [varstring31] | List of [signatures](#signature) and other data satisfying previous block’s [next consensus program](#consensus-program).
 —                       | —             | Additional fields may be added by future extensions.
 
-The entire witness data string (including any unsupported fields) is excluded from the [block’s signature hash](#block-signature-hash).
+The entire witness data string (including any unsupported fields) is excluded from the [block’s ID](#block-id).
 
 
 ### Block ID
 
-The *block ID* (also called *block hash*) is defined as [SHA3-256](#sha3) of the block serialized with 0x01 [serialization flags](#block-serialization-flags). This covers all header data including the block witness and the transactions’ merkle root, but it excludes transactions themselves.
+The *block ID* (also called *block hash*) is defined as [SHA3-256](#sha3) of the block serialized with 0x00 [serialization flags](#block-serialization-flags). This covers header data excluding the block witness, but including the [transactions’ merkle root](#transactions-merkle-root).
 
-
-### Block Signature Hash
-
-The *block signature hash* is defined as [SHA3-256](#sha3) of the block serialized with 0x00 [serialization flags](#block-serialization-flags). This covers header data excluding the block witness, but including the [transactions’ merkle root](#transactions-merkle-root).
 
 ### Transaction
 

--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -63,7 +63,7 @@ Blocks use [consensus programs](data.md#consensus-program) to define predicates 
 
 ### Block context
 
-Block context is defined by the block necessary for [BLOCKSIGHASH](#blocksighash), [NEXTPROGRAM](#nextprogram) and [BLOCKTIME](#blocktime) execution.
+Block context is defined by the block necessary for [BLOCKHASH](#blockhash), [NEXTPROGRAM](#nextprogram) and [BLOCKTIME](#blocktime) execution.
 
 Instruction [PROGRAM](#program) behaves differently than in transaction context.
 
@@ -88,7 +88,7 @@ Transaction context is defined by the pair of the entire transaction and the ind
 
 Execution of any of the following instructions results in immediate failure:
 
-* [BLOCKSIGHASH](#blocksighash)
+* [BLOCKHASH](#blockhash)
 * [NEXTPROGRAM](#nextprogram)
 * [BLOCKTIME](#blocktime)
 
@@ -1073,13 +1073,13 @@ Typically used with [CHECKSIG](#checksig) or [CHECKMULTISIG](#checkmultisig).
 Fails if executed in the [block context](#block-context).
 
 
-#### BLOCKSIGHASH
+#### BLOCKHASH
 
 Code  | Stack Diagram                  | Cost
 ------|--------------------------------|-----------------------------------------------------
 0xaf  | (∅ → hash)                     | 4·L<sub>hashed data</sub> + [standard memory cost](#standard-memory-cost)
 
-Returns the [block signature hash](data.md#block-signature-hash).
+Returns the [block ID](data.md#block-id).
 
 Typically used with [CHECKSIG](#checksig) or [CHECKMULTISIG](#checkmultisig).
 


### PR DESCRIPTION
This makes block hash (aka "block ID") not subject to block witness malleability. 

Rationale: turns out, when the block is agreed upon in a fully decentralized manner (e.g. any BFT consensus protocol), not via a assumed-to-be-alive generator, then nodes would require another round of agreement on _which_ combination of public signatures to commit to. What's worse, alternative combinations may be propagated quicker to other nodes that must be then ready to re-assign witnesses when later blocks arrive to keep on the same blockchain. 

Removing signatures from the chain of hashes eliminates this problem. Note that other nodes consuming the chain of headers or full blocks are still required to also receive and process witness data to authenticate the chain. Each block's witness still authenticates the entire blockchain under it.