### PR TITLE
core: use strings instead of string pointers for client tokens

### DIFF
--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -88,7 +88,7 @@ type Account struct {
 }
 
 // Create creates a new Account.
-func (m *Manager) Create(ctx context.Context, xpubs []string, quorum int, alias string, tags map[string]interface{}, clientToken *string) (*Account, error) {
+func (m *Manager) Create(ctx context.Context, xpubs []string, quorum int, alias string, tags map[string]interface{}, clientToken string) (*Account, error) {
 	signer, err := signers.Create(ctx, m.db, "account", xpubs, quorum, clientToken)
 	if err != nil {
 		return nil, errors.Wrap(err)

--- a/core/account/accounts_test.go
+++ b/core/account/accounts_test.go
@@ -20,7 +20,7 @@ func TestCreateAccount(t *testing.T) {
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 
-	account, err := m.Create(ctx, []string{dummyXPub}, 1, "", nil, nil)
+	account, err := m.Create(ctx, []string{dummyXPub}, 1, "", nil, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -43,11 +43,11 @@ func TestCreateAccountIdempotency(t *testing.T) {
 	ctx := context.Background()
 	var clientToken = "a-unique-client-token"
 
-	account1, err := m.Create(ctx, []string{dummyXPub}, 1, "satoshi", nil, &clientToken)
+	account1, err := m.Create(ctx, []string{dummyXPub}, 1, "satoshi", nil, clientToken)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
-	account2, err := m.Create(ctx, []string{dummyXPub}, 1, "satoshi", nil, &clientToken)
+	account2, err := m.Create(ctx, []string{dummyXPub}, 1, "satoshi", nil, clientToken)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -62,7 +62,7 @@ func TestCreateAccountReusedAlias(t *testing.T) {
 	ctx := context.Background()
 	m.createTestAccount(ctx, t, "some-account", nil)
 
-	_, err := m.Create(ctx, []string{dummyXPub}, 1, "some-account", nil, nil)
+	_, err := m.Create(ctx, []string{dummyXPub}, 1, "some-account", nil, "")
 	if errors.Root(err) != ErrDuplicateAlias {
 		t.Errorf("Expected %s when reusing an alias, got %v", ErrDuplicateAlias, err)
 	}
@@ -74,7 +74,7 @@ func TestCreateControlProgram(t *testing.T) {
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 
-	account, err := m.Create(ctx, []string{dummyXPub}, 1, "", nil, nil)
+	account, err := m.Create(ctx, []string{dummyXPub}, 1, "", nil, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -95,7 +95,7 @@ func TestCreateControlProgram(t *testing.T) {
 }
 
 func (m *Manager) createTestAccount(ctx context.Context, t testing.TB, alias string, tags map[string]interface{}) *Account {
-	account, err := m.Create(ctx, []string{dummyXPub}, 1, alias, tags, nil)
+	account, err := m.Create(ctx, []string{dummyXPub}, 1, alias, tags, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/core/accounts.go
+++ b/core/accounts.go
@@ -34,7 +34,7 @@ func (h *Handler) createAccount(ctx context.Context, ins []struct {
 	// should have a unique client token. The client token is used to ensure
 	// idempotency of create account requests. Duplicate create account requests
 	// with the same client_token will only create one account.
-	ClientToken *string `json:"client_token"`
+	ClientToken string `json:"client_token"`
 }) interface{} {
 	responses := make([]interface{}, len(ins))
 	var wg sync.WaitGroup

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -37,7 +37,7 @@ func TestBuildFinal(t *testing.T) {
 	accounts.IndexAccounts(query.NewIndexer(db, c, pinStore))
 	go accounts.ProcessBlocks(ctx)
 
-	acc, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, nil)
+	acc, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func TestAccountTransfer(t *testing.T) {
 	accounts.IndexAccounts(query.NewIndexer(db, c, pinStore))
 	go accounts.ProcessBlocks(ctx)
 
-	acc, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, nil)
+	acc, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/asset/annotate_test.go
+++ b/core/asset/annotate_test.go
@@ -17,13 +17,13 @@ func TestAnnotateTxs(t *testing.T) {
 	tags1 := map[string]interface{}{"foo": "bar"}
 	def1 := map[string]interface{}{"baz": "bar"}
 
-	asset1, err := reg.Define(ctx, []string{testutil.TestXPub.String()}, 1, def1, "", tags1, nil)
+	asset1, err := reg.Define(ctx, []string{testutil.TestXPub.String()}, 1, def1, "", tags1, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tags2 := map[string]interface{}{"foo": "baz"}
-	asset2, err := reg.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", tags2, nil)
+	asset2, err := reg.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", tags2, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/asset/asset_test.go
+++ b/core/asset/asset_test.go
@@ -15,7 +15,7 @@ func TestDefineAsset(t *testing.T) {
 	ctx := context.Background()
 
 	keys := []string{testutil.TestXPub.String()}
-	asset, err := r.Define(ctx, keys, 1, nil, "", nil, nil)
+	asset, err := r.Define(ctx, keys, 1, nil, "", nil, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -40,11 +40,11 @@ func TestDefineAssetIdempotency(t *testing.T) {
 	ctx := context.Background()
 	token := "test_token"
 	keys := []string{testutil.TestXPub.String()}
-	asset0, err := r.Define(ctx, keys, 1, nil, "", nil, &token)
+	asset0, err := r.Define(ctx, keys, 1, nil, "", nil, token)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
-	asset1, err := r.Define(ctx, keys, 1, nil, "", nil, &token)
+	asset1, err := r.Define(ctx, keys, 1, nil, "", nil, token)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -59,7 +59,7 @@ func TestFindAssetByID(t *testing.T) {
 	r := NewRegistry(pgtest.NewTx(t), prottest.NewChain(t), nil)
 	ctx := context.Background()
 	keys := []string{testutil.TestXPub.String()}
-	asset, err := r.Define(ctx, keys, 1, nil, "", nil, nil)
+	asset, err := r.Define(ctx, keys, 1, nil, "", nil, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -79,7 +79,7 @@ func TestAssetByClientToken(t *testing.T) {
 	keys := []string{testutil.TestXPub.String()}
 	token := "test_token"
 
-	asset, err := r.Define(ctx, keys, 1, nil, "", nil, &token)
+	asset, err := r.Define(ctx, keys, 1, nil, "", nil, token)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/core/asset/block_test.go
+++ b/core/asset/block_test.go
@@ -25,7 +25,7 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a local asset which should be unaffected by a block landing.
-	local, err := r.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", nil, nil)
+	local, err := r.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/assets.go
+++ b/core/assets.go
@@ -39,7 +39,7 @@ func (h *Handler) createAsset(ctx context.Context, ins []struct {
 	// should have a unique client token. The client token is used to ensure
 	// idempotency of create asset requests. Duplicate create asset requests
 	// with the same client_token will only create one asset.
-	ClientToken *string `json:"client_token"`
+	ClientToken string `json:"client_token"`
 }) ([]interface{}, error) {
 	responses := make([]interface{}, len(ins))
 	var wg sync.WaitGroup

--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -29,7 +29,7 @@ func CreatePins(ctx context.Context, t testing.TB, s *pin.Store) {
 
 func CreateAccount(ctx context.Context, t testing.TB, accounts *account.Manager, alias string, tags map[string]interface{}) string {
 	keys := []string{testutil.TestXPub.String()}
-	acc, err := accounts.Create(ctx, keys, 1, alias, tags, nil)
+	acc, err := accounts.Create(ctx, keys, 1, alias, tags, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -38,7 +38,7 @@ func CreateAccount(ctx context.Context, t testing.TB, accounts *account.Manager,
 
 func CreateAsset(ctx context.Context, t testing.TB, assets *asset.Registry, def map[string]interface{}, alias string, tags map[string]interface{}) bc.AssetID {
 	keys := []string{testutil.TestXPub.String()}
-	asset, err := assets.Define(ctx, keys, 1, def, alias, tags, nil)
+	asset, err := assets.Define(ctx, keys, 1, def, alias, tags, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -37,7 +37,7 @@ func TestMockHSM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	acct1, err := accounts.Create(ctx, []string{xpub1.XPub.String()}, 1, "", nil, nil)
+	acct1, err := accounts.Create(ctx, []string{xpub1.XPub.String()}, 1, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestMockHSM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	acct2, err := accounts.Create(ctx, []string{xpub2.String()}, 1, "", nil, nil)
+	acct2, err := accounts.Create(ctx, []string{xpub2.String()}, 1, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/query/query_test.go
+++ b/core/query/query_test.go
@@ -32,23 +32,23 @@ func setupQueryTest(t *testing.T) (context.Context, *Indexer, time.Time, time.Ti
 	go assets.ProcessBlocks(ctx)
 	go indexer.ProcessBlocks(ctx)
 
-	acct1, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, nil)
+	acct1, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	acct2, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, nil)
+	acct2, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	asset1Tags := map[string]interface{}{"currency": "USD"}
 
-	asset1, err := assets.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", asset1Tags, nil)
+	asset1, err := assets.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", asset1Tags, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	asset2, err := assets.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", nil, nil)
+	asset2, err := assets.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/signers/signers_test.go
+++ b/core/signers/signers_test.go
@@ -88,7 +88,7 @@ func TestCreate(t *testing.T) {
 	}}
 
 	for _, c := range cases {
-		_, got := Create(ctx, db, c.typ, c.xpubs, c.quorum, nil)
+		_, got := Create(ctx, db, c.typ, c.xpubs, c.quorum, "")
 
 		if errors.Root(got) != c.want {
 			t.Errorf("Create(%s, %v, %d) = %q want %q", c.typ, c.xpubs, c.quorum, errors.Root(got), c.want)
@@ -107,7 +107,7 @@ func TestCreateIdempotency(t *testing.T) {
 		"account",
 		[]string{testutil.TestXPub.String()},
 		1,
-		&clientToken,
+		clientToken,
 	)
 
 	if err != nil {
@@ -120,7 +120,7 @@ func TestCreateIdempotency(t *testing.T) {
 		"account",
 		[]string{testutil.TestXPub.String()},
 		1,
-		&clientToken,
+		clientToken,
 	)
 
 	if err != nil {
@@ -226,7 +226,7 @@ func createFixture(ctx context.Context, db pg.DB, t testing.TB) *Signer {
 		"account",
 		[]string{testutil.TestXPub.String()},
 		1,
-		&clientToken,
+		clientToken,
 	)
 
 	if err != nil {

--- a/core/transact_test.go
+++ b/core/transact_test.go
@@ -30,7 +30,7 @@ func TestAccountTransferSpendChange(t *testing.T) {
 	accounts.IndexAccounts(query.NewIndexer(db, c, pinStore))
 	go accounts.ProcessBlocks(ctx)
 
-	acc, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, nil)
+	acc, err := accounts.Create(ctx, []string{testutil.TestXPub.String()}, 1, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -362,11 +362,11 @@ func bootdb(ctx context.Context, db *sql.DB, t testing.TB) (*testInfo, error) {
 		return nil, err
 	}
 
-	acctA, err := accounts.Create(ctx, []string{accPub.String()}, 1, "", nil, nil)
+	acctA, err := accounts.Create(ctx, []string{accPub.String()}, 1, "", nil, "")
 	if err != nil {
 		return nil, err
 	}
-	acctB, err := accounts.Create(ctx, []string{accPub.String()}, 1, "", nil, nil)
+	acctB, err := accounts.Create(ctx, []string{accPub.String()}, 1, "", nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +375,7 @@ func bootdb(ctx context.Context, db *sql.DB, t testing.TB) (*testInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	asset, err := assets.Define(ctx, []string{assetPub.String()}, 1, nil, "", nil, nil)
+	asset, err := assets.Define(ctx, []string{assetPub.String()}, 1, nil, "", nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/core/txfeed/txfeed_test.go
+++ b/core/txfeed/txfeed_test.go
@@ -19,7 +19,7 @@ func TestInsertTxFeed(t *testing.T) {
 		Alias: &alias,
 	}
 
-	result, err := insertTxFeed(ctx, db, feed, &token)
+	result, err := insertTxFeed(ctx, db, feed, token)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -49,12 +49,12 @@ func TestInsertTxFeedRepeatToken(t *testing.T) {
 		Alias: &alias,
 	}
 
-	result0, err := insertTxFeed(ctx, db, feed, &token)
+	result0, err := insertTxFeed(ctx, db, feed, token)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	result1, err := insertTxFeed(ctx, db, feed, &token)
+	result1, err := insertTxFeed(ctx, db, feed, token)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -75,12 +75,12 @@ func TestInsertTxFeedDuplicateAlias(t *testing.T) {
 		Alias: &alias,
 	}
 
-	_, err := insertTxFeed(ctx, db, feed, &token0)
+	_, err := insertTxFeed(ctx, db, feed, token0)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	_, err = insertTxFeed(ctx, db, feed, &token1)
+	_, err = insertTxFeed(ctx, db, feed, token1)
 	if errors.Root(err) != ErrDuplicateAlias {
 		t.Errorf("expected ErrDuplicateAlias, got %v", err)
 	}
@@ -92,7 +92,7 @@ func TestCreateTxFeedBadFilter(t *testing.T) {
 	token := "test_token_0"
 	alias := "test_txfeed"
 	fil := "lol i'm not a ~real~ filter"
-	_, err := tracker.Create(ctx, alias, fil, "", &token)
+	_, err := tracker.Create(ctx, alias, fil, "", token)
 	if errors.Root(err) != filter.ErrBadFilter {
 		t.Errorf("expected ErrBadFilter, got %s", errors.Root(err))
 	}

--- a/core/txfeeds.go
+++ b/core/txfeeds.go
@@ -20,7 +20,7 @@ func (h *Handler) createTxFeed(ctx context.Context, in struct {
 	// should have a unique client token. The client token is used to ensure
 	// idempotency of create txfeed requests. Duplicate create txfeed requests
 	// with the same client_token will only create one txfeed.
-	ClientToken *string `json:"client_token"`
+	ClientToken string `json:"client_token"`
 }) (*txfeed.TxFeed, error) {
 	after := fmt.Sprintf("%d:%d-%d", h.Chain.Height(), math.MaxInt32, uint64(math.MaxInt64))
 	return h.TxFeeds.Create(ctx, in.Alias, in.Filter, after, in.ClientToken)


### PR DESCRIPTION
This is in preparation for moving to GRPC--there are no pointers (only strings) in protobufs. 