### PR TITLE
core/signers: change xpubs column type to bytea

### DIFF
--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -88,7 +88,7 @@ type Account struct {
 }
 
 // Create creates a new Account.
-func (m *Manager) Create(ctx context.Context, xpubs []string, quorum int, alias string, tags map[string]interface{}, clientToken string) (*Account, error) {
+func (m *Manager) Create(ctx context.Context, xpubs []chainkd.XPub, quorum int, alias string, tags map[string]interface{}, clientToken string) (*Account, error) {
 	signer, err := signers.Create(ctx, m.db, "account", xpubs, quorum, clientToken)
 	if err != nil {
 		return nil, errors.Wrap(err)

--- a/core/account/accounts_test.go
+++ b/core/account/accounts_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg/pgtest"
 	"chain/errors"
 	"chain/protocol/prottest"
@@ -13,14 +14,12 @@ import (
 	"chain/testutil"
 )
 
-var dummyXPub = testutil.TestXPub.String()
-
 func TestCreateAccount(t *testing.T) {
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 
-	account, err := m.Create(ctx, []string{dummyXPub}, 1, "", nil, "")
+	account, err := m.Create(ctx, []chainkd.XPub{testutil.TestXPub}, 1, "", nil, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -43,11 +42,11 @@ func TestCreateAccountIdempotency(t *testing.T) {
 	ctx := context.Background()
 	var clientToken = "a-unique-client-token"
 
-	account1, err := m.Create(ctx, []string{dummyXPub}, 1, "satoshi", nil, clientToken)
+	account1, err := m.Create(ctx, []chainkd.XPub{testutil.TestXPub}, 1, "satoshi", nil, clientToken)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
-	account2, err := m.Create(ctx, []string{dummyXPub}, 1, "satoshi", nil, clientToken)
+	account2, err := m.Create(ctx, []chainkd.XPub{testutil.TestXPub}, 1, "satoshi", nil, clientToken)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -62,7 +61,7 @@ func TestCreateAccountReusedAlias(t *testing.T) {
 	ctx := context.Background()
 	m.createTestAccount(ctx, t, "some-account", nil)
 
-	_, err := m.Create(ctx, []string{dummyXPub}, 1, "some-account", nil, "")
+	_, err := m.Create(ctx, []chainkd.XPub{testutil.TestXPub}, 1, "some-account", nil, "")
 	if errors.Root(err) != ErrDuplicateAlias {
 		t.Errorf("Expected %s when reusing an alias, got %v", ErrDuplicateAlias, err)
 	}
@@ -74,7 +73,7 @@ func TestCreateControlProgram(t *testing.T) {
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 
-	account, err := m.Create(ctx, []string{dummyXPub}, 1, "", nil, "")
+	account, err := m.Create(ctx, []chainkd.XPub{testutil.TestXPub}, 1, "", nil, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -95,7 +94,7 @@ func TestCreateControlProgram(t *testing.T) {
 }
 
 func (m *Manager) createTestAccount(ctx context.Context, t testing.TB, alias string, tags map[string]interface{}) *Account {
-	account, err := m.Create(ctx, []string{dummyXPub}, 1, alias, tags, "")
+	account, err := m.Create(ctx, []chainkd.XPub{testutil.TestXPub}, 1, alias, tags, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/core/accounts.go
+++ b/core/accounts.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"chain/core/signers"
+	"chain/crypto/ed25519/chainkd"
 	"chain/net/http/reqid"
 )
 
@@ -25,7 +26,7 @@ type accountKey struct {
 
 // POST /create-account
 func (h *Handler) createAccount(ctx context.Context, ins []struct {
-	RootXPubs []string `json:"root_xpubs"`
+	RootXPubs []chainkd.XPub `json:"root_xpubs"`
 	Quorum    int
 	Alias     string
 	Tags      map[string]interface{}

--- a/core/asset/annotate_test.go
+++ b/core/asset/annotate_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg/pgtest"
 	"chain/protocol/prottest"
 	"chain/testutil"
@@ -17,13 +18,13 @@ func TestAnnotateTxs(t *testing.T) {
 	tags1 := map[string]interface{}{"foo": "bar"}
 	def1 := map[string]interface{}{"baz": "bar"}
 
-	asset1, err := reg.Define(ctx, []string{testutil.TestXPub.String()}, 1, def1, "", tags1, "")
+	asset1, err := reg.Define(ctx, []chainkd.XPub{testutil.TestXPub}, 1, def1, "", tags1, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	tags2 := map[string]interface{}{"foo": "baz"}
-	asset2, err := reg.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", tags2, "")
+	asset2, err := reg.Define(ctx, []chainkd.XPub{testutil.TestXPub}, 1, nil, "", tags2, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -77,7 +77,7 @@ func (asset *Asset) SerializedDefinition() ([]byte, error) {
 }
 
 // Define defines a new Asset.
-func (reg *Registry) Define(ctx context.Context, xpubs []string, quorum int, definition map[string]interface{}, alias string, tags map[string]interface{}, clientToken string) (*Asset, error) {
+func (reg *Registry) Define(ctx context.Context, xpubs []chainkd.XPub, quorum int, definition map[string]interface{}, alias string, tags map[string]interface{}, clientToken string) (*Asset, error) {
 	assetSigner, err := signers.Create(ctx, reg.db, "asset", xpubs, quorum, clientToken)
 	if err != nil {
 		return nil, err
@@ -271,7 +271,7 @@ func assetQuery(ctx context.Context, db pg.DB, pred string, args ...interface{})
 		signerType string
 		quorum     int
 		keyIndex   uint64
-		xpubs      []string
+		xpubs      [][]byte
 		tags       []byte
 	)
 	err := db.QueryRow(ctx, fmt.Sprintf(baseQ, pred), args...).Scan(
@@ -283,7 +283,7 @@ func assetQuery(ctx context.Context, db pg.DB, pred string, args ...interface{})
 		&a.sortID,
 		&signerID,
 		&signerType,
-		(*pq.StringArray)(&xpubs),
+		(*pq.ByteaArray)(&xpubs),
 		&quorum,
 		&keyIndex,
 		&tags,

--- a/core/asset/asset_test.go
+++ b/core/asset/asset_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg/pgtest"
 	"chain/protocol/prottest"
 	"chain/testutil"
@@ -14,7 +15,7 @@ func TestDefineAsset(t *testing.T) {
 	r := NewRegistry(pgtest.NewTx(t), prottest.NewChain(t), nil)
 	ctx := context.Background()
 
-	keys := []string{testutil.TestXPub.String()}
+	keys := []chainkd.XPub{testutil.TestXPub}
 	asset, err := r.Define(ctx, keys, 1, nil, "", nil, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
@@ -39,7 +40,7 @@ func TestDefineAssetIdempotency(t *testing.T) {
 	r := NewRegistry(pgtest.NewTx(t), prottest.NewChain(t), nil)
 	ctx := context.Background()
 	token := "test_token"
-	keys := []string{testutil.TestXPub.String()}
+	keys := []chainkd.XPub{testutil.TestXPub}
 	asset0, err := r.Define(ctx, keys, 1, nil, "", nil, token)
 	if err != nil {
 		testutil.FatalErr(t, err)
@@ -58,7 +59,7 @@ func TestDefineAssetIdempotency(t *testing.T) {
 func TestFindAssetByID(t *testing.T) {
 	r := NewRegistry(pgtest.NewTx(t), prottest.NewChain(t), nil)
 	ctx := context.Background()
-	keys := []string{testutil.TestXPub.String()}
+	keys := []chainkd.XPub{testutil.TestXPub}
 	asset, err := r.Define(ctx, keys, 1, nil, "", nil, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
@@ -76,7 +77,7 @@ func TestFindAssetByID(t *testing.T) {
 func TestAssetByClientToken(t *testing.T) {
 	r := NewRegistry(pgtest.NewTx(t), prottest.NewChain(t), nil)
 	ctx := context.Background()
-	keys := []string{testutil.TestXPub.String()}
+	keys := []chainkd.XPub{testutil.TestXPub}
 	token := "test_token"
 
 	asset, err := r.Define(ctx, keys, 1, nil, "", nil, token)

--- a/core/asset/block_test.go
+++ b/core/asset/block_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"chain/crypto/ed25519"
+	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg/pgtest"
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
@@ -25,7 +26,7 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	ctx := context.Background()
 
 	// Create a local asset which should be unaffected by a block landing.
-	local, err := r.Define(ctx, []string{testutil.TestXPub.String()}, 1, nil, "", nil, "")
+	local, err := r.Define(ctx, []chainkd.XPub{testutil.TestXPub}, 1, nil, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/assets.go
+++ b/core/assets.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"chain/core/signers"
+	"chain/crypto/ed25519/chainkd"
 	"chain/encoding/json"
 	"chain/net/http/reqid"
 )
@@ -30,7 +31,7 @@ type assetKey struct {
 // POST /create-asset
 func (h *Handler) createAsset(ctx context.Context, ins []struct {
 	Alias      string
-	RootXPubs  []string `json:"root_xpubs"`
+	RootXPubs  []chainkd.XPub `json:"root_xpubs"`
 	Quorum     int
 	Definition map[string]interface{}
 	Tags       map[string]interface{}

--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -28,7 +28,7 @@ func CreatePins(ctx context.Context, t testing.TB, s *pin.Store) {
 }
 
 func CreateAccount(ctx context.Context, t testing.TB, accounts *account.Manager, alias string, tags map[string]interface{}) string {
-	keys := []string{testutil.TestXPub.String()}
+	keys := []chainkd.XPub{testutil.TestXPub}
 	acc, err := accounts.Create(ctx, keys, 1, alias, tags, "")
 	if err != nil {
 		testutil.FatalErr(t, err)
@@ -37,7 +37,7 @@ func CreateAccount(ctx context.Context, t testing.TB, accounts *account.Manager,
 }
 
 func CreateAsset(ctx context.Context, t testing.TB, assets *asset.Registry, def map[string]interface{}, alias string, tags map[string]interface{}) bc.AssetID {
-	keys := []string{testutil.TestXPub.String()}
+	keys := []chainkd.XPub{testutil.TestXPub}
 	asset, err := assets.Define(ctx, keys, 1, def, alias, tags, "")
 	if err != nil {
 		testutil.FatalErr(t, err)

--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -37,7 +37,7 @@ func TestMockHSM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	acct1, err := accounts.Create(ctx, []string{xpub1.XPub.String()}, 1, "", nil, "")
+	acct1, err := accounts.Create(ctx, []chainkd.XPub{xpub1.XPub}, 1, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestMockHSM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	acct2, err := accounts.Create(ctx, []string{xpub2.String()}, 1, "", nil, "")
+	acct2, err := accounts.Create(ctx, []chainkd.XPub{xpub2}, 1, "", nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -75,4 +75,12 @@ var migrations = []migration{
 	{Name: "2017-01-05.0.core.rename_block_key.sql", SQL: `
 		ALTER TABLE config RENAME COLUMN block_xpub TO block_pub;
 	`},
+	{Name: "2017-01-10.0.signers.xpubs-type.sql", SQL: `
+		ALTER TABLE signers ADD COLUMN xpub_byteas bytea[] NOT NULL DEFAULT '{}';
+		UPDATE signers s1
+			SET xpub_byteas=(SELECT array_agg(decode(unnest(xpubs), 'hex')) FROM signers s2 WHERE s1.id=s2.id);
+		ALTER TABLE signers DROP COLUMN xpubs;
+		ALTER TABLE signers RENAME COLUMN xpub_byteas TO xpubs;
+		ALTER TABLE signers ALTER COLUMN xpubs DROP DEFAULT;
+	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.2
--- Dumped by pg_dump version 9.5.2
+-- Dumped from database version 9.5.0
+-- Dumped by pg_dump version 9.5.0
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -463,9 +463,9 @@ CREATE TABLE signers (
     id text NOT NULL,
     type text NOT NULL,
     key_index bigint NOT NULL,
-    xpubs text[] NOT NULL,
     quorum integer NOT NULL,
-    client_token text
+    client_token text,
+    xpubs bytea[] NOT NULL
 );
 
 
@@ -877,3 +877,4 @@ insert into migrations (filename, hash) values ('2016-11-22.0.account.utxos-inde
 insert into migrations (filename, hash) values ('2016-11-23.0.query.jsonb-path-ops.sql', 'adb15b9a6b7b223a17dbfd5f669e44c500b343568a563f87e1ae67ba0f938d55');
 insert into migrations (filename, hash) values ('2016-11-28.0.core.submitted-txs-hash.sql', 'cabbd7fd79a2b672b2d3c854783bde3b8245fe666c50261c3335a0c0501ff2ea');
 insert into migrations (filename, hash) values ('2017-01-05.0.core.rename_block_key.sql', 'ba6a62e498236ec9d2f13238a945829a5cab83f897068fef57a2c152a2e36037');
+insert into migrations (filename, hash) values ('2017-01-10.0.signers.xpubs-type.sql', '4a4d6c736a2bf65e69abbdc87771faa1dc17a0106b2651a6a58af067708d095a');


### PR DESCRIPTION
Rather than dealing with string types and converting back and forth
between hex, the raw bytes can be used directly.