### PR TITLE
sdk/java: use list of objects for filter params

### DIFF
--- a/sdk/java/src/main/java/com/chain/api/BaseQueryBuilder.java
+++ b/sdk/java/src/main/java/com/chain/api/BaseQueryBuilder.java
@@ -56,7 +56,7 @@ public abstract class BaseQueryBuilder<T extends BaseQueryBuilder<T>> {
    * @param param parameter to be added
    * @return updated builder object
    */
-  public T addFilterParameter(String param) {
+  public T addFilterParameter(Object param) {
     this.next.filterParams.add(param);
     return (T) this;
   }
@@ -66,7 +66,7 @@ public abstract class BaseQueryBuilder<T extends BaseQueryBuilder<T>> {
    * <strong>Note:</strong> any existing filter params will be replaced.
    * @param params list of parameters to be added
    */
-  public T setFilterParameters(List<String> params) {
+  public T setFilterParameters(List<Object> params) {
     this.next.filterParams = new ArrayList<>(params);
     return (T) this;
   }

--- a/sdk/java/src/main/java/com/chain/api/Query.java
+++ b/sdk/java/src/main/java/com/chain/api/Query.java
@@ -18,7 +18,7 @@ public class Query {
    * Parameters used in the query's filter.
    */
   @SerializedName("filter_params")
-  public List<String> filterParams;
+  public List<Object> filterParams;
 
   /**
    * Specifies if this query is being used within a transaction feed.<br>

--- a/sdk/java/src/test/java/com/chain/integration/QueryTest.java
+++ b/sdk/java/src/test/java/com/chain/integration/QueryTest.java
@@ -286,7 +286,7 @@ public class QueryTest {
     UnspentOutput.Items items =
         new UnspentOutput.QueryBuilder()
             .setFilter("reference_data.test=$1")
-            .setFilterParameters(Arrays.asList((Object)test))
+            .setFilterParameters(Arrays.asList((Object) test))
             .setTimestamp(System.currentTimeMillis() - 100000000000L)
             .execute(client);
     assertEquals(0, items.list.size());
@@ -294,7 +294,7 @@ public class QueryTest {
     items =
         new UnspentOutput.QueryBuilder()
             .setFilter("reference_data.test=$1")
-            .setFilterParameters(Arrays.asList((Object)test))
+            .setFilterParameters(Arrays.asList((Object) test))
             .execute(client);
     UnspentOutput unspent = items.next();
     assertNotNull(unspent.type);

--- a/sdk/java/src/test/java/com/chain/integration/QueryTest.java
+++ b/sdk/java/src/test/java/com/chain/integration/QueryTest.java
@@ -286,7 +286,7 @@ public class QueryTest {
     UnspentOutput.Items items =
         new UnspentOutput.QueryBuilder()
             .setFilter("reference_data.test=$1")
-            .setFilterParameters(Arrays.asList(test))
+            .setFilterParameters(Arrays.asList((Object)test))
             .setTimestamp(System.currentTimeMillis() - 100000000000L)
             .execute(client);
     assertEquals(0, items.list.size());
@@ -294,7 +294,7 @@ public class QueryTest {
     items =
         new UnspentOutput.QueryBuilder()
             .setFilter("reference_data.test=$1")
-            .setFilterParameters(Arrays.asList(test))
+            .setFilterParameters(Arrays.asList((Object)test))
             .execute(client);
     UnspentOutput unspent = items.next();
     assertNotNull(unspent.type);


### PR DESCRIPTION
Some filter parameters cannot be represented as strings.