### PR TITLE
docs/protocol: add acceptance program

### DIFF
--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -38,6 +38,7 @@
   * [Consensus Program](#consensus-program)
   * [Control Program](#control-program)
   * [Issuance Program](#issuance-program)
+  * [Acceptance Program](#acceptance-program)
   * [Program Arguments](#program-arguments)
   * [Asset Version](#asset-version)
   * [Asset ID](#asset-id)
@@ -359,10 +360,11 @@ The *output commitment* encapsulates both the value and the authentication data 
 
 Field           | Type                    | Description
 ----------------|-------------------------|----------------------------------------------------------
-Asset ID        | sha3-256                | Global [asset identifier](#asset-id).
-Amount          | varint63                | Number of units of the specified asset.
-VM Version      | varint63                | [Version of the VM](#vm-version) that executes the [control program](#control-program).
-Control Program | varstring31             | Predicate [program](#control-program) to control the specified amount.
+Asset ID           | sha3-256                | Global [asset identifier](#asset-id).
+Amount             | varint63                | Number of units of the specified asset.
+VM Version         | varint63                | [Version of the VM](#vm-version) that executes the [control program](#control-program).
+Control Program    | varstring31             | Predicate [program](#control-program) to control the specified amount.
+Acceptance Program | varstring31             | Predicate [program](#control-program) that must be satisfied by the transaction in which this output is included.
 —               | —                       | Additional fields may be added by future extensions.
 
 
@@ -372,7 +374,11 @@ Like the input witness data, the *output witness* string contains data necessary
 
 The output witness string can be extended with additional commitments, proofs or validation hints that are excluded from the [transaction ID](#transaction-id), but committed to the blockchain via the [witness hash](#transaction-witness-hash).
 
-**Asset version 1** and **VM version 1** do not use the output witness data which is set to an empty string (encoded as a single byte 0x00 that represents a varstring31 encoding of an empty string). To support future upgrades, nodes must accept and ignore arbitrary data in the output witness string.
+Field           | Type                    | Description
+----------------|-------------------------|----------------------------------------------------------
+Program Arguments Count | varint31                | Number of [program arguments](#program-arguments) that follow.
+Program Arguments       | [varstring31]           | [Signatures](#signature) and other data satisfying the acceptance program. Used to initialize the [data stack](vm1.md#vm-state) of the VM that executes the acceptance program.
+—               | —                       | Additional fields may be added by future extensions.
 
 ### Transaction Serialization Flags
 
@@ -455,6 +461,9 @@ The control program is a program specifying a predicate for transferring an asse
 
 The issuance program is a [program](#program) specifying a predicate for issuing an asset within an [input issuance commitment](#asset-version-1-issuance-commitment). The asset ID is derived from the issuance program, guaranteeing the authenticity of the issuer.
 
+### Acceptance Program
+
+The acceptance program is a [program](#program) specifying a predicate for including an output in a transaction. The program is executed at the time the output is created, unlike a control program, which is executed at the time the output is spent.
 
 ### Program Arguments
 

--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -1254,13 +1254,24 @@ Pushes the block timestamp in milliseconds on the data stack.
 
 Fails if executed in the [transaction context](#transaction-context).
 
+#### ACCEPTANCEPROGRAM
+
+Code  | Stack Diagram   | Cost
+------|-----------------|-----------------------------------------------------
+0xcf  | (∅ → program)     | 1; [standard memory cost](#standard-memory-cost)
+
+Pushes the [acceptance program](data.md#acceptance-program) from the output being spent.
+
+Fails if the current input is not an [issuance input](data.md#transaction-input-commitment).
+
+Fails if executed in the [block context](#block-context).
 
 
 ### Expansion opcodes
 
 Code  | Stack Diagram   | Cost
 ------|-----------------|-----------------------------------------------------
-0x50, 0x61, 0x62, 0x65, 0x66, 0x67, 0x68, 0x8a, 0x8d, 0x8e, 0xa6, 0xa7, 0xa9, 0xab, 0xb0..0xbf, 0xca, 0xcd..0xcf, 0xd0..0xff  | (∅ → ∅)     | 1
+0x50, 0x61, 0x62, 0x65, 0x66, 0x67, 0x68, 0x8a, 0x8d, 0x8e, 0xa6, 0xa7, 0xa9, 0xab, 0xb0..0xbf, 0xca, 0xd0..0xff  | (∅ → ∅)     | 1
 
 The unassigned codes are reserved for future expansion and have no effect on the state of the VM apart from reducing run limit by 1.
 

--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -80,6 +80,7 @@ Execution of any of the following instructions results in immediate failure:
 * [INDEX](#index)
 * [OUTPOINT](#outpoint)
 * [NONCE](#nonce)
+* [ACCOUNTPROGRAM](#accountprogram)
 
 
 ### Transaction context
@@ -1100,15 +1101,16 @@ Note: [standard memory cost](#standard-memory-cost) is applied *after* the instr
 
 Code  | Stack Diagram                                        | Cost
 ------|------------------------------------------------------|-----------------------------------------------------
-0xc1  | (index refdatahash amount assetid version prog → q)  | 16; [standard memory cost](#standard-memory-cost)
+0xc1  | (index refdatahash amount assetid version controlprog acceptanceprog → q)  | 16; [standard memory cost](#standard-memory-cost)
 
-1. Pops 6 items from the data stack: `index`, `refdatahash`, `amount`, `assetid`, `version`, `prog`.
+1. Pops 7 items from the data stack: `index`, `refdatahash`, `amount`, `assetid`, `version`, `controlprog`, `acceptanceprog`.
 2. Fails if `index` is negative or not a valid [number](#vm-number).
 3. Fails if the number of outputs is less or equal to `index`.
 4. Fails if `amount` and `version` are not non-negative [numbers](#vm-number).
 5. Finds a transaction output at the given `index`.
 6. If the output satisfies all of the following conditions pushes [true](#vm-boolean) on the data stack; otherwise pushes [false](#vm-boolean):
-    1. control program equals `prog`,
+    1. acceptance program equals `acceptanceprog`,
+    1. control program equals `controlprog`,
     2. VM version equals `version`,
     3. asset ID equals `assetid`,
     4. amount equals `amount`,


### PR DESCRIPTION
This adds a fourth use of VM programs, "acceptance programs". Acceptance programs are included in outputs alongside control programs, are run at the time that output is included in a transaction (rather than when it is spent), and must be satisfied by the transaction in which they are included.

Control programs can use the new `ACCEPTANCEPROGRAM` opcode to confirm, at the time the output is spent, which acceptance program was included in it. This means that if someone changes the acceptance program that is associated with a control program, the output will become unspendable.

This allows control programs to indirectly enforce conditions on transactions that spend to them. For example, the acceptance program can set an expiration time after which it cannot be included in an output, or it can require a signature by the recipient or some other party. The control program can then commit to that acceptance program.

