### PR TITLE
core/query: leave unmarshaling to request layer

### DIFF
--- a/core/accounts.go
+++ b/core/accounts.go
@@ -6,22 +6,23 @@ import (
 
 	"chain/core/signers"
 	"chain/crypto/ed25519/chainkd"
+	"chain/encoding/json"
 	"chain/net/http/reqid"
 )
 
 // This type enforces JSON field ordering in API output.
 type accountResponse struct {
-	ID     interface{} `json:"id"`
-	Alias  interface{} `json:"alias"`
-	Keys   interface{} `json:"keys"`
-	Quorum interface{} `json:"quorum"`
-	Tags   interface{} `json:"tags"`
+	ID     string                 `json:"id"`
+	Alias  string                 `json:"alias"`
+	Keys   []*accountKey          `json:"keys"`
+	Quorum int                    `json:"quorum"`
+	Tags   map[string]interface{} `json:"tags"`
 }
 
 type accountKey struct {
-	RootXPub              interface{} `json:"root_xpub"`
-	AccountXPub           interface{} `json:"account_xpub"`
-	AccountDerivationPath interface{} `json:"account_derivation_path"`
+	RootXPub              chainkd.XPub    `json:"root_xpub"`
+	AccountXPub           chainkd.XPub    `json:"account_xpub"`
+	AccountDerivationPath []json.HexBytes `json:"account_derivation_path"`
 }
 
 // POST /create-account
@@ -53,12 +54,16 @@ func (h *Handler) createAccount(ctx context.Context, ins []struct {
 				return
 			}
 			path := signers.Path(acc.Signer, signers.AccountKeySpace)
-			var keys []accountKey
+			var hexPath []json.HexBytes
+			for _, p := range path {
+				hexPath = append(hexPath, p)
+			}
+			var keys []*accountKey
 			for _, xpub := range acc.XPubs {
-				keys = append(keys, accountKey{
+				keys = append(keys, &accountKey{
 					RootXPub:              xpub,
 					AccountXPub:           xpub.Derive(path),
-					AccountDerivationPath: path,
+					AccountDerivationPath: hexPath,
 				})
 			}
 			responses[i] = &accountResponse{

--- a/core/assets.go
+++ b/core/assets.go
@@ -8,26 +8,27 @@ import (
 	"chain/crypto/ed25519/chainkd"
 	"chain/encoding/json"
 	"chain/net/http/reqid"
+	"chain/protocol/bc"
 )
 
 // This type enforces JSON field ordering in API output.
 type assetResponse struct {
-	ID              interface{} `json:"id"`
-	Alias           *string     `json:"alias"`
-	VMVersion       interface{} `json:"vm_version"`
-	IssuanceProgram interface{} `json:"issuance_program"`
-	Keys            interface{} `json:"keys"`
-	Quorum          interface{} `json:"quorum"`
-	Definition      interface{} `json:"definition"`
-	RawDefinition   interface{} `json:"raw_definition"`
-	Tags            interface{} `json:"tags"`
-	IsLocal         interface{} `json:"is_local"`
+	ID              bc.AssetID             `json:"id"`
+	Alias           *string                `json:"alias"`
+	VMVersion       uint64                 `json:"vm_version"`
+	IssuanceProgram json.HexBytes          `json:"issuance_program"`
+	Keys            []*assetKey            `json:"keys"`
+	Quorum          int                    `json:"quorum"`
+	Definition      map[string]interface{} `json:"definition"`
+	RawDefinition   json.HexBytes          `json:"raw_definition"`
+	Tags            map[string]interface{} `json:"tags"`
+	IsLocal         string                 `json:"is_local"`
 }
 
 type assetKey struct {
-	RootXPub            interface{} `json:"root_xpub"`
-	AssetPubkey         interface{} `json:"asset_pubkey"`
-	AssetDerivationPath interface{} `json:"asset_derivation_path"`
+	RootXPub            chainkd.XPub    `json:"root_xpub"`
+	AssetPubkey         json.HexBytes   `json:"asset_pubkey"`
+	AssetDerivationPath []json.HexBytes `json:"asset_derivation_path"`
 }
 
 // POST /create-asset
@@ -67,14 +68,18 @@ func (h *Handler) createAsset(ctx context.Context, ins []struct {
 				responses[i] = err
 				return
 			}
-			var keys []assetKey
+			var keys []*assetKey
 			for _, xpub := range asset.Signer.XPubs {
 				path := signers.Path(asset.Signer, signers.AssetKeySpace)
+				var hexPath []json.HexBytes
+				for _, p := range path {
+					hexPath = append(hexPath, p)
+				}
 				derived := xpub.Derive(path)
-				keys = append(keys, assetKey{
-					AssetPubkey:         json.HexBytes(derived[:]),
+				keys = append(keys, &assetKey{
+					AssetPubkey:         derived[:],
 					RootXPub:            xpub,
-					AssetDerivationPath: path,
+					AssetDerivationPath: hexPath,
 				})
 			}
 			parsedDef, _ := asset.Definition() // cannot fail because Assets.Define() would catch parsing issues
@@ -82,7 +87,7 @@ func (h *Handler) createAsset(ctx context.Context, ins []struct {
 				ID:              asset.AssetID,
 				Alias:           asset.Alias,
 				VMVersion:       asset.VMVersion,
-				IssuanceProgram: json.HexBytes(asset.IssuanceProgram),
+				IssuanceProgram: asset.IssuanceProgram,
 				Keys:            keys,
 				Quorum:          asset.Signer.Quorum,
 				Definition:      parsedDef,

--- a/core/query/accounts.go
+++ b/core/query/accounts.go
@@ -27,7 +27,7 @@ func (ind *Indexer) SaveAnnotatedAccount(ctx context.Context, accountID string, 
 }
 
 // Accounts queries the blockchain for accounts matching the query `q`.
-func (ind *Indexer) Accounts(ctx context.Context, p filter.Predicate, vals []interface{}, after string, limit int) ([]map[string]interface{}, string, error) {
+func (ind *Indexer) Accounts(ctx context.Context, p filter.Predicate, vals []interface{}, after string, limit int) ([][]byte, string, error) {
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
 	}
@@ -43,7 +43,7 @@ func (ind *Indexer) Accounts(ctx context.Context, p filter.Predicate, vals []int
 	}
 	defer rows.Close()
 
-	accounts := make([]map[string]interface{}, 0, limit)
+	accounts := make([][]byte, 0, limit)
 	for rows.Next() {
 		var accID string
 		var rawAccount []byte
@@ -52,16 +52,8 @@ func (ind *Indexer) Accounts(ctx context.Context, p filter.Predicate, vals []int
 			return nil, "", errors.Wrap(err, "scanning account row")
 		}
 
-		var account map[string]interface{}
-		if len(rawAccount) > 0 {
-			err = json.Unmarshal(rawAccount, &account)
-			if err != nil {
-				return nil, "", err
-			}
-		}
-
 		after = accID
-		accounts = append(accounts, account)
+		accounts = append(accounts, rawAccount)
 	}
 	return accounts, after, errors.Wrap(rows.Err())
 }

--- a/core/query/assets.go
+++ b/core/query/assets.go
@@ -28,7 +28,7 @@ func (ind *Indexer) SaveAnnotatedAsset(ctx context.Context, assetID bc.AssetID, 
 }
 
 // Assets queries the blockchain for annotated assets matching the query.
-func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []interface{}, after string, limit int) ([]map[string]interface{}, string, error) {
+func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []interface{}, after string, limit int) ([][]byte, string, error) {
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
 	}
@@ -44,7 +44,7 @@ func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []inter
 	}
 	defer rows.Close()
 
-	assets := make([]map[string]interface{}, 0, limit)
+	assets := make([][]byte, 0, limit)
 	for rows.Next() {
 		var (
 			sortID   string
@@ -55,16 +55,8 @@ func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []inter
 			return nil, "", errors.Wrap(err, "scanning annotated asset row")
 		}
 
-		var asset map[string]interface{}
-		if len(rawAsset) > 0 {
-			err = json.Unmarshal(rawAsset, &asset)
-			if err != nil {
-				return nil, "", err
-			}
-		}
-
 		after = sortID
-		assets = append(assets, asset)
+		assets = append(assets, rawAsset)
 	}
 	err = rows.Err()
 	if err != nil {

--- a/core/query/outputs.go
+++ b/core/query/outputs.go
@@ -3,7 +3,6 @@ package query
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
@@ -48,7 +47,7 @@ func DecodeOutputsAfter(str string) (c *OutputsAfter, err error) {
 	}, nil
 }
 
-func (ind *Indexer) Outputs(ctx context.Context, p filter.Predicate, vals []interface{}, timestampMS uint64, after *OutputsAfter, limit int) ([]interface{}, *OutputsAfter, error) {
+func (ind *Indexer) Outputs(ctx context.Context, p filter.Predicate, vals []interface{}, timestampMS uint64, after *OutputsAfter, limit int) ([][]byte, *OutputsAfter, error) {
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
 	}
@@ -68,7 +67,7 @@ func (ind *Indexer) Outputs(ctx context.Context, p filter.Predicate, vals []inte
 		newAfter = *after
 	}
 
-	outputs := make([]interface{}, 0, limit)
+	outputs := make([][]byte, 0, limit)
 	for rows.Next() {
 		var (
 			blockHeight uint64
@@ -80,7 +79,7 @@ func (ind *Indexer) Outputs(ctx context.Context, p filter.Predicate, vals []inte
 		if err != nil {
 			return nil, nil, err
 		}
-		outputs = append(outputs, (*json.RawMessage)(&data))
+		outputs = append(outputs, data)
 
 		newAfter.lastBlockHeight = blockHeight
 		newAfter.lastTxPos = txPos

--- a/core/query/outputs_test.go
+++ b/core/query/outputs_test.go
@@ -258,8 +258,7 @@ func TestQueryOutputs(t *testing.T) {
 					AccountID *string `json:"account_id"`
 				}
 
-				bytes := output.(*json.RawMessage)
-				err := json.Unmarshal(*bytes, &got)
+				err := json.Unmarshal(output, &got)
 				if err != nil {
 					t.Fatalf("case %d: output is not a JSON object", i)
 				}

--- a/core/query/transactions.go
+++ b/core/query/transactions.go
@@ -3,7 +3,6 @@ package query
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -71,7 +70,7 @@ func (ind *Indexer) LookupTxAfter(ctx context.Context, begin, end uint64) (TxAft
 
 // Transactions queries the blockchain for transactions matching the
 // filter predicate `p`.
-func (ind *Indexer) Transactions(ctx context.Context, p filter.Predicate, vals []interface{}, after TxAfter, limit int, asc bool) ([]interface{}, *TxAfter, error) {
+func (ind *Indexer) Transactions(ctx context.Context, p filter.Predicate, vals []interface{}, after TxAfter, limit int, asc bool) ([][]byte, *TxAfter, error) {
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
 	}
@@ -125,21 +124,21 @@ func constructTransactionsQuery(expr filter.SQLExpr, after TxAfter, asc bool, li
 	return buf.String(), vals
 }
 
-func (ind *Indexer) fetchTransactions(ctx context.Context, queryStr string, queryArgs []interface{}, after TxAfter, limit int) ([]interface{}, *TxAfter, error) {
+func (ind *Indexer) fetchTransactions(ctx context.Context, queryStr string, queryArgs []interface{}, after TxAfter, limit int) ([][]byte, *TxAfter, error) {
 	rows, err := ind.db.Query(ctx, queryStr, queryArgs...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "executing txn query")
 	}
 	defer rows.Close()
 
-	txns := make([]interface{}, 0, limit)
+	txns := make([][]byte, 0, limit)
 	for rows.Next() {
 		var data []byte
 		err := rows.Scan(&after.FromBlockHeight, &after.FromPosition, &data)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "scanning transaction row")
 		}
-		txns = append(txns, (*json.RawMessage)(&data))
+		txns = append(txns, data)
 	}
 	err = rows.Err()
 	if err != nil {
@@ -149,16 +148,16 @@ func (ind *Indexer) fetchTransactions(ctx context.Context, queryStr string, quer
 }
 
 type fetchResp struct {
-	txns  []interface{}
+	txns  [][]byte
 	after *TxAfter
 	err   error
 }
 
-func (ind *Indexer) waitForAndFetchTransactions(ctx context.Context, queryStr string, queryArgs []interface{}, after TxAfter, limit int) ([]interface{}, *TxAfter, error) {
+func (ind *Indexer) waitForAndFetchTransactions(ctx context.Context, queryStr string, queryArgs []interface{}, after TxAfter, limit int) ([][]byte, *TxAfter, error) {
 	resp := make(chan fetchResp, 1)
 	go func() {
 		var (
-			txs []interface{}
+			txs [][]byte
 			aft *TxAfter
 			err error
 		)


### PR DESCRIPTION
Rather than unmarshaling from the database into a struct or map
and then doing conversion at the request layer before sending a
response to the client, just leave the unmarshaling to the request
layer, where it can guarantee ordering.