### PR TITLE
core/config: make MaxIssuanceWindow a json.Duration

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -17,6 +17,7 @@ import (
 	"chain/core/mockhsm"
 	"chain/crypto/ed25519"
 	"chain/database/sql"
+	chainjson "chain/encoding/json"
 	"chain/env"
 	"chain/log"
 )
@@ -118,11 +119,13 @@ func configGenerator(db *sql.DB, args []string) {
 	}
 
 	conf := &config.Config{
-		IsGenerator:       true,
-		IsSigner:          *isSigner,
-		Quorum:            quorum,
-		Signers:           signers,
-		MaxIssuanceWindow: *maxIssuanceWindow,
+		IsGenerator: true,
+		IsSigner:    *isSigner,
+		Quorum:      quorum,
+		Signers:     signers,
+		MaxIssuanceWindow: chainjson.Duration{
+			Duration: *maxIssuanceWindow,
+		},
 	}
 
 	ctx := context.Background()

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -237,7 +237,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 		for _, signer := range remoteSignerInfo(ctx, processID, buildTag, conf.BlockchainID.String(), conf) {
 			generatorSigners = append(generatorSigners, signer)
 		}
-		c.MaxIssuanceWindow = conf.MaxIssuanceWindow
+		c.MaxIssuanceWindow = conf.MaxIssuanceWindow.Duration
 	}
 
 	var submitter txbuilder.Submitter

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	BlockPub             string        `json:"block_pub"`
 	Signers              []BlockSigner `json:"block_signer_urls"`
 	Quorum               int
-	MaxIssuanceWindow    time.Duration
+	MaxIssuanceWindow    chainjson.Duration
 }
 
 type BlockSigner struct {
@@ -97,7 +97,7 @@ func Load(ctx context.Context, db pg.DB) (*Config, error) {
 		}
 	}
 
-	c.MaxIssuanceWindow = time.Duration(miw) * time.Millisecond
+	c.MaxIssuanceWindow = chainjson.Duration{time.Duration(miw) * time.Millisecond}
 	return c, nil
 }
 
@@ -188,7 +188,7 @@ func Configure(ctx context.Context, db pg.DB, c *Config) error {
 		}
 
 		c.BlockchainID = initialBlockHash
-		chain.MaxIssuanceWindow = c.MaxIssuanceWindow
+		chain.MaxIssuanceWindow = c.MaxIssuanceWindow.Duration
 	}
 
 	var blockSignerData []byte
@@ -223,7 +223,7 @@ func Configure(ctx context.Context, db pg.DB, c *Config) error {
 		c.GeneratorURL,
 		c.GeneratorAccessToken,
 		blockSignerData,
-		bc.DurationMillis(c.MaxIssuanceWindow),
+		bc.DurationMillis(c.MaxIssuanceWindow.Duration),
 	)
 	return err
 }

--- a/core/core.go
+++ b/core/core.go
@@ -134,8 +134,8 @@ func (h *Handler) configure(ctx context.Context, x *config.Config) error {
 		return errAlreadyConfigured
 	}
 
-	if x.IsGenerator && x.MaxIssuanceWindow == 0 {
-		x.MaxIssuanceWindow = 24 * time.Hour
+	if x.IsGenerator && x.MaxIssuanceWindow.Duration == 0 {
+		x.MaxIssuanceWindow.Duration = 24 * time.Hour
 	}
 
 	err := config.Configure(ctx, h.DB, x)


### PR DESCRIPTION
When MaxIssuanceWindow was a time.Duration it was difficult to configure through an API call; now it accepts values like "12h." 

This will change when we switch to gRPC, but for now, this is nice.