### PR TITLE
net/http/limit: extract limit functionality

### DIFF
--- a/net/http/limit/limit.go
+++ b/net/http/limit/limit.go
@@ -1,4 +1,3 @@
-// Package limit provides a rate limiting HTTP handler.
 package limit
 
 import (
@@ -8,15 +7,43 @@ import (
 	"golang.org/x/time/rate"
 )
 
+type BucketLimiter struct {
+	freq  rate.Limit
+	burst int
+
+	bucketMu sync.Mutex // protects the following
+	buckets  map[string]*rate.Limiter
+}
+
+func NewBucketLimiter(freq, burst int) *BucketLimiter {
+	return &BucketLimiter{
+		freq:    rate.Limit(freq),
+		burst:   burst,
+		buckets: make(map[string]*rate.Limiter),
+	}
+}
+
+func (b *BucketLimiter) Allow(id string) bool {
+	return b.bucket(id).Allow()
+}
+
+func (b *BucketLimiter) bucket(id string) *rate.Limiter {
+	b.bucketMu.Lock()
+	bucket, ok := b.buckets[id]
+	if !ok {
+		bucket = rate.NewLimiter(b.freq, b.burst)
+		b.buckets[id] = bucket
+	}
+	b.bucketMu.Unlock()
+	return bucket
+}
+
 type handler struct {
 	next    http.Handler
 	limited http.Handler
 	f       func(*http.Request) string
-	freq    rate.Limit
-	burst   int
 
-	bucketMu sync.Mutex // protects the following
-	buckets  map[string]*rate.Limiter
+	limiter *BucketLimiter
 }
 
 func Handler(next, limited http.Handler, freq, burst int, f func(*http.Request) string) http.Handler {
@@ -24,30 +51,17 @@ func Handler(next, limited http.Handler, freq, burst int, f func(*http.Request) 
 		next:    next,
 		limited: limited,
 		f:       f,
-		freq:    rate.Limit(freq),
-		burst:   burst,
-		buckets: make(map[string]*rate.Limiter),
+		limiter: NewBucketLimiter(freq, burst),
 	}
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	id := h.f(r)
-	if !h.bucket(id).Allow() {
+	if !h.limiter.Allow(id) {
 		h.limited.ServeHTTP(w, r)
 		return
 	}
 	h.next.ServeHTTP(w, r)
-}
-
-func (h *handler) bucket(id string) *rate.Limiter {
-	h.bucketMu.Lock()
-	bucket, ok := h.buckets[id]
-	if !ok {
-		bucket = rate.NewLimiter(h.freq, h.burst)
-		h.buckets[id] = bucket
-	}
-	h.bucketMu.Unlock()
-	return bucket
 }
 
 func RemoteAddrID(r *http.Request) string {


### PR DESCRIPTION
Rather than having the limit functionality contained in handler, it is
moved to a separate struct. This is helpful for allowing other protocols
to use limiters.