### PR TITLE
encoding/blockchain: Encapsulate "varstrlist" and "extensible string" patterns

### DIFF
--- a/encoding/blockchain/blockchain.go
+++ b/encoding/blockchain/blockchain.go
@@ -4,12 +4,13 @@ package blockchain
 
 import (
 	"bytes"
-	"chain/encoding/bufpool"
 	"encoding/binary"
 	"errors"
 	"io"
 	"math"
 	"sync"
+
+	"chain/encoding/bufpool"
 )
 
 var bufPool = sync.Pool{New: func() interface{} { return new([9]byte) }}

--- a/encoding/blockchain/blockchain.go
+++ b/encoding/blockchain/blockchain.go
@@ -3,6 +3,8 @@
 package blockchain
 
 import (
+	"bytes"
+	"chain/encoding/bufpool"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -89,6 +91,78 @@ func WriteVarstr31(w io.Writer, str []byte) (int, error) {
 	}
 	n2, err := w.Write(str)
 	return n + n2, err
+}
+
+// WriteVarstrList writes a varint31 length prefix followed by the
+// elements of l as varstrs.
+func WriteVarstrList(w io.Writer, l [][]byte) (int, error) {
+	n, err := WriteVarint31(w, uint64(len(l)))
+	if err != nil {
+		return n, err
+	}
+	for _, s := range l {
+		n2, err := WriteVarstr31(w, s)
+		n += n2
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, err
+}
+
+// ReadVarstrList reads a varint31 length prefix followed by that many
+// varstrs.
+func ReadVarstrList(r io.Reader) ([][]byte, int, error) {
+	nelts, n, err := ReadVarint31(r)
+	if err != nil {
+		return nil, n, err
+	}
+	if nelts == 0 {
+		return nil, n, nil
+	}
+	result := make([][]byte, 0, nelts)
+	for ; nelts > 0; nelts-- {
+		s, n2, err := ReadVarstr31(r)
+		n += n2
+		if err != nil {
+			return nil, n, err
+		}
+		result = append(result, s)
+	}
+	return result, n, nil
+}
+
+// WriteExtensibleString sends the output of the given function,
+// together with a varint31 length prefix, to w.
+func WriteExtensibleString(w io.Writer, f func(io.Writer) error) (int, error) {
+	buf := bufpool.Get()
+	defer bufpool.Put(buf)
+	err := f(buf)
+	if err != nil {
+		return 0, err
+	}
+	return WriteVarstr31(w, buf.Bytes())
+}
+
+var ErrLeftover = errors.New("extensible string partially unconsumed")
+
+// ReadExtensibleString reads a varint31 length prefix and then calls
+// the given function to consume that many bytes. If all is true, it
+// is an error for any bytes to be left over.
+func ReadExtensibleString(r io.Reader, all bool, f func(io.Reader) error) (int, error) {
+	s, n, err := ReadVarstr31(r)
+	if err != nil {
+		return n, err
+	}
+	sr := bytes.NewReader(s)
+	err = f(sr)
+	if err != nil {
+		return n, err
+	}
+	if all && sr.Len() > 0 {
+		return n, ErrLeftover
+	}
+	return n, nil
 }
 
 // byteReader wraps io.Reader, satisfies io.ByteReader, keeps a

--- a/encoding/blockchain/blockchain_test.go
+++ b/encoding/blockchain/blockchain_test.go
@@ -2,8 +2,10 @@ package blockchain
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"math"
+	"reflect"
 	"testing"
 )
 
@@ -75,8 +77,7 @@ func TestVarint31(t *testing.T) {
 		if !bytes.Equal(c.want, b.Bytes()) {
 			t.Errorf("WriteVarint31(%d): got %x, want %x", c.n, b.Bytes(), c.want)
 		}
-		b = bytes.NewBuffer(b.Bytes())
-		v, n, err := ReadVarint31(b)
+		v, n, err := ReadVarint31(bytes.NewReader(b.Bytes()))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -129,8 +130,7 @@ func TestVarint63(t *testing.T) {
 		if !bytes.Equal(c.want, b.Bytes()) {
 			t.Errorf("WriteVarint63(%d): got %x, want %x", c.n, b.Bytes(), c.want)
 		}
-		b = bytes.NewBuffer(b.Bytes())
-		v, n, err := ReadVarint63(b)
+		v, n, err := ReadVarint63(bytes.NewReader(b.Bytes()))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -154,8 +154,7 @@ func TestVarstring31(t *testing.T) {
 	if !bytes.Equal(b.Bytes(), want) {
 		t.Errorf("got %x, want %x", b.Bytes(), want)
 	}
-	b = bytes.NewBuffer(want)
-	s, _, err = ReadVarstr31(b)
+	s, _, err = ReadVarstr31(bytes.NewReader(want))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,5 +184,87 @@ func TestEmptyVarstring31(t *testing.T) {
 	want = nil // we deliberately return nil for empty strings to avoid unnecessary byteslice allocation
 	if !bytes.Equal(s, want) {
 		t.Errorf("got %x, expected %x", s, want)
+	}
+}
+
+func TestVarstrList(t *testing.T) {
+	for i := 0; i < 4; i++ {
+		// make a list of i+1 strs, each with length i+1, each made of repeating byte i
+		strs := make([][]byte, 0, i+1)
+		for j := 0; j <= i; j++ {
+			str := make([]byte, 0, i+1)
+			for k := 0; k <= i; k++ {
+				str = append(str, byte(i))
+			}
+			strs = append(strs, str)
+		}
+		var buf bytes.Buffer
+		_, err := WriteVarstrList(&buf, strs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		strs2, _, err := ReadVarstrList(bytes.NewReader(buf.Bytes()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(strs, strs2) {
+			t.Errorf("got %v, want %v", strs2, strs)
+		}
+	}
+}
+
+func TestExtensibleString(t *testing.T) {
+	for i := 0; i < 4; i++ {
+		// make a string of length i+1
+		str := make([]byte, 0, i+1)
+		for j := 0; j <= i; j++ {
+			str = append(str, byte(i))
+		}
+		var buf bytes.Buffer
+		_, err := WriteExtensibleString(&buf, func(w io.Writer) error {
+			_, err := w.Write(str)
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var str2 []byte
+		b := buf.Bytes()
+		_, err = ReadExtensibleString(bytes.NewReader(b), true, func(r io.Reader) error {
+			str2, err = ioutil.ReadAll(r)
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(str, str2) {
+			t.Errorf("got %x, want %x", str2, str)
+		}
+		_, err = ReadExtensibleString(bytes.NewReader(b[:i]), false, func(r io.Reader) error {
+			return nil
+		})
+		switch err {
+		case nil:
+			t.Errorf("got no error, want io.EOF")
+		case io.EOF, io.ErrUnexpectedEOF:
+		default:
+			t.Errorf("got error %s, want io.EOF", err)
+		}
+		_, err = ReadExtensibleString(bytes.NewReader(b), false, func(r io.Reader) error {
+			return nil
+		})
+		if err != nil {
+			t.Error(err)
+		}
+		_, err = ReadExtensibleString(bytes.NewReader(b), true, func(r io.Reader) error {
+			return nil
+		})
+		switch err {
+		case nil:
+			t.Errorf("got no error, want ErrLeftover")
+		case ErrLeftover:
+		default:
+			t.Errorf("got error %s, want ErrLeftover", err)
+		}
 	}
 }

--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -374,10 +374,13 @@ func (a *AssetAmount) readFrom(r io.Reader) (int, error) {
 	return n1 + n2, err
 }
 
-// assumes w has sticky errors
-func (a *AssetAmount) writeTo(w io.Writer) {
-	w.Write(a.AssetID[:])
-	blockchain.WriteVarint63(w, a.Amount) // TODO(bobg): check and return error
+func (a *AssetAmount) writeTo(w io.Writer) error {
+	_, err := w.Write(a.AssetID[:])
+	if err != nil {
+		return err
+	}
+	_, err = blockchain.WriteVarint63(w, a.Amount)
+	return err
 }
 
 // assumes w has sticky errors

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -1,14 +1,12 @@
 package bc
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
 	"io"
 
 	"chain/crypto/sha3pool"
 	"chain/encoding/blockchain"
-	"chain/encoding/bufpool"
+	"chain/errors"
 )
 
 type (
@@ -164,67 +162,57 @@ func (t *TxInput) readFrom(r io.Reader, txVersion uint64) (err error) {
 		return err
 	}
 
-	inputCommitment, _, err := blockchain.ReadVarstr31(r)
-	if err != nil {
-		return err
-	}
-
 	var (
 		ii      *IssuanceInput
 		si      *SpendInput
 		assetID AssetID
 	)
-	if t.AssetVersion == 1 {
-		icBuf := bytes.NewBuffer(inputCommitment)
-		var icType [1]byte
-		_, err = io.ReadFull(icBuf, icType[:])
-		if err != nil {
-			return err
+
+	all := txVersion == 1
+	_, err = blockchain.ReadExtensibleString(r, all, func(r io.Reader) error {
+		if t.AssetVersion == 1 {
+			var icType [1]byte
+			_, err = io.ReadFull(r, icType[:])
+			if err != nil {
+				return errors.Wrap(err, "reading input commitment type")
+			}
+			switch icType[0] {
+			case 0:
+				ii = new(IssuanceInput)
+
+				ii.Nonce, _, err = blockchain.ReadVarstr31(r)
+				if err != nil {
+					return err
+				}
+				_, err = io.ReadFull(r, assetID[:])
+				if err != nil {
+					return err
+				}
+				ii.Amount, _, err = blockchain.ReadVarint63(r)
+				if err != nil {
+					return err
+				}
+
+			case 1:
+				si = new(SpendInput)
+
+				_, err = si.Outpoint.readFrom(r)
+				if err != nil {
+					return err
+				}
+				_, err = si.OutputCommitment.readFrom(r, txVersion, 1)
+				if err != nil {
+					return err
+				}
+
+			default:
+				return fmt.Errorf("unsupported input type %d", icType[0])
+			}
 		}
-		bytesRead := 1
-		var n int
-		switch icType[0] {
-		case 0:
-			ii = new(IssuanceInput)
-
-			ii.Nonce, n, err = blockchain.ReadVarstr31(icBuf)
-			if err != nil {
-				return err
-			}
-			bytesRead += n
-
-			n, err = io.ReadFull(icBuf, assetID[:])
-			if err != nil {
-				return err
-			}
-			bytesRead += n
-
-			ii.Amount, n, err = blockchain.ReadVarint63(icBuf)
-			if err != nil {
-				return err
-			}
-			bytesRead += n
-
-		case 1:
-			si = new(SpendInput)
-			n, err = si.Outpoint.readFrom(icBuf)
-			if err != nil {
-				return err
-			}
-			bytesRead += n
-			n, err = si.OutputCommitment.readFrom(icBuf, txVersion, 1)
-			if err != nil {
-				return err
-			}
-			bytesRead += n
-
-		default:
-			return fmt.Errorf("unsupported input type %d", icType[0])
-		}
-
-		if txVersion == 1 && bytesRead < len(inputCommitment) {
-			return fmt.Errorf("unrecognized extra data in input commitment for transaction version 1")
-		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	t.ReferenceData, _, err = blockchain.ReadVarstr31(r)
@@ -232,31 +220,26 @@ func (t *TxInput) readFrom(r io.Reader, txVersion uint64) (err error) {
 		return err
 	}
 
-	inputWitness, _, err := blockchain.ReadVarstr31(r)
-	if err != nil {
-		return err
-	}
-
-	if assetVersion == 1 { // TODO(bobg): also test serialization flags include SerWitness, when we relax the serflags-must-be-0x7 rule
-		iwBuf := bytes.NewBuffer(inputWitness)
+	_, err = blockchain.ReadExtensibleString(r, false, func(r io.Reader) error {
+		// TODO(bobg): test that serialization flags include SerWitness, when we relax the serflags-must-be-0x7 rule
 		if ii != nil {
 			// read IssuanceInput witness
-			_, err = io.ReadFull(iwBuf, ii.InitialBlock[:])
+			_, err = io.ReadFull(r, ii.InitialBlock[:])
 			if err != nil {
 				return err
 			}
 
-			ii.AssetDefinition, _, err = blockchain.ReadVarstr31(iwBuf)
+			ii.AssetDefinition, _, err = blockchain.ReadVarstr31(r)
 			if err != nil {
 				return err
 			}
 
-			ii.VMVersion, _, err = blockchain.ReadVarint63(iwBuf)
+			ii.VMVersion, _, err = blockchain.ReadVarint63(r)
 			if err != nil {
 				return err
 			}
 
-			ii.IssuanceProgram, _, err = blockchain.ReadVarstr31(iwBuf)
+			ii.IssuanceProgram, _, err = blockchain.ReadVarstr31(r)
 			if err != nil {
 				return err
 			}
@@ -266,25 +249,19 @@ func (t *TxInput) readFrom(r io.Reader, txVersion uint64) (err error) {
 				return errBadAssetID
 			}
 		}
-
-		// The following is shared in common by spendinputs and issuanceinputs
-		n, _, err := blockchain.ReadVarint31(iwBuf)
+		args, _, err := blockchain.ReadVarstrList(r)
 		if err != nil {
 			return err
-		}
-		var args [][]byte
-		for ; n > 0; n-- {
-			arg, _, err := blockchain.ReadVarstr31(iwBuf)
-			if err != nil {
-				return err
-			}
-			args = append(args, arg)
 		}
 		if ii != nil {
 			ii.Arguments = args
 		} else if si != nil {
 			si.Arguments = args
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 	if ii != nil {
 		t.TypedInput = ii
@@ -297,15 +274,16 @@ func (t *TxInput) readFrom(r io.Reader, txVersion uint64) (err error) {
 // assumes w has sticky errors
 func (t *TxInput) writeTo(w io.Writer, serflags uint8) {
 	blockchain.WriteVarint63(w, t.AssetVersion) // TODO(bobg): check and return error
-	buf := bufpool.Get()
-	defer bufpool.Put(buf)
-	t.WriteInputCommitment(buf)
-	blockchain.WriteVarstr31(w, buf.Bytes())
+	blockchain.WriteExtensibleString(w, func(w io.Writer) error {
+		t.WriteInputCommitment(w)
+		return nil
+	})
 	blockchain.WriteVarstr31(w, t.ReferenceData)
 	if serflags&SerWitness != 0 {
-		buf.Reset()
-		t.writeInputWitness(buf)
-		blockchain.WriteVarstr31(w, buf.Bytes())
+		blockchain.WriteExtensibleString(w, func(w io.Writer) error {
+			t.writeInputWitness(w)
+			return nil
+		})
 	}
 }
 
@@ -329,20 +307,15 @@ func (t *TxInput) WriteInputCommitment(w io.Writer) {
 
 func (t *TxInput) writeInputWitness(w io.Writer) {
 	if t.AssetVersion == 1 {
-		var arguments [][]byte
 		switch inp := t.TypedInput.(type) {
 		case *IssuanceInput:
 			w.Write(inp.InitialBlock[:])
 			blockchain.WriteVarstr31(w, inp.AssetDefinition) // TODO(bobg): check and return error
 			blockchain.WriteVarint63(w, inp.VMVersion)       // TODO(bobg): check and return error
 			blockchain.WriteVarstr31(w, inp.IssuanceProgram) // TODO(bobg): check and return error
-			arguments = inp.Arguments
+			blockchain.WriteVarstrList(w, inp.Arguments)
 		case *SpendInput:
-			arguments = inp.Arguments
-		}
-		blockchain.WriteVarint31(w, uint64(len(arguments))) // TODO(bobg): check and return error
-		for _, arg := range arguments {
-			blockchain.WriteVarstr31(w, arg) // TODO(bobg): check and return error
+			blockchain.WriteVarstrList(w, inp.Arguments)
 		}
 	}
 }

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -105,13 +105,23 @@ func (to *TxOutput) WriteCommitment(w io.Writer) {
 	to.OutputCommitment.writeTo(w, to.AssetVersion)
 }
 
-func (oc *OutputCommitment) writeTo(w io.Writer, assetVersion uint64) {
+func (oc *OutputCommitment) writeTo(w io.Writer, assetVersion uint64) (err error) {
 	b := bufpool.Get()
 	defer bufpool.Put(b)
 	if assetVersion == 1 {
-		oc.AssetAmount.writeTo(b)
-		blockchain.WriteVarint63(b, oc.VMVersion) // TODO(bobg): check and return error
-		blockchain.WriteVarstr31(b, oc.ControlProgram)
+		err = oc.AssetAmount.writeTo(b)
+		if err != nil {
+			return err
+		}
+		_, err = blockchain.WriteVarint63(b, oc.VMVersion)
+		if err != nil {
+			return err
+		}
+		_, err = blockchain.WriteVarstr31(b, oc.ControlProgram)
+		if err != nil {
+			return err
+		}
 	}
-	blockchain.WriteVarstr31(w, b.Bytes()) // TODO(bobg): check and return error
+	_, err = blockchain.WriteVarstr31(w, b.Bytes())
+	return err
 }

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -94,9 +94,7 @@ func (to *TxOutput) writeTo(w io.Writer, serflags byte) {
 	blockchain.WriteVarint63(w, to.AssetVersion) // TODO(bobg): check and return error
 	to.OutputCommitment.writeTo(w, to.AssetVersion)
 	writeRefData(w, to.ReferenceData, serflags)
-	if serflags&SerWitness != 0 {
-		blockchain.WriteVarstr31(w, nil)
-	}
+	blockchain.WriteVarstr31(w, nil)
 }
 
 func (to *TxOutput) witnessHash() Hash {


### PR DESCRIPTION
Use the new functions throughout `protocol/bc`.