### PR TITLE
protocol/bc: move OutputCommitment into its own file

### DIFF
--- a/protocol/bc/outputcommitment.go
+++ b/protocol/bc/outputcommitment.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"chain/encoding/blockchain"
+	"chain/encoding/bufpool"
 	"chain/errors"
 )
 
@@ -16,39 +17,50 @@ type OutputCommitment struct {
 	ControlProgram []byte
 }
 
-func (oc *OutputCommitment) WriteTo(w io.Writer) error {
-	err := oc.AssetAmount.writeTo(w)
-	if err != nil {
-		return errors.Wrap(err, "writing asset amount")
+func (oc *OutputCommitment) writeTo(w io.Writer, assetVersion uint64) (err error) {
+	b := bufpool.Get()
+	defer bufpool.Put(b)
+	if assetVersion == 1 {
+		err = oc.AssetAmount.writeTo(b)
+		if err != nil {
+			return errors.Wrap(err, "writing asset amount")
+		}
+
+		_, err = blockchain.WriteVarint63(b, oc.VMVersion)
+		if err != nil {
+			return errors.Wrap(err, "writing vm version")
+		}
+		_, err = blockchain.WriteVarstr31(b, oc.ControlProgram)
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = blockchain.WriteVarint63(w, oc.VMVersion)
-	if err != nil {
-		return errors.Wrap(err, "writing vm version")
-	}
-
-	_, err = blockchain.WriteVarstr31(w, oc.ControlProgram)
+	_, err = blockchain.WriteVarstr31(w, b.Bytes())
 	return errors.Wrap(err, "writing control program")
 }
 
-func (oc *OutputCommitment) ReadFrom(r io.Reader) (int64, error) {
-	n, err := oc.AssetAmount.readFrom(r)
-	if err != nil {
-		return int64(n), errors.Wrap(err, "reading asset+amount")
+func (oc *OutputCommitment) readFrom(r io.Reader, txVersion, assetVersion uint64) (n int, err error) {
+	if assetVersion != 1 {
+		return n, fmt.Errorf("unrecognized asset version %d", assetVersion)
 	}
+	all := txVersion == 1
+	return blockchain.ReadExtensibleString(r, all, func(r io.Reader) error {
+		_, err := oc.AssetAmount.readFrom(r)
+		if err != nil {
+			return errors.Wrap(err, "reading asset+amount")
+		}
 
-	var n2 int
-	oc.VMVersion, n2, err = blockchain.ReadVarint63(r)
-	n += n2
-	if err != nil {
-		return int64(n), errors.Wrap(err, "reading VM version")
-	}
+		oc.VMVersion, _, err = blockchain.ReadVarint63(r)
+		if err != nil {
+			return errors.Wrap(err, "reading VM version")
+		}
 
-	if oc.VMVersion != 1 {
-		return int64(n), fmt.Errorf("unrecognized VM version %d for asset version 1", oc.VMVersion)
-	}
+		if oc.VMVersion != 1 {
+			return fmt.Errorf("unrecognized VM version %d for asset version 1", oc.VMVersion)
+		}
 
-	oc.ControlProgram, n2, err = blockchain.ReadVarstr31(r)
-	n += n2
-	return int64(n), errors.Wrap(err, "reading control program")
+		oc.ControlProgram, _, err = blockchain.ReadVarstr31(r)
+		return errors.Wrap(err, "reading control program")
+	})
 }

--- a/protocol/bc/outputcommitment.go
+++ b/protocol/bc/outputcommitment.go
@@ -1,0 +1,54 @@
+package bc
+
+import (
+	"fmt"
+	"io"
+
+	"chain/encoding/blockchain"
+	"chain/errors"
+)
+
+// OutputCommitment contains the commitment data for a transaction
+// output (which also appears in the spend input of that output).
+type OutputCommitment struct {
+	AssetAmount
+	VMVersion      uint64
+	ControlProgram []byte
+}
+
+func (oc *OutputCommitment) WriteTo(w io.Writer) (int64, error) {
+	n, err := oc.AssetAmount.writeTo(w)
+	if err != nil {
+		return n, err
+	}
+	n2, err := blockchain.WriteVarint63(w, oc.VMVersion)
+	n += int64(n2)
+	if err != nil {
+		return n, err
+	}
+	n2, err = blockchain.WriteVarstr31(w, oc.ControlProgram)
+	n += int64(n2)
+	return n, err
+}
+
+func (oc *OutputCommitment) ReadFrom(r io.Reader) (int64, error) {
+	n, err := oc.AssetAmount.readFrom(r)
+	if err != nil {
+		return int64(n), errors.Wrap(err, "reading asset+amount")
+	}
+
+	var n2 int
+	oc.VMVersion, n2, err = blockchain.ReadVarint63(r)
+	n += n2
+	if err != nil {
+		return int64(n), errors.Wrap(err, "reading VM version")
+	}
+
+	if oc.VMVersion != 1 {
+		return int64(n), fmt.Errorf("unrecognized VM version %d for asset version 1", oc.VMVersion)
+	}
+
+	oc.ControlProgram, n2, err = blockchain.ReadVarstr31(r)
+	n += n2
+	return int64(n), errors.Wrap(err, "reading control program")
+}

--- a/protocol/bc/outputcommitment.go
+++ b/protocol/bc/outputcommitment.go
@@ -16,19 +16,19 @@ type OutputCommitment struct {
 	ControlProgram []byte
 }
 
-func (oc *OutputCommitment) WriteTo(w io.Writer) (int64, error) {
-	n, err := oc.AssetAmount.writeTo(w)
+func (oc *OutputCommitment) WriteTo(w io.Writer) error {
+	err := oc.AssetAmount.writeTo(w)
 	if err != nil {
-		return n, err
+		return errors.Wrap(err, "writing asset amount")
 	}
-	n2, err := blockchain.WriteVarint63(w, oc.VMVersion)
-	n += int64(n2)
+
+	_, err = blockchain.WriteVarint63(w, oc.VMVersion)
 	if err != nil {
-		return n, err
+		return errors.Wrap(err, "writing vm version")
 	}
-	n2, err = blockchain.WriteVarstr31(w, oc.ControlProgram)
-	n += int64(n2)
-	return n, err
+
+	_, err = blockchain.WriteVarstr31(w, oc.ControlProgram)
+	return errors.Wrap(err, "writing control program")
 }
 
 func (oc *OutputCommitment) ReadFrom(r io.Reader) (int64, error) {

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -1,30 +1,20 @@
 package bc
 
 import (
-	"fmt"
 	"io"
 
 	"chain/encoding/blockchain"
-	"chain/encoding/bufpool"
 	"chain/errors"
 )
 
 // TODO(bobg): Review serialization/deserialization logic for
 // assetVersions other than 1.
 
-type (
-	TxOutput struct {
-		AssetVersion uint64
-		OutputCommitment
-		ReferenceData []byte
-	}
-
-	OutputCommitment struct {
-		AssetAmount
-		VMVersion      uint64
-		ControlProgram []byte
-	}
-)
+type TxOutput struct {
+	AssetVersion uint64
+	OutputCommitment
+	ReferenceData []byte
+}
 
 func NewTxOutput(assetID AssetID, amount uint64, controlProgram, referenceData []byte) *TxOutput {
 	return &TxOutput{
@@ -64,31 +54,6 @@ func (to *TxOutput) readFrom(r io.Reader, txVersion uint64) (err error) {
 	return errors.Wrap(err, "reading output witness")
 }
 
-func (oc *OutputCommitment) readFrom(r io.Reader, txVersion, assetVersion uint64) (n int, err error) {
-	if assetVersion != 1 {
-		return n, fmt.Errorf("unrecognized asset version %d", assetVersion)
-	}
-	all := txVersion == 1
-	return blockchain.ReadExtensibleString(r, all, func(r io.Reader) error {
-		_, err := oc.AssetAmount.readFrom(r)
-		if err != nil {
-			return errors.Wrap(err, "reading asset+amount")
-		}
-
-		oc.VMVersion, _, err = blockchain.ReadVarint63(r)
-		if err != nil {
-			return errors.Wrap(err, "reading VM version")
-		}
-
-		if oc.VMVersion != 1 {
-			return fmt.Errorf("unrecognized VM version %d for asset version 1", oc.VMVersion)
-		}
-
-		oc.ControlProgram, _, err = blockchain.ReadVarstr31(r)
-		return errors.Wrap(err, "reading control program")
-	})
-}
-
 // assumes r has sticky errors
 func (to *TxOutput) writeTo(w io.Writer, serflags byte) {
 	blockchain.WriteVarint63(w, to.AssetVersion) // TODO(bobg): check and return error
@@ -103,25 +68,4 @@ func (to *TxOutput) witnessHash() Hash {
 
 func (to *TxOutput) WriteCommitment(w io.Writer) {
 	to.OutputCommitment.writeTo(w, to.AssetVersion)
-}
-
-func (oc *OutputCommitment) writeTo(w io.Writer, assetVersion uint64) (err error) {
-	b := bufpool.Get()
-	defer bufpool.Put(b)
-	if assetVersion == 1 {
-		err = oc.AssetAmount.writeTo(b)
-		if err != nil {
-			return err
-		}
-		_, err = blockchain.WriteVarint63(b, oc.VMVersion)
-		if err != nil {
-			return err
-		}
-		_, err = blockchain.WriteVarstr31(b, oc.ControlProgram)
-		if err != nil {
-			return err
-		}
-	}
-	_, err = blockchain.WriteVarstr31(w, b.Bytes())
-	return err
 }


### PR DESCRIPTION
Part of #349. 

Note that this simply splits out `OutputCommitment` without making some of the other changes to the output commitment that are included in 349.