### PR TITLE
core/txbuilder: replace string keys with XPubs

### DIFF
--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -90,7 +90,7 @@ func SignTxTemplate(t testing.TB, ctx context.Context, template *txbuilder.Templ
 	if priv == nil {
 		priv = &testutil.TestXPrv
 	}
-	err := txbuilder.Sign(ctx, template, []string{priv.XPub().String()}, func(_ context.Context, _ string, path [][]byte, data [32]byte) ([]byte, error) {
+	err := txbuilder.Sign(ctx, template, []chainkd.XPub{priv.XPub()}, func(_ context.Context, _ chainkd.XPub, path [][]byte, data [32]byte) ([]byte, error) {
 		derived := priv.Derive(path)
 		return derived.Sign(data[:]), nil
 	})

--- a/core/hsm.go
+++ b/core/hsm.go
@@ -6,7 +6,6 @@ import (
 	"chain/core/mockhsm"
 	"chain/core/txbuilder"
 	"chain/crypto/ed25519/chainkd"
-	"chain/errors"
 	"chain/net/http/httpjson"
 )
 
@@ -45,7 +44,7 @@ func (h *Handler) mockhsmDelKey(ctx context.Context, xpub chainkd.XPub) error {
 
 func (h *Handler) mockhsmSignTemplates(ctx context.Context, x struct {
 	Txs   []*txbuilder.Template `json:"transactions"`
-	XPubs []string              `json:"xpubs"`
+	XPubs []chainkd.XPub        `json:"xpubs"`
 }) []interface{} {
 	resp := make([]interface{}, 0, len(x.Txs))
 	for _, tx := range x.Txs {
@@ -60,12 +59,7 @@ func (h *Handler) mockhsmSignTemplates(ctx context.Context, x struct {
 	return resp
 }
 
-func (h *Handler) mockhsmSignTemplate(ctx context.Context, xpubstr string, path [][]byte, data [32]byte) ([]byte, error) {
-	var xpub chainkd.XPub
-	err := xpub.UnmarshalText([]byte(xpubstr))
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing xpub")
-	}
+func (h *Handler) mockhsmSignTemplate(ctx context.Context, xpub chainkd.XPub, path [][]byte, data [32]byte) ([]byte, error) {
 	sigBytes, err := h.HSM.XSign(ctx, xpub, path, data[:])
 	if err == mockhsm.ErrNoKey {
 		return nil, nil

--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -87,8 +87,8 @@ func TestMockHSM(t *testing.T) {
 	h := &Handler{HSM: mockhsm}
 	outTmpls := h.mockhsmSignTemplates(ctx, struct {
 		Txs   []*txbuilder.Template `json:"transactions"`
-		XPubs []string              `json:"xpubs"`
-	}{[]*txbuilder.Template{tmpl}, []string{xpub1.XPub.String()}})
+		XPubs []chainkd.XPub        `json:"xpubs"`
+	}{[]*txbuilder.Template{tmpl}, []chainkd.XPub{xpub1.XPub}})
 	if len(outTmpls) != 1 {
 		t.Fatalf("expected 1 output template, got %d", len(outTmpls))
 	}

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -75,12 +75,12 @@ func KeyIDs(xpubs []chainkd.XPub, path [][]byte) []KeyID {
 		hexPath = append(hexPath, p)
 	}
 	for _, xpub := range xpubs {
-		result = append(result, KeyID{xpub.String(), hexPath})
+		result = append(result, KeyID{xpub, hexPath})
 	}
 	return result
 }
 
-func Sign(ctx context.Context, tpl *Template, xpubs []string, signFn SignFunc) error {
+func Sign(ctx context.Context, tpl *Template, xpubs []chainkd.XPub, signFn SignFunc) error {
 	for i, sigInst := range tpl.SigningInstructions {
 		for j, c := range sigInst.WitnessComponents {
 			err := c.Sign(ctx, tpl, uint32(i), xpubs, signFn)

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -131,7 +131,7 @@ func TestMaterializeWitnesses(t *testing.T) {
 				&SignatureWitness{
 					Quorum: 1,
 					Keys: []KeyID{{
-						XPub:           pubkey.String(),
+						XPub:           pubkey,
 						DerivationPath: []json.HexBytes{{0, 0, 0, 0}},
 					}},
 					Program: prog,
@@ -211,15 +211,15 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 				Quorum: 2,
 				Keys: []KeyID{
 					{
-						XPub:           pubkey1.String(),
+						XPub:           pubkey1,
 						DerivationPath: []json.HexBytes{{0, 0, 0, 0}},
 					},
 					{
-						XPub:           pubkey2.String(),
+						XPub:           pubkey2,
 						DerivationPath: []json.HexBytes{{0, 0, 0, 0}},
 					},
 					{
-						XPub:           pubkey3.String(),
+						XPub:           pubkey3,
 						DerivationPath: []json.HexBytes{{0, 0, 0, 0}},
 					},
 				},

--- a/core/txbuilder/witness_test.go
+++ b/core/txbuilder/witness_test.go
@@ -11,6 +11,7 @@ import (
 	chainjson "chain/encoding/json"
 	"chain/protocol/bc"
 	"chain/protocol/vm"
+	"chain/testutil"
 )
 
 func TestInferConstraints(t *testing.T) {
@@ -48,7 +49,7 @@ func TestWitnessJSON(t *testing.T) {
 			&SignatureWitness{
 				Quorum: 4,
 				Keys: []KeyID{{
-					XPub:           "fd",
+					XPub:           testutil.TestXPub,
 					DerivationPath: []chainjson.HexBytes{{5, 6, 7}},
 				}},
 				Sigs: []chainjson.HexBytes{{8, 9, 10}},


### PR DESCRIPTION
Rather than working with strings, these functions can work with the keys
themselves, and leave conversion to the request layer.