### PR TITLE
core: use bytea for hash columns

### DIFF
--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -15,9 +15,9 @@ const sampleAccountUTXOs = `
 	INSERT INTO account_utxos
 	(tx_hash, index, asset_id, amount, account_id, control_program_index,
      control_program, confirmed_in) VALUES (
-		'270b725a94429496a178c56b390a89d03f801fe2ee992d90cf4fdf7d7855318e',
+		decode('270b725a94429496a178c56b390a89d03f801fe2ee992d90cf4fdf7d7855318e', 'hex'),
 		0,
-		'df1df9d4f66437ab5be715e4d1faeb29d24c80a6dc8276d6a630f05c5f1f7693',
+		decode('df1df9d4f66437ab5be715e4d1faeb29d24c80a6dc8276d6a630f05c5f1f7693', 'hex'),
 		1000, 'accEXAMPLE', 1, '\x6a'::bytea, 1);
 `
 

--- a/core/asset/annotate.go
+++ b/core/asset/annotate.go
@@ -53,10 +53,10 @@ func (reg *Registry) AnnotateTxs(ctx context.Context, txs []map[string]interface
 		localByAssetIDStr   = make(map[string]bool, len(assetIDStrs))
 	)
 	const q = `
-		SELECT id, COALESCE(alias, ''), signer_id IS NOT NULL, tags, definition
+		SELECT encode(id, 'hex'), COALESCE(alias, ''), signer_id IS NOT NULL, tags, definition
 		FROM assets
 		LEFT JOIN asset_tags ON asset_id=id
-		WHERE id IN (SELECT unnest($1::text[]))
+		WHERE id IN (SELECT decode(unnest($1::text[]), 'hex'))
 	`
 	err := pg.ForQueryRows(ctx, reg.db, q, pq.StringArray(assetIDStrs),
 		func(assetIDStr, alias string, local bool, tagsBlob []byte, defBlob []byte) error {

--- a/core/asset/annotate_test.go
+++ b/core/asset/annotate_test.go
@@ -39,7 +39,7 @@ func TestAnnotateTxs(t *testing.T) {
 					"asset_id": asset2.AssetID.String(),
 				},
 				map[string]interface{}{
-					"asset_id": "unknown",
+					"asset_id": "bad0",
 				},
 			},
 			"outputs": []interface{}{
@@ -50,7 +50,7 @@ func TestAnnotateTxs(t *testing.T) {
 					"asset_id": asset2.AssetID.String(),
 				},
 				map[string]interface{}{
-					"asset_id": "unknown",
+					"asset_id": "bad0",
 				},
 			},
 		},
@@ -71,7 +71,7 @@ func TestAnnotateTxs(t *testing.T) {
 					"asset_definition": map[string]interface{}{},
 				},
 				map[string]interface{}{
-					"asset_id":         "unknown",
+					"asset_id":         "bad0",
 					"asset_tags":       map[string]interface{}{},
 					"asset_is_local":   "no",
 					"asset_definition": map[string]interface{}{},
@@ -91,7 +91,7 @@ func TestAnnotateTxs(t *testing.T) {
 					"asset_definition": map[string]interface{}{},
 				},
 				map[string]interface{}{
-					"asset_id":         "unknown",
+					"asset_id":         "bad0",
 					"asset_tags":       map[string]interface{}{},
 					"asset_is_local":   "no",
 					"asset_definition": map[string]interface{}{},

--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -184,7 +184,7 @@ func (reg *Registry) insertAsset(ctx context.Context, asset *Asset, clientToken 
 	const q = `
 		INSERT INTO assets
 			(id, alias, signer_id, initial_block_hash, issuance_program, definition, client_token)
-		VALUES($1, $2, $3, $4, $5, $6, $7)
+		VALUES($1::bytea, $2, $3, $4, $5, $6, $7)
 		ON CONFLICT (client_token) DO NOTHING
 		RETURNING sort_id
   `
@@ -220,7 +220,7 @@ func (reg *Registry) insertAsset(ctx context.Context, asset *Asset, clientToken 
 			return nil, errors.Wrap(err, "retrieving existing asset")
 		}
 	} else if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err)
 	}
 	return asset, nil
 }
@@ -237,7 +237,7 @@ func insertAssetTags(ctx context.Context, db pg.DB, assetID bc.AssetID, tags map
 		INSERT INTO asset_tags (asset_id, tags) VALUES ($1, $2)
 		ON CONFLICT (asset_id) DO UPDATE SET tags = $2
 	`
-	_, err = db.Exec(ctx, q, assetID.String(), tagsParam)
+	_, err = db.Exec(ctx, q, assetID, tagsParam)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/core/asset/asset_test.go
+++ b/core/asset/asset_test.go
@@ -1,12 +1,14 @@
 package asset
 
 import (
+	"bytes"
 	"context"
 	"reflect"
 	"testing"
 
 	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg/pgtest"
+	"chain/protocol/bc"
 	"chain/protocol/prottest"
 	"chain/testutil"
 )
@@ -25,14 +27,14 @@ func TestDefineAsset(t *testing.T) {
 	}
 
 	// Verify that the asset was defined.
-	var id string
+	var id bc.AssetID
 	var checkQ = `SELECT id FROM assets`
 	err = r.db.QueryRow(ctx, checkQ).Scan(&id)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
-	if id != asset.AssetID.String() {
-		t.Errorf("expected new asset %s to be recorded as %s", asset.AssetID.String(), id)
+	if !bytes.Equal(id[:], asset.AssetID[:]) {
+		t.Errorf("expected new asset %s to be recorded as %s", asset.AssetID, id)
 	}
 }
 

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -83,4 +83,17 @@ var migrations = []migration{
 		ALTER TABLE signers RENAME COLUMN xpub_byteas TO xpubs;
 		ALTER TABLE signers ALTER COLUMN xpubs DROP DEFAULT;
 	`},
+	{Name: "2017-01-11.0.core.hash-bytea.sql", SQL: `
+		ALTER TABLE account_utxos ALTER COLUMN tx_hash SET DATA TYPE bytea USING decode(tx_hash, 'hex');
+		ALTER TABLE annotated_outputs ALTER COLUMN tx_hash SET DATA TYPE bytea USING decode(tx_hash, 'hex');
+		ALTER TABLE annotated_txs ALTER COLUMN tx_hash SET DATA TYPE bytea USING decode(tx_hash, 'hex');
+		ALTER TABLE account_utxos ALTER COLUMN asset_id SET DATA TYPE bytea USING decode(asset_id, 'hex');
+		ALTER TABLE asset_tags ALTER COLUMN asset_id SET DATA TYPE bytea USING decode(asset_id, 'hex');
+		ALTER TABLE assets ALTER COLUMN id SET DATA TYPE bytea USING decode(id, 'hex');
+		ALTER TABLE annotated_assets ALTER COLUMN id SET DATA TYPE bytea USING decode(id, 'hex');
+		ALTER TABLE blocks ALTER COLUMN block_hash SET DATA TYPE bytea USING decode(block_hash, 'hex');
+		ALTER TABLE signed_blocks ALTER COLUMN block_hash SET DATA TYPE bytea USING decode(block_hash, 'hex');
+		ALTER TABLE assets ALTER COLUMN initial_block_hash SET DATA TYPE bytea USING decode(initial_block_hash, 'hex');
+		ALTER TABLE config ALTER COLUMN blockchain_id SET DATA TYPE bytea USING decode(blockchain_id, 'hex');
+	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -187,9 +187,9 @@ CREATE TABLE account_control_programs (
 --
 
 CREATE TABLE account_utxos (
-    tx_hash text NOT NULL,
+    tx_hash bytea NOT NULL,
     index integer NOT NULL,
-    asset_id text NOT NULL,
+    asset_id bytea NOT NULL,
     amount bigint NOT NULL,
     account_id text NOT NULL,
     control_program_index bigint NOT NULL,
@@ -224,7 +224,7 @@ CREATE TABLE annotated_accounts (
 --
 
 CREATE TABLE annotated_assets (
-    id text NOT NULL,
+    id bytea NOT NULL,
     data jsonb NOT NULL,
     sort_id text NOT NULL
 );
@@ -238,7 +238,7 @@ CREATE TABLE annotated_outputs (
     block_height bigint NOT NULL,
     tx_pos integer NOT NULL,
     output_index integer NOT NULL,
-    tx_hash text NOT NULL,
+    tx_hash bytea NOT NULL,
     data jsonb NOT NULL,
     timespan int8range NOT NULL
 );
@@ -251,7 +251,7 @@ CREATE TABLE annotated_outputs (
 CREATE TABLE annotated_txs (
     block_height bigint NOT NULL,
     tx_pos integer NOT NULL,
-    tx_hash text NOT NULL,
+    tx_hash bytea NOT NULL,
     data jsonb NOT NULL
 );
 
@@ -261,7 +261,7 @@ CREATE TABLE annotated_txs (
 --
 
 CREATE TABLE asset_tags (
-    asset_id text NOT NULL,
+    asset_id bytea NOT NULL,
     tags jsonb
 );
 
@@ -271,13 +271,13 @@ CREATE TABLE asset_tags (
 --
 
 CREATE TABLE assets (
-    id text NOT NULL,
+    id bytea NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     definition_mutable boolean DEFAULT false NOT NULL,
     sort_id text DEFAULT next_chain_id('asset'::text) NOT NULL,
     issuance_program bytea NOT NULL,
     client_token text,
-    initial_block_hash text NOT NULL,
+    initial_block_hash bytea NOT NULL,
     signer_id text,
     definition jsonb,
     alias text,
@@ -312,7 +312,7 @@ CREATE TABLE block_processors (
 --
 
 CREATE TABLE blocks (
-    block_hash text NOT NULL,
+    block_hash bytea NOT NULL,
     height bigint NOT NULL,
     data bytea NOT NULL,
     header bytea NOT NULL
@@ -339,7 +339,7 @@ CREATE TABLE config (
     singleton boolean DEFAULT true NOT NULL,
     is_signer boolean,
     is_generator boolean,
-    blockchain_id text NOT NULL,
+    blockchain_id bytea NOT NULL,
     configured_at timestamp with time zone NOT NULL,
     generator_url text DEFAULT ''::text NOT NULL,
     block_pub text DEFAULT ''::text NOT NULL,
@@ -451,7 +451,7 @@ CREATE SEQUENCE reservation_seq
 
 CREATE TABLE signed_blocks (
     block_height bigint NOT NULL,
-    block_hash text NOT NULL
+    block_hash bytea NOT NULL
 );
 
 
@@ -878,3 +878,4 @@ insert into migrations (filename, hash) values ('2016-11-23.0.query.jsonb-path-o
 insert into migrations (filename, hash) values ('2016-11-28.0.core.submitted-txs-hash.sql', 'cabbd7fd79a2b672b2d3c854783bde3b8245fe666c50261c3335a0c0501ff2ea');
 insert into migrations (filename, hash) values ('2017-01-05.0.core.rename_block_key.sql', 'ba6a62e498236ec9d2f13238a945829a5cab83f897068fef57a2c152a2e36037');
 insert into migrations (filename, hash) values ('2017-01-10.0.signers.xpubs-type.sql', '4a4d6c736a2bf65e69abbdc87771faa1dc17a0106b2651a6a58af067708d095a');
+insert into migrations (filename, hash) values ('2017-01-11.0.core.hash-bytea.sql', '9f7f15df3479c38f193884a2d3cb7ae8001ed08607f9cc661fd5c420e248688d');

--- a/core/txdb/txdb_test.go
+++ b/core/txdb/txdb_test.go
@@ -19,9 +19,9 @@ func TestGetBlock(t *testing.T) {
 	pgtest.Exec(ctx, dbtx, t, `
 		INSERT INTO blocks (block_hash, height, data, header)
 		VALUES
-		('0000000000000000000000000000000000000000000000000000000000000000', 0, '', ''),
+		(decode('0000000000000000000000000000000000000000000000000000000000000000', 'hex'), 0, '', ''),
 		(
-			'1f20d89dd393f452b4396589ed5d6f90465cb032aa3f9fe42a99d47c7089b0a3',
+			decode('1f20d89dd393f452b4396589ed5d6f90465cb032aa3f9fe42a99d47c7089b0a3', 'hex'),
 			1,
 			decode('03010131323300000000000000000000000000000000000000000000000000000000006453414243000000000000000000000000000000000000000000000000000000000058595a000000000000000000000000000000000000000000000000000000000012746573742d6f75747075742d73637269707411010f746573742d7369672d73637269707401070102000000000007746573742d7478', 'hex'),
 			''
@@ -59,7 +59,7 @@ func TestGetBlock(t *testing.T) {
 	}
 }
 
-func getBlockByHash(ctx context.Context, db pg.DB, hash string) (*bc.Block, error) {
+func getBlockByHash(ctx context.Context, db pg.DB, hash bc.Hash) (*bc.Block, error) {
 	const q = `SELECT data FROM blocks WHERE block_hash=$1`
 	block := new(bc.Block)
 	err := db.QueryRow(ctx, q, hash).Scan(block)
@@ -92,7 +92,7 @@ func TestInsertBlock(t *testing.T) {
 	}
 
 	// block in database
-	_, err = getBlockByHash(ctx, dbtx, blk.Hash().String())
+	_, err = getBlockByHash(ctx, dbtx, blk.Hash())
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/protocol/bc/hash.go
+++ b/protocol/bc/hash.go
@@ -72,16 +72,15 @@ func (h *Hash) UnmarshalJSON(b []byte) error {
 
 // Value satisfies the driver.Valuer interface
 func (h Hash) Value() (driver.Value, error) {
-	return h.MarshalText()
+	return h[:], nil
 }
 
 // Scan satisfies the driver.Scanner interface
 func (h *Hash) Scan(val interface{}) error {
 	switch v := val.(type) {
 	case []byte:
-		return h.UnmarshalText(v)
-	case string:
-		return h.UnmarshalText([]byte(v))
+		copy(h[:], v)
+		return nil
 	default:
 		return fmt.Errorf("Hash.Scan received unsupported type %T", val)
 	}


### PR DESCRIPTION
Replaces all the hash columns in the database that use text with ones
that use bytea.