### PR TITLE
core/account: introduce receivers

### DIFF
--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -239,13 +239,10 @@ func (m *Manager) insertAccountControlProgram(ctx context.Context, progs ...*con
 		keyIndexes = append(keyIndexes, int64(p.keyIndex))
 		controlProgs = append(controlProgs, p.controlProgram)
 		change = append(change, p.change)
-
-		var expiry stdsql.NullString
-		if !p.expiresAt.IsZero() {
-			expiry.String = p.expiresAt.Format(time.RFC3339)
-			expiry.Valid = true
-		}
-		expirations = append(expirations, expiry)
+		expirations = append(expirations, stdsql.NullString{
+			String: p.expiresAt.Format(time.RFC3339),
+			Valid:  !p.expiresAt.IsZero(),
+		})
 	}
 
 	_, err := m.db.Exec(ctx, q, accountIDs, keyIndexes, controlProgs, change, pq.Array(expirations))

--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -177,9 +177,10 @@ type controlProgram struct {
 	keyIndex       uint64
 	controlProgram []byte
 	change         bool
+	expiresAt      time.Time
 }
 
-func (m *Manager) createControlProgram(ctx context.Context, accountID string, change bool) (*controlProgram, error) {
+func (m *Manager) createControlProgram(ctx context.Context, accountID string, change bool, expiresAt time.Time) (*controlProgram, error) {
 	account, err := m.findByID(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -202,17 +203,17 @@ func (m *Manager) createControlProgram(ctx context.Context, accountID string, ch
 		keyIndex:       idx,
 		controlProgram: control,
 		change:         change,
+		expiresAt:      expiresAt,
 	}, nil
 }
 
 // CreateControlProgram creates a control program
 // that is tied to the Account and stores it in the database.
-func (m *Manager) CreateControlProgram(ctx context.Context, accountID string, change bool) ([]byte, error) {
-	cp, err := m.createControlProgram(ctx, accountID, change)
+func (m *Manager) CreateControlProgram(ctx context.Context, accountID string, change bool, expiresAt time.Time) ([]byte, error) {
+	cp, err := m.createControlProgram(ctx, accountID, change, expiresAt)
 	if err != nil {
 		return nil, err
 	}
-
 	err = m.insertAccountControlProgram(ctx, cp)
 	if err != nil {
 		return nil, err
@@ -222,23 +223,32 @@ func (m *Manager) CreateControlProgram(ctx context.Context, accountID string, ch
 
 func (m *Manager) insertAccountControlProgram(ctx context.Context, progs ...*controlProgram) error {
 	const q = `
-		INSERT INTO account_control_programs (signer_id, key_index, control_program, change)
-		SELECT unnest($1::text[]), unnest($2::bigint[]), unnest($3::bytea[]), unnest($4::boolean[])
+		INSERT INTO account_control_programs (signer_id, key_index, control_program, change, expires_at)
+		SELECT unnest($1::text[]), unnest($2::bigint[]), unnest($3::bytea[]), unnest($4::boolean[]),
+			unnest($5::timestamp with time zone[])
 	`
 	var (
 		accountIDs   pq.StringArray
 		keyIndexes   pq.Int64Array
 		controlProgs pq.ByteaArray
 		change       pq.BoolArray
+		expirations  []stdsql.NullString
 	)
 	for _, p := range progs {
 		accountIDs = append(accountIDs, p.accountID)
 		keyIndexes = append(keyIndexes, int64(p.keyIndex))
 		controlProgs = append(controlProgs, p.controlProgram)
 		change = append(change, p.change)
+
+		var expiry stdsql.NullString
+		if !p.expiresAt.IsZero() {
+			expiry.String = p.expiresAt.Format(time.RFC3339)
+			expiry.Valid = true
+		}
+		expirations = append(expirations, expiry)
 	}
 
-	_, err := m.db.Exec(ctx, q, accountIDs, keyIndexes, controlProgs, change)
+	_, err := m.db.Exec(ctx, q, accountIDs, keyIndexes, controlProgs, change, pq.Array(expirations))
 	return errors.Wrap(err)
 }
 

--- a/core/account/accounts_test.go
+++ b/core/account/accounts_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg/pgtest"
@@ -77,7 +78,7 @@ func TestCreateControlProgram(t *testing.T) {
 		testutil.FatalErr(t, err)
 	}
 
-	got, err := m.CreateControlProgram(ctx, account.ID, false)
+	got, err := m.CreateControlProgram(ctx, account.ID, false, time.Now().Add(5*time.Minute))
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -107,7 +108,7 @@ func (m *Manager) createTestControlProgram(ctx context.Context, t testing.TB, ac
 		accountID = account.ID
 	}
 
-	acp, err := m.CreateControlProgram(ctx, accountID, false)
+	acp, err := m.CreateControlProgram(ctx, accountID, false, time.Now().Add(5*time.Minute))
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -77,7 +77,7 @@ func (a *spendAction) Build(ctx context.Context, b *txbuilder.TemplateBuilder) e
 	}
 
 	if res.Change > 0 {
-		acp, err := a.accounts.createControlProgram(ctx, a.AccountID, true)
+		acp, err := a.accounts.createControlProgram(ctx, a.AccountID, true, b.MaxTime())
 		if err != nil {
 			return errors.Wrap(err, "creating control program")
 		}
@@ -211,7 +211,7 @@ func (a *controlAction) Build(ctx context.Context, b *txbuilder.TemplateBuilder)
 	}
 
 	// Produce a control program, but don't insert it into the database yet.
-	acp, err := a.accounts.createControlProgram(ctx, a.AccountID, false)
+	acp, err := a.accounts.createControlProgram(ctx, a.AccountID, false, b.MaxTime())
 	if err != nil {
 		return err
 	}

--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"chain/core/account"
 	"chain/core/asset"
@@ -49,8 +50,8 @@ func TestAccountSourceReserve(t *testing.T) {
 	}
 	source := accounts.NewSpendAction(assetAmount1, accID, nil, nil)
 
-	var builder txbuilder.TemplateBuilder
-	err := source.Build(ctx, &builder)
+	builder := txbuilder.NewBuilder(time.Now().Add(5 * time.Minute))
+	err := source.Build(ctx, builder)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -100,8 +101,8 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 
 	source := accounts.NewSpendUTXOAction(out.OutputID)
 
-	var builder txbuilder.TemplateBuilder
-	err := source.Build(ctx, &builder)
+	builder := txbuilder.NewBuilder(time.Now().Add(5 * time.Minute))
+	err := source.Build(ctx, builder)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -154,9 +155,9 @@ func TestAccountSourceReserveIdempotency(t *testing.T) {
 	<-pinStore.PinWaiter(account.PinName, c.Height())
 
 	reserveFunc := func(source txbuilder.Action) []*bc.TxInput {
-		var builder txbuilder.TemplateBuilder
+		builder := txbuilder.NewBuilder(time.Now().Add(5 * time.Minute))
 
-		err := source.Build(ctx, &builder)
+		err := source.Build(ctx, builder)
 		if err != nil {
 			testutil.FatalErr(t, err)
 		}

--- a/core/account/receivers.go
+++ b/core/account/receivers.go
@@ -1,0 +1,45 @@
+package account
+
+import (
+	"context"
+	"time"
+
+	chainjson "chain/encoding/json"
+	"chain/errors"
+)
+
+const defaultReceiverExpiry = 30 * 24 * time.Hour // 30 days
+
+// Reciever encapsulates information about where to send assets to
+// be received by an account.
+type Receiver struct {
+	ControlProgram chainjson.HexBytes `json:"control_program"`
+	ExpiresAt      time.Time          `json:"expires_at"`
+}
+
+// CreateReceiver creates a new account receiver for an account
+// with the provided expiry. If a zero time is provided for the
+// expiry, a default expiry of 30 days from the current time is
+// used.
+func (m *Manager) CreateReceiver(ctx context.Context, accID, accAlias string, expiresAt time.Time) (*Receiver, error) {
+	if expiresAt.IsZero() {
+		expiresAt = time.Now().Add(defaultReceiverExpiry)
+	}
+
+	if accAlias != "" {
+		s, err := m.FindByAlias(ctx, accAlias)
+		if err != nil {
+			return nil, err
+		}
+		accID = s.ID
+	}
+
+	cp, err := m.CreateControlProgram(ctx, accID, false, expiresAt)
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+	return &Receiver{
+		ControlProgram: cp,
+		ExpiresAt:      expiresAt,
+	}, nil
+}

--- a/core/account/receivers_test.go
+++ b/core/account/receivers_test.go
@@ -1,0 +1,35 @@
+package account
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"chain/crypto/ed25519/chainkd"
+	"chain/database/pg/pgtest"
+	"chain/protocol/prottest"
+	"chain/testutil"
+)
+
+func TestCreateReceiver(t *testing.T) {
+	// use pgtest.NewDB for deterministic postgres sequences
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	m := NewManager(db, prottest.NewChain(t), nil)
+	ctx := context.Background()
+
+	account, err := m.Create(ctx, []chainkd.XPub{testutil.TestXPub}, 1, "alias", nil, "")
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+
+	exp := time.Now().Add(24 * 365 * time.Hour)
+	_, err = m.CreateReceiver(ctx, account.ID, "", exp)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+
+	_, err = m.CreateReceiver(ctx, "", "alias", exp)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+}

--- a/core/api.go
+++ b/core/api.go
@@ -120,7 +120,8 @@ func (h *Handler) init() {
 	m.Handle("/create-asset", needConfig(h.createAsset))
 	m.Handle("/build-transaction", needConfig(h.build))
 	m.Handle("/submit-transaction", needConfig(h.submit))
-	m.Handle("/create-control-program", needConfig(h.createControlProgram))
+	m.Handle("/create-control-program", needConfig(h.createControlProgram)) // DEPRECATED
+	m.Handle("/create-account-receiver", needConfig(h.createAccountReceiver))
 	m.Handle("/create-transaction-feed", needConfig(h.createTxFeed))
 	m.Handle("/get-transaction-feed", needConfig(h.getTxFeed))
 	m.Handle("/update-transaction-feed", needConfig(h.updateTxFeed))

--- a/core/control_programs.go
+++ b/core/control_programs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stdjson "encoding/json"
 	"sync"
+	"time"
 
 	"chain/encoding/json"
 	"chain/errors"
@@ -68,7 +69,7 @@ func (h *Handler) createAccountControlProgram(ctx context.Context, input []byte)
 		accountID = acc.ID
 	}
 
-	controlProgram, err := h.Accounts.CreateControlProgram(ctx, accountID, false)
+	controlProgram, err := h.Accounts.CreateControlProgram(ctx, accountID, false, time.Time{})
 	if err != nil {
 		return nil, err
 	}

--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -52,7 +52,7 @@ func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuild
 	tpl, err := txbuilder.Build(ctx, nil, []txbuilder.Action{
 		assets.NewIssueAction(assetAmount, nil), // does not support reference data
 		accounts.NewControlAction(bc.AssetAmount{AssetID: assetID, Amount: amount}, accountID, nil),
-	}, time.Now().Add(time.Minute))
+	}, time.Now().Add(time.Hour))
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
@@ -71,7 +71,7 @@ func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuild
 }
 
 func Transfer(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuilder.Submitter, actions []txbuilder.Action) *bc.Tx {
-	template, err := txbuilder.Build(ctx, nil, actions, time.Now().Add(time.Minute))
+	template, err := txbuilder.Build(ctx, nil, actions, time.Now().Add(time.Hour))
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -114,4 +114,7 @@ var migrations = []migration{
 			ADD COLUMN output_id bytea UNIQUE NOT NULL,
 			ADD COLUMN unspent_id bytea UNIQUE NOT NULL;
 	`},
+	{Name: "2017-01-25.0.account.cp-expiry.sql", SQL: `
+		ALTER TABLE account_control_programs ADD COLUMN expires_at timestamp with time zone;
+	`},
 }

--- a/core/receivers.go
+++ b/core/receivers.go
@@ -1,0 +1,38 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"chain/net/http/reqid"
+)
+
+// POST /create-account-receiver
+func (h *Handler) createAccountReceiver(ctx context.Context, ins []struct {
+	AccountID    string    `json:"account_id"`
+	AccountAlias string    `json:"account_alias"`
+	ExpiresAt    time.Time `json:"expires_at"`
+}) []interface{} {
+	responses := make([]interface{}, len(ins))
+	var wg sync.WaitGroup
+	wg.Add(len(responses))
+
+	for i := 0; i < len(responses); i++ {
+		go func(i int) {
+			subctx := reqid.NewSubContext(ctx, reqid.New())
+			defer wg.Done()
+			defer batchRecover(subctx, &responses[i])
+
+			receiver, err := h.Accounts.CreateReceiver(subctx, ins[i].AccountID, ins[i].AccountAlias, ins[i].ExpiresAt)
+			if err != nil {
+				responses[i] = err
+			} else {
+				responses[i] = receiver
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	return responses
+}

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.0
--- Dumped by pg_dump version 9.6.0
+-- Dumped from database version 9.6.1
+-- Dumped by pg_dump version 9.6.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -178,7 +178,8 @@ CREATE TABLE account_control_programs (
     signer_id text NOT NULL,
     key_index bigint NOT NULL,
     control_program bytea NOT NULL,
-    change boolean NOT NULL
+    change boolean NOT NULL,
+    expires_at timestamp with time zone
 );
 
 
@@ -909,3 +910,4 @@ insert into migrations (filename, hash) values ('2017-01-11.0.core.hash-bytea.sq
 insert into migrations (filename, hash) values ('2017-01-13.0.core.asset-definition-bytea.sql', 'f49458c5c8873d919ec35be4683074be0b04913c95f5ab1bf1402aa2b4847cf5');
 insert into migrations (filename, hash) values ('2017-01-19.0.asset.drop-mutable-flag.sql', '7850023d44c545c155c0ee372e7cdfef1859b40221bd94307b836503c26dd3de');
 insert into migrations (filename, hash) values ('2017-01-20.0.core.add-output-id-to-outputs.sql', '4c8531c06e62405d2989e0651a7ef6c2ebd0b2b269b57c179e9e36f7fdbb715b');
+insert into migrations (filename, hash) values ('2017-01-25.0.account.cp-expiry.sql', 'a2076b7b3ac3f844d17e13eea57fea01216c868a63f9df7b9df24cac9c4b82a4');

--- a/core/txbuilder/builder.go
+++ b/core/txbuilder/builder.go
@@ -9,6 +9,10 @@ import (
 	"chain/protocol/bc"
 )
 
+func NewBuilder(maxTime time.Time) *TemplateBuilder {
+	return &TemplateBuilder{maxTime: maxTime}
+}
+
 type TemplateBuilder struct {
 	base                *bc.TxData
 	inputs              []*bc.TxInput


### PR DESCRIPTION
Add a create-account-receiver endpoint to create expiring control
programs. By default, a receiver expires in 30 days. Control programs
created through the create-control-program rpc do not expire.
Control programs created automatically during transaction building
are created with the transaction's max time as an expiration.

The expiration is only considered to be elapsed once the Core ingests a
block with a timestamp greater than the control program's expiration.
This allows us to use a transaction's max time as the control program's
expiry without worrying about clock skew. Once the expiration has
elapsed, the control programs are deleted and forgotten.

If any assets are sent to an expired control program, the Core will not
index them (so they will not be spendable) or annotate them as belonging
to any account.

This PR adds a new server RPC but does not expose it as an interface
in the SDK yet.