### PR TITLE
core/txbuilder: remove maxTime Build parameter

### DIFF
--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -3,7 +3,6 @@ package account
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"chain/core/signers"
 	"chain/core/txbuilder"
@@ -37,7 +36,7 @@ type spendAction struct {
 	ClientToken   *string       `json:"client_token"`
 }
 
-func (a *spendAction) Build(ctx context.Context, maxTime time.Time, b *txbuilder.TemplateBuilder) error {
+func (a *spendAction) Build(ctx context.Context, b *txbuilder.TemplateBuilder) error {
 	var missing []string
 	if a.AccountID == "" {
 		missing = append(missing, "account_id")
@@ -58,7 +57,7 @@ func (a *spendAction) Build(ctx context.Context, maxTime time.Time, b *txbuilder
 		AssetID:   a.AssetID,
 		AccountID: a.AccountID,
 	}
-	res, err := a.accounts.utxoDB.Reserve(ctx, src, a.Amount, a.ClientToken, maxTime)
+	res, err := a.accounts.utxoDB.Reserve(ctx, src, a.Amount, a.ClientToken, b.MaxTime())
 	if err != nil {
 		return errors.Wrap(err, "reserving utxos")
 	}
@@ -117,7 +116,7 @@ type spendUTXOAction struct {
 	ClientToken   *string       `json:"client_token"`
 }
 
-func (a *spendUTXOAction) Build(ctx context.Context, maxTime time.Time, b *txbuilder.TemplateBuilder) error {
+func (a *spendUTXOAction) Build(ctx context.Context, b *txbuilder.TemplateBuilder) error {
 	var missing []string
 	if a.TxHash == nil {
 		missing = append(missing, "transaction_id")
@@ -130,7 +129,7 @@ func (a *spendUTXOAction) Build(ctx context.Context, maxTime time.Time, b *txbui
 	}
 
 	out := bc.Outpoint{Hash: *a.TxHash, Index: *a.TxOut}
-	res, err := a.accounts.utxoDB.ReserveUTXO(ctx, out, a.ClientToken, maxTime)
+	res, err := a.accounts.utxoDB.ReserveUTXO(ctx, out, a.ClientToken, b.MaxTime())
 	if err != nil {
 		return err
 	}
@@ -198,7 +197,7 @@ type controlAction struct {
 	ReferenceData chainjson.Map `json:"reference_data"`
 }
 
-func (a *controlAction) Build(ctx context.Context, maxTime time.Time, b *txbuilder.TemplateBuilder) error {
+func (a *controlAction) Build(ctx context.Context, b *txbuilder.TemplateBuilder) error {
 	var missing []string
 	if a.AccountID == "" {
 		missing = append(missing, "account_id")

--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"reflect"
 	"testing"
-	"time"
 
 	"chain/core/account"
 	"chain/core/asset"
@@ -52,7 +51,7 @@ func TestAccountSourceReserve(t *testing.T) {
 	source := accounts.NewSpendAction(assetAmount1, accID, nil, nil)
 
 	var builder txbuilder.TemplateBuilder
-	err := source.Build(ctx, time.Now().Add(time.Minute), &builder)
+	err := source.Build(ctx, &builder)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -103,7 +102,7 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 	source := accounts.NewSpendUTXOAction(out.Outpoint)
 
 	var builder txbuilder.TemplateBuilder
-	err := source.Build(ctx, time.Now().Add(time.Minute), &builder)
+	err := source.Build(ctx, &builder)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -158,7 +157,7 @@ func TestAccountSourceReserveIdempotency(t *testing.T) {
 	reserveFunc := func(source txbuilder.Action) []*bc.TxInput {
 		var builder txbuilder.TemplateBuilder
 
-		err := source.Build(ctx, time.Now().Add(time.Minute), &builder)
+		err := source.Build(ctx, &builder)
 		if err != nil {
 			testutil.FatalErr(t, err)
 		}

--- a/core/asset/builder.go
+++ b/core/asset/builder.go
@@ -34,7 +34,7 @@ type issueAction struct {
 	ReferenceData chainjson.Map `json:"reference_data"`
 }
 
-func (a *issueAction) Build(ctx context.Context, maxTime time.Time, builder *txbuilder.TemplateBuilder) error {
+func (a *issueAction) Build(ctx context.Context, builder *txbuilder.TemplateBuilder) error {
 	if a.AssetID == (bc.AssetID{}) {
 		return txbuilder.MissingFieldsError("asset_id")
 	}
@@ -59,6 +59,6 @@ func (a *issueAction) Build(ctx context.Context, maxTime time.Time, builder *txb
 	keyIDs := txbuilder.KeyIDs(asset.Signer.XPubs, path)
 	tplIn.AddWitnessKeys(keyIDs, asset.Signer.Quorum)
 
-	builder.RestrictMinTimeMS(bc.Millis(time.Now()))
+	builder.RestrictMinTime(time.Now())
 	return builder.AddInput(txin, tplIn)
 }

--- a/core/txbuilder/actions.go
+++ b/core/txbuilder/actions.go
@@ -3,7 +3,6 @@ package txbuilder
 import (
 	"context"
 	stdjson "encoding/json"
-	"time"
 
 	"chain/encoding/json"
 	"chain/protocol/bc"
@@ -21,7 +20,7 @@ type controlProgramAction struct {
 	ReferenceData json.Map      `json:"reference_data"`
 }
 
-func (a *controlProgramAction) Build(ctx context.Context, maxTime time.Time, b *TemplateBuilder) error {
+func (a *controlProgramAction) Build(ctx context.Context, b *TemplateBuilder) error {
 	var missing []string
 	if len(a.Program) == 0 {
 		missing = append(missing, "control_program")
@@ -47,7 +46,7 @@ type setTxRefDataAction struct {
 	Data json.Map `json:"reference_data"`
 }
 
-func (a *setTxRefDataAction) Build(ctx context.Context, maxTime time.Time, b *TemplateBuilder) error {
+func (a *setTxRefDataAction) Build(ctx context.Context, b *TemplateBuilder) error {
 	if len(a.Data) == 0 {
 		return MissingFieldsError("reference_data")
 	}

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -37,7 +37,7 @@ func Build(ctx context.Context, tx *bc.TxData, actions []Action, maxTime time.Ti
 	// Build all of the actions, updating the builder.
 	var errs []error
 	for i, action := range actions {
-		err := action.Build(ctx, maxTime, &builder)
+		err := action.Build(ctx, &builder)
 		if err != nil {
 			err = errors.WithData(err, "index", i)
 			errs = append(errs, err)

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -24,7 +24,7 @@ import (
 
 type testAction bc.AssetAmount
 
-func (t testAction) Build(ctx context.Context, maxTime time.Time, b *TemplateBuilder) error {
+func (t testAction) Build(ctx context.Context, b *TemplateBuilder) error {
 	in := bc.NewSpendInput([32]byte{255}, 0, nil, t.AssetID, t.Amount, nil, nil)
 	tplIn := &SigningInstruction{}
 

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -3,7 +3,6 @@ package txbuilder
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"chain/errors"
 	"chain/protocol/bc"
@@ -71,10 +70,5 @@ func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 }
 
 type Action interface {
-	// TODO(bobg, jeffomatic): see if there is a way to remove the maxTime
-	// parameter from the build call. One possibility would be to treat TTL as
-	// a transaction-wide default parameter that gets folded into actions that
-	// care about it. This could happen when the build request is being
-	// deserialized.
-	Build(context.Context, time.Time, *TemplateBuilder) error
+	Build(context.Context, *TemplateBuilder) error
 }


### PR DESCRIPTION
Remove the maxTime parameter from the Build method on the Action
interface. Instead, provide a `MaxTime` method on the `TemplateBuilder`.

Also, changes `RestrictMinTimeMS` to `RestrictMinTime` so that both
min and max times operate on time structs.