### PR TITLE
core/generator: collect pool txs on Generator

### DIFF
--- a/core/generator/block.go
+++ b/core/generator/block.go
@@ -39,11 +39,16 @@ func recordSince(t0 time.Time) {
 
 // makeBlock generates a new bc.Block, collects the required signatures
 // and commits the block to the blockchain.
-func (g *generator) makeBlock(ctx context.Context) error {
+func (g *Generator) makeBlock(ctx context.Context) error {
 	t0 := time.Now()
 	defer recordSince(t0)
 
-	txs := g.pool.Dump(ctx)
+	g.mu.Lock()
+	txs := g.pool
+	g.pool = nil
+	g.poolHashes = make(map[bc.Hash]bool)
+	g.mu.Unlock()
+
 	b, s, err := g.chain.GenerateBlock(ctx, g.latestBlock, g.latestSnapshot, time.Now(), txs)
 	if err != nil {
 		return errors.Wrap(err, "generate")
@@ -58,7 +63,7 @@ func (g *generator) makeBlock(ctx context.Context) error {
 	return g.commitBlock(ctx, b, s)
 }
 
-func (g *generator) commitBlock(ctx context.Context, b *bc.Block, s *state.Snapshot) error {
+func (g *Generator) commitBlock(ctx context.Context, b *bc.Block, s *state.Snapshot) error {
 	err := g.getAndAddBlockSignatures(ctx, b, g.latestBlock)
 	if err != nil {
 		return errors.Wrap(err, "sign")
@@ -74,7 +79,7 @@ func (g *generator) commitBlock(ctx context.Context, b *bc.Block, s *state.Snaps
 	return nil
 }
 
-func (g *generator) getAndAddBlockSignatures(ctx context.Context, b, prevBlock *bc.Block) error {
+func (g *Generator) getAndAddBlockSignatures(ctx context.Context, b, prevBlock *bc.Block) error {
 	if prevBlock == nil && b.Height == 1 {
 		return nil // no signatures needed for initial block
 	}

--- a/core/generator/generator.go
+++ b/core/generator/generator.go
@@ -6,13 +6,13 @@ package generator
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"chain/database/pg"
 	"chain/log"
 	"chain/protocol"
 	"chain/protocol/bc"
-	"chain/protocol/mempool"
 	"chain/protocol/state"
 	"chain/protocol/validation"
 )
@@ -25,13 +25,17 @@ type BlockSigner interface {
 	SignBlock(context.Context, *bc.Block) (signature []byte, err error)
 }
 
-// generator produces new blocks on an interval.
-type generator struct {
+// Generator collects pending transactions and produces new blocks on
+// an interval.
+type Generator struct {
 	// config
 	db      pg.DB
 	chain   *protocol.Chain
-	pool    *mempool.MemPool
 	signers []BlockSigner
+
+	mu         sync.Mutex
+	pool       []*bc.Tx // in topological order
+	poolHashes map[bc.Hash]bool
 
 	// latestBlock and latestSnapshot are current as long as this
 	// process remains the leader process. If the process is demoted,
@@ -41,35 +45,51 @@ type generator struct {
 	latestSnapshot *state.Snapshot
 }
 
+// New creates and initializes a new Generator.
+func New(
+	c *protocol.Chain,
+	s []BlockSigner,
+	db pg.DB,
+) *Generator {
+	return &Generator{
+		db:         db,
+		chain:      c,
+		signers:    s,
+		poolHashes: make(map[bc.Hash]bool),
+	}
+}
+
+// Submit adds a new pending tx to the pending tx pool.
+func (g *Generator) Submit(ctx context.Context, tx *bc.Tx) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if g.poolHashes[tx.Hash] {
+		return nil
+	}
+
+	g.poolHashes[tx.Hash] = true
+	g.pool = append(g.pool, tx)
+	return nil
+}
+
 // Generate runs in a loop, making one new block
 // every block period. It returns when its context
 // is canceled.
 // After each attempt to make a block, it calls health
 // to report either an error or nil to indicate success.
-func Generate(
+func (g *Generator) Generate(
 	ctx context.Context,
-	c *protocol.Chain,
-	pool *mempool.MemPool,
-	s []BlockSigner,
-	db pg.DB,
 	period time.Duration,
 	health func(error),
 ) {
 	// This process just became leader, so it's responsible
 	// for recovering after the previous leader's exit.
-	recoveredBlock, recoveredSnapshot, err := c.Recover(ctx)
+	recoveredBlock, recoveredSnapshot, err := g.chain.Recover(ctx)
 	if err != nil {
 		log.Fatal(ctx, log.KeyError, err)
 	}
-
-	g := &generator{
-		db:             db,
-		chain:          c,
-		pool:           pool,
-		signers:        s,
-		latestBlock:    recoveredBlock,
-		latestSnapshot: recoveredSnapshot,
-	}
+	g.latestBlock, g.latestSnapshot = recoveredBlock, recoveredSnapshot
 
 	// Check to see if we already have a pending, generated block.
 	// This can happen if the leader process exits between generating

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -47,6 +47,12 @@ func (c *Chain) GenerateBlock(ctx context.Context, prev *bc.Block, snapshot *sta
 		return nil, nil, fmt.Errorf("timestamp %d is earlier than prevblock timestamp %d", timestampMS, prev.TimestampMS)
 	}
 
+	// Topologically sort the transactions, if needed.
+	if !isTopSorted(txs) {
+		log.Messagef(ctx, "set of %d txs not in topo order; sorting", len(txs))
+		txs = topSort(txs)
+	}
+
 	// Make a copy of the state that we can apply our changes to.
 	result = state.Copy(snapshot)
 	result.PruneIssuances(timestampMS)

--- a/protocol/mempool/mempool.go
+++ b/protocol/mempool/mempool.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"sync"
 
-	"chain/log"
 	"chain/protocol/bc"
 )
 
@@ -43,14 +42,9 @@ func (m *MemPool) Submit(ctx context.Context, tx *bc.Tx) error {
 // empties the pool.
 func (m *MemPool) Dump(ctx context.Context) []*bc.Tx {
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	txs := m.pool
 	m.pool = nil
 	m.hashes = make(map[bc.Hash]bool)
-	m.mu.Unlock()
-
-	if !isTopSorted(txs) {
-		log.Messagef(ctx, "set of %d txs not in topo order; sorting", len(txs))
-		txs = topSort(txs)
-	}
 	return txs
 }

--- a/protocol/sort.go
+++ b/protocol/sort.go
@@ -1,4 +1,4 @@
-package mempool
+package protocol
 
 import "chain/protocol/bc"
 


### PR DESCRIPTION
Collect pending transactions on the generator struct instead of a
separate type. Since Generator now implements the `txbuilder.Submitter`,
we can incrementally build blocks as new transactions are submitted.
The protocol/mempool type still exists for tests.

Future work:
* use generator.Generator in core/ tests where possible
* move protocol/mempool type into protocol/prottest
* incrementally build blocks as transactions are submitted