### PR TITLE
wercker.yml: disable flaky dashboard linting in CI

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -28,12 +28,6 @@ cored:
         name: check for tk and xxx
         code: |
           check-tk-xxx
-    - inz/npm-install@1.1.5:
-      cwd: $CHAIN/dashboard/
-    - script:
-        name: dashboard tests
-        code: |
-          dashboard-tests
 
 java:
   steps:


### PR DESCRIPTION
For reasons not yet fully understood, Wercker only intermittently
fails on lint errors on the dashboard source. The issue appears
connected to using a cached node_modules folder (this feature is
enabled by the inz/step-npm-install Wercker plugin). If this
cache is disabled, linter errors will appear consistently.

Caching node_modules is necessary for a smooth workflow, so we'll
disable automated linting for now, since it currently only serves
to intermittently fail other folks' PRs with irrelevent liting
errors.

As a fallback, we will make sure the team is diligent about self-linting
as they work. We're also planning to add a call to eslint from
`bin/bundle-dashboard`, so there is at least some form of
automated sanity-check.