### PR TITLE
core/txbuilder: build returns tx data along with template

### DIFF
--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -55,22 +55,22 @@ func TestAccountSourceReserve(t *testing.T) {
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
-	tpl, err := builder.Build()
+	_, tx, err := builder.Build()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	wantTxIns := []*bc.TxInput{bc.NewSpendInput(out.Hash, out.Index, nil, out.AssetID, out.Amount, out.ControlProgram, nil)}
-	if !reflect.DeepEqual(tpl.Transaction.Inputs, wantTxIns) {
-		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tpl.Transaction.Inputs, wantTxIns)
+	if !reflect.DeepEqual(tx.Inputs, wantTxIns) {
+		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tx.Inputs, wantTxIns)
 	}
-	if len(tpl.Transaction.Outputs) != 1 {
+	if len(tx.Outputs) != 1 {
 		t.Errorf("expected 1 change output")
 	}
-	if tpl.Transaction.Outputs[0].Amount != 1 {
+	if tx.Outputs[0].Amount != 1 {
 		t.Errorf("expected change amount to be 1")
 	}
-	if !programInAccount(ctx, t, db, tpl.Transaction.Outputs[0].ControlProgram, accID) {
+	if !programInAccount(ctx, t, db, tx.Outputs[0].ControlProgram, accID) {
 		t.Errorf("expected change control program to belong to account")
 	}
 }
@@ -106,15 +106,15 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
-	tpl, err := builder.Build()
+	_, tx, err := builder.Build()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	wantTxIns := []*bc.TxInput{bc.NewSpendInput(out.Hash, out.Index, nil, out.AssetID, out.Amount, out.ControlProgram, nil)}
 
-	if !reflect.DeepEqual(tpl.Transaction.Inputs, wantTxIns) {
-		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tpl.Transaction.Inputs, wantTxIns)
+	if !reflect.DeepEqual(tx.Inputs, wantTxIns) {
+		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tx.Inputs, wantTxIns)
 	}
 }
 
@@ -161,14 +161,14 @@ func TestAccountSourceReserveIdempotency(t *testing.T) {
 		if err != nil {
 			testutil.FatalErr(t, err)
 		}
-		tpl, err := builder.Build()
+		_, tx, err := builder.Build()
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(tpl.Transaction.Inputs) != 1 {
-			t.Fatalf("got %d result utxo, expected 1 result utxo", len(tpl.Transaction.Inputs))
+		if len(tx.Inputs) != 1 {
+			t.Fatalf("got %d result utxo, expected 1 result utxo", len(tx.Inputs))
 		}
-		return tpl.Transaction.Inputs
+		return tx.Inputs
 	}
 
 	var (

--- a/core/txbuilder/builder.go
+++ b/core/txbuilder/builder.go
@@ -82,50 +82,52 @@ func (b *TemplateBuilder) rollback() {
 	}
 }
 
-func (b *TemplateBuilder) Build() (*Template, error) {
+func (b *TemplateBuilder) Build() (*Template, *bc.TxData, error) {
 	// Run any building callbacks.
 	for _, cb := range b.callbacks {
 		err := cb()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
-	tpl := &Template{Transaction: b.base}
-	if tpl.Transaction == nil {
-		tpl.Transaction = &bc.TxData{
+	tpl := &Template{}
+	tx := b.base
+	if tx == nil {
+		tx = &bc.TxData{
 			Version: bc.CurrentTransactionVersion,
 		}
 		tpl.Local = true
 	}
 
 	// Update min & max times.
-	if !b.minTime.IsZero() && bc.Millis(b.minTime) > tpl.Transaction.MinTime {
-		tpl.Transaction.MinTime = bc.Millis(b.minTime)
+	if !b.minTime.IsZero() && bc.Millis(b.minTime) > tx.MinTime {
+		tx.MinTime = bc.Millis(b.minTime)
 	}
-	if tpl.Transaction.MaxTime == 0 || tpl.Transaction.MaxTime > bc.Millis(b.maxTime) {
-		tpl.Transaction.MaxTime = bc.Millis(b.maxTime)
+	if tx.MaxTime == 0 || tx.MaxTime > bc.Millis(b.maxTime) {
+		tx.MaxTime = bc.Millis(b.maxTime)
 	}
 
 	// Set transaction reference data if applicable.
 	if len(b.referenceData) > 0 {
-		tpl.Transaction.ReferenceData = b.referenceData
+		tx.ReferenceData = b.referenceData
 	}
 
 	// Add all the built outputs.
-	tpl.Transaction.Outputs = append(tpl.Transaction.Outputs, b.outputs...)
+	tx.Outputs = append(tx.Outputs, b.outputs...)
 
 	// Add all the built inputs and their corresponding signing instructions.
 	for i, in := range b.inputs {
 		instruction := b.signingInstructions[i]
-		instruction.Position = len(tpl.Transaction.Inputs)
+		instruction.Position = len(tx.Inputs)
 
 		// Empty signature arrays should be serialized as empty arrays, not null.
 		if instruction.WitnessComponents == nil {
 			instruction.WitnessComponents = []WitnessComponent{}
 		}
 		tpl.SigningInstructions = append(tpl.SigningInstructions, instruction)
-		tpl.Transaction.Inputs = append(tpl.Transaction.Inputs, in)
+		tx.Inputs = append(tx.Inputs, in)
 	}
-	return tpl, nil
+	tpl.Transaction = tx
+	return tpl, tx, nil
 }

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -51,13 +51,13 @@ func Build(ctx context.Context, tx *bc.TxData, actions []Action, maxTime time.Ti
 	}
 
 	// Build the transaction template.
-	tpl, err := builder.Build()
+	tpl, tx, err := builder.Build()
 	if err != nil {
 		builder.rollback()
 		return nil, err
 	}
 
-	err = checkBlankCheck(tpl.Transaction)
+	err = checkBlankCheck(tx)
 	if err != nil {
 		builder.rollback()
 		return nil, err


### PR DESCRIPTION
More prep for gRPC--we used to pass the txdata struct around inside of the txtemplate because we could rely on the marshal function of txdata. 