### PR TITLE
core/assets: createAsset response encodes IssuanceProgram in hex

### DIFF
--- a/core/assets.go
+++ b/core/assets.go
@@ -78,7 +78,7 @@ func (h *Handler) createAsset(ctx context.Context, ins []struct {
 			responses[i] = &assetResponse{
 				ID:              asset.AssetID,
 				Alias:           asset.Alias,
-				IssuanceProgram: asset.IssuanceProgram,
+				IssuanceProgram: json.HexBytes(asset.IssuanceProgram),
 				Keys:            keys,
 				Quorum:          asset.Signer.Quorum,
 				Definition:      asset.Definition,


### PR DESCRIPTION
Current implementation uses default base64 encoding that's inconsistent with use elsewhere (e.g. https://github.com/chain/chain/blob/27e2c5af0195d71aba8837e7e04fadf2ffbd2069/core/asset/block.go#L36). This change ensures hex-encoding for the issuance program in the "createAsset" response.