### PR TITLE
core: store info vars on config

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -101,6 +101,10 @@ func init() {
 	expvar.NewString("runtime.GOOS").Set(runtime.GOOS)
 	expvar.NewString("runtime.GOARCH").Set(runtime.GOARCH)
 	expvar.NewString("runtime.Version").Set(runtime.Version())
+
+	config.Version = version
+	config.BuildCommit = buildCommit
+	config.BuildDate = buildDate
 }
 
 func main() {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -33,6 +33,8 @@ var (
 	ErrBadSignerURL    = errors.New("block signer URL is invalid")
 	ErrBadSignerPubkey = errors.New("block signer pubkey is invalid")
 	ErrBadQuorum       = errors.New("quorum must be greater than 0 if there are signers")
+
+	Version, BuildCommit, BuildDate string
 )
 
 // Config encapsulates Core-level, persistent configuration options.

--- a/core/core.go
+++ b/core/core.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"expvar"
 	"net/http"
 	"strings"
@@ -97,10 +96,6 @@ func (h *Handler) leaderInfo(ctx context.Context) (map[string]interface{}, error
 		}
 	}
 
-	version := json.RawMessage(expvar.Get("version").String())
-	buildCommit := json.RawMessage(expvar.Get("buildcommit").String())
-	buildDate := json.RawMessage(expvar.Get("builddate").String())
-
 	m := map[string]interface{}{
 		"is_configured":                     true,
 		"configured_at":                     h.Config.ConfiguredAt,
@@ -115,9 +110,9 @@ func (h *Handler) leaderInfo(ctx context.Context) (map[string]interface{}, error
 		"is_production":                     isProduction(),
 		"network_rpc_version":               networkRPCVersion,
 		"core_id":                           h.Config.ID,
-		"version":                           &version,
-		"build_commit":                      &buildCommit,
-		"build_date":                        &buildDate,
+		"version":                           config.Version,
+		"build_commit":                      config.BuildCommit,
+		"build_date":                        config.BuildDate,
 		"health":                            h.health(),
 	}
 


### PR DESCRIPTION
`/info` no longer returns JSON for `version`, `buildDate` and `buildCommit` (another pre-req for GRPC). 