### PR TITLE
core/txbuilder: turn ints into uint32s on signing path

### DIFF
--- a/core/txbuilder/builder.go
+++ b/core/txbuilder/builder.go
@@ -119,7 +119,7 @@ func (b *TemplateBuilder) Build() (*Template, *bc.TxData, error) {
 	// Add all the built inputs and their corresponding signing instructions.
 	for i, in := range b.inputs {
 		instruction := b.signingInstructions[i]
-		instruction.Position = len(tx.Inputs)
+		instruction.Position = uint32(len(tx.Inputs))
 
 		// Empty signature arrays should be serialized as empty arrays, not null.
 		if instruction.WitnessComponents == nil {

--- a/core/txbuilder/finalize.go
+++ b/core/txbuilder/finalize.go
@@ -89,7 +89,7 @@ func checkTxSighashCommitment(tx *bc.Tx) error {
 		if !bytes.Equal(prog[33:], []byte{byte(vm.OP_TXSIGHASH), byte(vm.OP_EQUAL)}) {
 			continue
 		}
-		h := sigHasher.Hash(i)
+		h := sigHasher.Hash(uint32(i))
 		if !bytes.Equal(h[:], prog[1:33]) {
 			continue
 		}

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -83,7 +83,7 @@ func KeyIDs(xpubs []chainkd.XPub, path [][]byte) []KeyID {
 func Sign(ctx context.Context, tpl *Template, xpubs []string, signFn SignFunc) error {
 	for i, sigInst := range tpl.SigningInstructions {
 		for j, c := range sigInst.WitnessComponents {
-			err := c.Sign(ctx, tpl, i, xpubs, signFn)
+			err := c.Sign(ctx, tpl, uint32(i), xpubs, signFn)
 			if err != nil {
 				return errors.WithDetailf(err, "adding signature(s) to witness component %d of input %d", j, i)
 			}

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -33,7 +33,7 @@ func (t *Template) Hash(idx uint32) bc.Hash {
 	if t.sigHasher == nil {
 		t.sigHasher = bc.NewSigHasher(t.Transaction)
 	}
-	return t.sigHasher.Hash(int(idx))
+	return t.sigHasher.Hash(idx)
 }
 
 // SigningInstruction gives directions for signing inputs in a TxTemplate.

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -29,16 +29,16 @@ type Template struct {
 	sigHasher *bc.SigHasher
 }
 
-func (t *Template) Hash(idx int) bc.Hash {
+func (t *Template) Hash(idx uint32) bc.Hash {
 	if t.sigHasher == nil {
 		t.sigHasher = bc.NewSigHasher(t.Transaction)
 	}
-	return t.sigHasher.Hash(idx)
+	return t.sigHasher.Hash(int(idx))
 }
 
 // SigningInstruction gives directions for signing inputs in a TxTemplate.
 type SigningInstruction struct {
-	Position int `json:"position"`
+	Position uint32 `json:"position"`
 	bc.AssetAmount
 	WitnessComponents []WitnessComponent `json:"witness_components,omitempty"`
 }
@@ -46,7 +46,7 @@ type SigningInstruction struct {
 func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 	var pre struct {
 		bc.AssetAmount
-		Position          int `json:"position"`
+		Position          uint32 `json:"position"`
 		WitnessComponents []struct {
 			Type string
 			SignatureWitness

--- a/core/txbuilder/witness.go
+++ b/core/txbuilder/witness.go
@@ -23,11 +23,11 @@ type SignFunc func(context.Context, string, [][]byte, [32]byte) ([]byte, error)
 type WitnessComponent interface {
 	// Sign is called to add signatures. Actual signing is delegated to
 	// a callback function.
-	Sign(context.Context, *Template, int, []string, SignFunc) error
+	Sign(context.Context, *Template, uint32, []string, SignFunc) error
 
 	// Materialize is called to turn the component into a vector of
 	// arguments for the input witness.
-	Materialize(*Template, int, *[][]byte) error
+	Materialize(*Template, uint32, *[][]byte) error
 }
 
 // materializeWitnesses takes a filled in Template and "materializes"
@@ -99,7 +99,7 @@ var ErrEmptyProgram = errors.New("empty signature program")
 //  - the mintime and maxtime of the transaction (if non-zero)
 //  - the outpoint and (if non-empty) reference data of the current input
 //  - the assetID, amount, control program, and (if non-empty) reference data of each output.
-func (sw *SignatureWitness) Sign(ctx context.Context, tpl *Template, index int, xpubs []string, signFn SignFunc) error {
+func (sw *SignatureWitness) Sign(ctx context.Context, tpl *Template, index uint32, xpubs []string, signFn SignFunc) error {
 	// Compute the predicate to sign. This is either a
 	// txsighash program if tpl.AllowAdditional is false (i.e., the tx is complete
 	// and no further changes are allowed) or a program enforcing
@@ -150,7 +150,7 @@ func contains(list []string, key string) bool {
 	return false
 }
 
-func buildSigProgram(tpl *Template, index int) []byte {
+func buildSigProgram(tpl *Template, index uint32) []byte {
 	if !tpl.AllowAdditional {
 		h := tpl.Hash(index)
 		builder := vmutil.NewBuilder()
@@ -201,7 +201,7 @@ func buildSigProgram(tpl *Template, index int) []byte {
 	return program
 }
 
-func (sw SignatureWitness) Materialize(tpl *Template, index int, args *[][]byte) error {
+func (sw SignatureWitness) Materialize(tpl *Template, index uint32, args *[][]byte) error {
 	// This is the value of N for the CHECKPREDICATE call. The code
 	// assumes that everything already in the arg list before this call
 	// to Materialize is input to the signature program, so N is

--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -262,7 +262,7 @@ func (tx *TxData) IssuanceHash(n int) (h Hash, err error) {
 
 // HashForSig generates the hash required for the specified input's
 // signature.
-func (tx *TxData) HashForSig(idx int) Hash {
+func (tx *TxData) HashForSig(idx uint32) Hash {
 	return NewSigHasher(tx).Hash(idx)
 }
 
@@ -276,7 +276,7 @@ func NewSigHasher(txData *TxData) *SigHasher {
 	return &SigHasher{txData: txData}
 }
 
-func (s *SigHasher) Hash(idx int) Hash {
+func (s *SigHasher) Hash(idx uint32) Hash {
 	if s.txHash == nil {
 		h := s.txData.Hash()
 		s.txHash = &h

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -312,7 +312,7 @@ func TestTxHashForSig(t *testing.T) {
 		ReferenceData: []byte("transfer"),
 	}
 	cases := []struct {
-		idx      int
+		idx      uint32
 		wantHash string
 	}{
 		{0, "94b72d62d47a8ba581246c0c721b18b36282cf81f2cdb92a3b1ab4fef4640654"},

--- a/protocol/tx_test.go
+++ b/protocol/tx_test.go
@@ -46,7 +46,7 @@ func newDest(t testing.TB) *testDest {
 	}
 }
 
-func (d *testDest) sign(t testing.TB, tx *bc.TxData, index int) {
+func (d *testDest) sign(t testing.TB, tx *bc.TxData, index uint32) {
 	txsighash := tx.HashForSig(index)
 	prog, _ := vm.Assemble(fmt.Sprintf("0x%x TXSIGHASH EQUAL", txsighash[:]))
 	h := sha3.Sum256(prog)

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -251,7 +251,7 @@ func CheckTxWellFormed(tx *bc.Tx) error {
 	}
 
 	for i := range tx.Inputs {
-		ok, err := vm.VerifyTxInput(tx, i)
+		ok, err := vm.VerifyTxInput(tx, uint32(i))
 		if err == nil && !ok {
 			err = ErrFalseVMResult
 		}

--- a/protocol/vm/vm.go
+++ b/protocol/vm/vm.go
@@ -44,7 +44,7 @@ type virtualMachine struct {
 // execution.
 var TraceOut io.Writer
 
-func VerifyTxInput(tx *bc.Tx, inputIndex int) (ok bool, err error) {
+func VerifyTxInput(tx *bc.Tx, inputIndex uint32) (ok bool, err error) {
 	defer func() {
 		if panErr := recover(); panErr != nil {
 			ok = false
@@ -55,7 +55,7 @@ func VerifyTxInput(tx *bc.Tx, inputIndex int) (ok bool, err error) {
 }
 
 func verifyTxInput(tx *bc.Tx, inputIndex uint32) (bool, error) {
-	if inputIndex < 0 || inputIndex >= len(tx.Inputs) {
+	if inputIndex < 0 || inputIndex >= uint32(len(tx.Inputs)) {
 		return false, ErrBadValue
 	}
 

--- a/protocol/vm/vm.go
+++ b/protocol/vm/vm.go
@@ -34,7 +34,7 @@ type virtualMachine struct {
 	altStack  [][]byte
 
 	tx         *bc.Tx
-	inputIndex int
+	inputIndex uint32
 	sigHasher  *bc.SigHasher
 
 	block *bc.Block
@@ -54,7 +54,7 @@ func VerifyTxInput(tx *bc.Tx, inputIndex int) (ok bool, err error) {
 	return verifyTxInput(tx, inputIndex)
 }
 
-func verifyTxInput(tx *bc.Tx, inputIndex int) (bool, error) {
+func verifyTxInput(tx *bc.Tx, inputIndex uint32) (bool, error) {
 	if inputIndex < 0 || inputIndex >= len(tx.Inputs) {
 		return false, ErrBadValue
 	}


### PR DESCRIPTION
gRPC requires that we specify the int type; on the signing path we chose uint32s. 