### PR TITLE
docker/ci: add protobuf to ci build

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -7,6 +7,7 @@ RUN apk --no-cache add bash clang git g++ make nodejs openjdk8 python perl \
     && go get -u github.com/golang/protobuf/proto \
     && go get -u github.com/golang/protobuf/protoc-gen-go \
     && go get -u google.golang.org/grpc \
+# TODO: remove third party glibc (as well as openssl and ca-certificates) package when protobuf works with musl (next release)
     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
     && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk \
     && apk add glibc-2.23-r3.apk \

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,7 +1,15 @@
-FROM golang:1.7.3-alpine
+FROM golang:1.7.4-alpine
 
 RUN apk --no-cache add bash clang git g++ make nodejs openjdk8 python perl \
-    ruby ruby-bigdecimal ruby-bundler ruby-io-console ruby-irb ruby-json \
+    ruby ruby-bigdecimal ruby-bundler ruby-io-console ruby-irb ruby-json openssl ca-certificates \
+    && echo "http://dl-cdn.alpinelinux.org/alpine/v3.5/main" >> /etc/apk/repositories \
+    && apk --no-cache add "protobuf>3.1.0" \
+    && go get -u github.com/golang/protobuf/proto \
+    && go get -u github.com/golang/protobuf/protoc-gen-go \
+    && go get -u google.golang.org/grpc \
+    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
+    && wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.23-r3/glibc-2.23-r3.apk \
+    && apk add glibc-2.23-r3.apk \
     && MAVEN_VERSION=3.3.9 \
     && cd /usr/share \
     && wget -q http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -O - | tar xzf - \

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20161122
+box: chaindev/ci:20170113
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20170113
+box: chaindev/ci:20170118
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 


### PR DESCRIPTION
Protobuf 3.1 is not added until alpine 3.5, so that repository has to
be added to the list to get it. Additionally, protobuf was compiled
using glibc, but alpine by default only has musl. A third party
maintains an alpine package providing glibc.

A patch that allows protobuf to be compiled with musl has already been
merged, and should be available at the next release of protobuf. At that
time, glibc should be removed from this build.