### PR TITLE
core/txbuilder: improve signature witness signing perf

### DIFF
--- a/core/txbuilder/witness.go
+++ b/core/txbuilder/witness.go
@@ -130,9 +130,9 @@ func (sw *SignatureWitness) Sign(ctx context.Context, tpl *Template, index uint3
 		if !contains(xpubs, keyID.XPub) {
 			continue
 		}
-		var path [][]byte
-		for _, p := range keyID.DerivationPath {
-			path = append(path, p)
+		path := make([]([]byte), len(keyID.DerivationPath))
+		for i, p := range keyID.DerivationPath {
+			path[i] = p
 		}
 		sigBytes, err := signFn(ctx, keyID.XPub, path, h)
 		if err != nil {


### PR DESCRIPTION
Working on improving TransferWithBlocks, and this is a tiny fix. 

Before
```
BenchmarkTransferWithBlocks-4   	     200	  31896144 ns/op	   61624 B/op	     919 allocs/op
```

After
```
BenchmarkTransferWithBlocks-4   	     300	  25861102 ns/op	   67099 B/op	     913 allocs/op
```

