### PR TITLE
all: revise Ruby requirement from 2 to 2.1

### DIFF
--- a/docs/core/get-started/sdk.md
+++ b/docs/core/get-started/sdk.md
@@ -13,7 +13,7 @@ The Java SDK is available as a self-contained JAR file, with dependencies compil
 
 ## Ruby
 
-The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2 is required.
+The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2.1 or greater is required.
 
 For most applications, you can simply add the following to your `Gemfile`:
 

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -4,7 +4,7 @@
 
 ### Get the gem
 
-The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2 is required.
+The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2.1 or greater is required.
 
 For most applications, you can simply add the following to your `Gemfile`:
 

--- a/sdk/ruby/chain-sdk.gemspec
+++ b/sdk/ruby/chain-sdk.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.summary = 'The Official Ruby SDK for the Chain Core Developer Edition'
   s.licenses = ['Apache-2.0']
   s.homepage = 'https://github.com/chain/chain/tree/main/sdk/ruby'
+  s.required_ruby_version = '~> 2.1'
 
   s.files = ['README.md', 'LICENSE']
   s.files += Dir['lib/**/*.rb']


### PR DESCRIPTION
The Ruby SDK makes use of language features only available in
Ruby 2.1, so the documentation should reflect this.

Resolves #358.