### PR TITLE
core/txdb: delete older snapshots

### DIFF
--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -117,4 +117,7 @@ var migrations = []migration{
 	{Name: "2017-01-25.0.account.cp-expiry.sql", SQL: `
 		ALTER TABLE account_control_programs ADD COLUMN expires_at timestamp with time zone;
 	`},
+	{Name: "2017-01-26.0.txdb.snapshots-timestamp.sql", SQL: `
+		ALTER TABLE snapshots ADD COLUMN created_at timestamp without time zone DEFAULT now();
+	`},
 }

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -117,7 +117,7 @@ var migrations = []migration{
 	{Name: "2017-01-25.0.account.cp-expiry.sql", SQL: `
 		ALTER TABLE account_control_programs ADD COLUMN expires_at timestamp with time zone;
 	`},
-	{Name: "2017-01-26.0.txdb.snapshots-timestamp.sql", SQL: `
+	{Name: "2017-01-30.0.txdb.snapshots-timestamp.sql", SQL: `
 		ALTER TABLE snapshots ADD COLUMN created_at timestamp without time zone DEFAULT now();
 	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -7,7 +7,6 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -913,4 +912,4 @@ insert into migrations (filename, hash) values ('2017-01-13.0.core.asset-definit
 insert into migrations (filename, hash) values ('2017-01-19.0.asset.drop-mutable-flag.sql', '7850023d44c545c155c0ee372e7cdfef1859b40221bd94307b836503c26dd3de');
 insert into migrations (filename, hash) values ('2017-01-20.0.core.add-output-id-to-outputs.sql', '4c8531c06e62405d2989e0651a7ef6c2ebd0b2b269b57c179e9e36f7fdbb715b');
 insert into migrations (filename, hash) values ('2017-01-25.0.account.cp-expiry.sql', 'a2076b7b3ac3f844d17e13eea57fea01216c868a63f9df7b9df24cac9c4b82a4');
-insert into migrations (filename, hash) values ('2017-01-26.0.txdb.snapshots-timestamp.sql', '3ab923b782e048300315fc4ea8ae8bdf42183aa423d0a12bc228411c2d8c5093');
+insert into migrations (filename, hash) values ('2017-01-30.0.txdb.snapshots-timestamp.sql', '3ab923b782e048300315fc4ea8ae8bdf42183aa423d0a12bc228411c2d8c5093');

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -7,6 +7,7 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -498,7 +499,8 @@ ALTER SEQUENCE signers_key_index_seq OWNED BY signers.key_index;
 
 CREATE TABLE snapshots (
     height bigint NOT NULL,
-    data bytea NOT NULL
+    data bytea NOT NULL,
+    created_at timestamp without time zone DEFAULT now()
 );
 
 
@@ -911,3 +913,4 @@ insert into migrations (filename, hash) values ('2017-01-13.0.core.asset-definit
 insert into migrations (filename, hash) values ('2017-01-19.0.asset.drop-mutable-flag.sql', '7850023d44c545c155c0ee372e7cdfef1859b40221bd94307b836503c26dd3de');
 insert into migrations (filename, hash) values ('2017-01-20.0.core.add-output-id-to-outputs.sql', '4c8531c06e62405d2989e0651a7ef6c2ebd0b2b269b57c179e9e36f7fdbb715b');
 insert into migrations (filename, hash) values ('2017-01-25.0.account.cp-expiry.sql', 'a2076b7b3ac3f844d17e13eea57fea01216c868a63f9df7b9df24cac9c4b82a4');
+insert into migrations (filename, hash) values ('2017-01-26.0.txdb.snapshots-timestamp.sql', '3ab923b782e048300315fc4ea8ae8bdf42183aa423d0a12bc228411c2d8c5093');

--- a/core/txdb/snapshot.go
+++ b/core/txdb/snapshot.go
@@ -75,14 +75,14 @@ func storeStateSnapshot(ctx context.Context, db pg.DB, snapshot *state.Snapshot,
 
 	const insertQ = `
 		INSERT INTO snapshots (height, data) VALUES($1, $2)
-		ON CONFLICT (height) DO UPDATE SET data = $2
+		ON CONFLICT (height) DO UPDATE SET data = $2, created_at = NOW()
 	`
 	_, err = db.Exec(ctx, insertQ, blockHeight, b)
 	if err != nil {
 		return errors.Wrap(err, "writing state snapshot to database")
 	}
 
-	const deleteQ = `DELETE FROM snapshots WHERE timestamp < NOW() - INTERVAL '24 hours'`
+	const deleteQ = `DELETE FROM snapshots WHERE created_at < NOW() - INTERVAL '24 hours'`
 	_, err = db.Exec(ctx, deleteQ)
 	return errors.Wrap(err, "deleting old snapshots")
 }

--- a/core/txdb/snapshot.go
+++ b/core/txdb/snapshot.go
@@ -2,7 +2,6 @@ package txdb
 
 import (
 	"context"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 
@@ -14,8 +13,6 @@ import (
 	"chain/protocol/patricia"
 	"chain/protocol/state"
 )
-
-const maxSnapshotAge = 24 * time.Hour
 
 // DecodeSnapshot decodes a snapshot from the Chain Core's binary,
 // protobuf representation of the snapshot.
@@ -85,8 +82,8 @@ func storeStateSnapshot(ctx context.Context, db pg.DB, snapshot *state.Snapshot,
 		return errors.Wrap(err, "writing state snapshot to database")
 	}
 
-	const deleteQ = `DELETE FROM snapshots WHERE timestamp < $1`
-	_, err = db.Exec(ctx, deleteQ, time.Now().Add(-maxSnapshotAge))
+	const deleteQ = `DELETE FROM snapshots WHERE timestamp < NOW() - INTERVAL '24 hours'`
+	_, err = db.Exec(ctx, deleteQ)
 	return errors.Wrap(err, "deleting old snapshots")
 }
 


### PR DESCRIPTION
After saving a new snapshot, delete older snapshots.

We could change the snapshots table to be a singleton table, but the
/get-snapshot RPC uses content-addressable snapshots. There would be
a race condition between when a client looks up the height of the
most recent snapshot and when they retrieve that snapshot.

There might be other motivations for keeping more snapshots
than just the most recent snapshot?