### PR TITLE
protocol/bc: return errors from WitnessHash functions

### DIFF
--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -200,7 +200,7 @@ func (tx *TxData) Hash() Hash {
 // WitnessHash is the combined hash of the
 // transactions hash and signature data hash.
 // It is used to compute the TxRoot of a block.
-func (tx *Tx) WitnessHash() (hash Hash) {
+func (tx *Tx) WitnessHash() (hash Hash, err error) {
 	hasher := sha3pool.Get256()
 	defer sha3pool.Put256(hasher)
 
@@ -208,7 +208,10 @@ func (tx *Tx) WitnessHash() (hash Hash) {
 
 	blockchain.WriteVarint31(hasher, uint64(len(tx.Inputs))) // TODO(bobg): check and return error
 	for _, txin := range tx.Inputs {
-		h := txin.witnessHash()
+		h, err := txin.witnessHash()
+		if err != nil {
+			return hash, err
+		}
 		hasher.Write(h[:])
 	}
 
@@ -219,7 +222,7 @@ func (tx *Tx) WitnessHash() (hash Hash) {
 	}
 
 	hasher.Read(hash[:])
-	return hash
+	return hash, nil
 }
 
 func (tx *TxData) IssuanceHash(n int) (h Hash, err error) {

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -163,7 +163,12 @@ func TestTransaction(t *testing.T) {
 		if test.tx.Hash != test.hash {
 			t.Errorf("test %d: hash = %s want %x", i, test.tx.Hash, test.hash)
 		}
-		if g := test.tx.WitnessHash(); g != test.witnessHash {
+
+		g, err := test.tx.WitnessHash()
+		if err != nil {
+			t.Fatalf("unexpected error %s", err)
+		}
+		if g != test.witnessHash {
 			t.Errorf("test %d: witness hash = %s want %x", i, g, test.witnessHash)
 		}
 

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -348,13 +348,15 @@ func (t *TxInput) writeInputWitness(w io.Writer) error {
 	return nil
 }
 
-func (t *TxInput) witnessHash() Hash {
-	var h Hash
+func (t *TxInput) witnessHash() (h Hash, err error) {
 	sha := sha3pool.Get256()
 	defer sha3pool.Put256(sha)
-	t.writeInputWitness(sha)
+	err = t.writeInputWitness(sha)
+	if err != nil {
+		return h, err
+	}
 	sha.Read(h[:])
-	return h
+	return h, nil
 }
 
 func (t *TxInput) Outpoint() (o Outpoint) {

--- a/protocol/recover_test.go
+++ b/protocol/recover_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"context"
+	"log"
 	"testing"
 	"time"
 
@@ -55,6 +56,11 @@ func TestRecoverSnapshotNoAdditionalBlocks(t *testing.T) {
 }
 
 func createEmptyBlock(block *bc.Block, snapshot *state.Snapshot) *bc.Block {
+	root, err := validation.CalcMerkleRoot(nil)
+	if err != nil {
+		log.Fatalf("calculating empty merkle root: %s", err)
+	}
+
 	return &bc.Block{
 		BlockHeader: bc.BlockHeader{
 			Version:                bc.NewBlockVersion,
@@ -62,7 +68,7 @@ func createEmptyBlock(block *bc.Block, snapshot *state.Snapshot) *bc.Block {
 			PreviousBlockHash:      block.Hash(),
 			TimestampMS:            bc.Millis(time.Now()),
 			ConsensusProgram:       block.ConsensusProgram,
-			TransactionsMerkleRoot: validation.CalcMerkleRoot(nil),
+			TransactionsMerkleRoot: root,
 			AssetsMerkleRoot:       snapshot.Tree.RootHash(),
 		},
 	}

--- a/protocol/validation/block.go
+++ b/protocol/validation/block.go
@@ -141,7 +141,11 @@ func validateBlockHeader(prev *bc.BlockHeader, block *bc.Block) error {
 		}
 	}
 
-	txMerkleRoot := CalcMerkleRoot(block.Transactions)
+	txMerkleRoot, err := CalcMerkleRoot(block.Transactions)
+	if err != nil {
+		return errors.Wrap(err, "calculating tx merkle root")
+	}
+
 	// can be modified to allow soft fork
 	if block.TransactionsMerkleRoot != txMerkleRoot {
 		return ErrBadTxRoot

--- a/protocol/validation/merkle_test.go
+++ b/protocol/validation/merkle_test.go
@@ -62,7 +62,10 @@ func TestCalcMerkleRoot(t *testing.T) {
 				},
 			}))
 		}
-		got := CalcMerkleRoot(txs)
+		got, err := CalcMerkleRoot(txs)
+		if err != nil {
+			t.Fatalf("unexpected error %s", err)
+		}
 		if !bytes.Equal(got[:], c.want[:]) {
 			t.Log("witnesses", c.witnesses)
 			t.Errorf("got merkle root = %s want %s", got, c.want)
@@ -86,11 +89,17 @@ func TestDuplicateLeaves(t *testing.T) {
 
 	// first, get the root of an unbalanced tree
 	txns := []*bc.Tx{txs[5], txs[4], txs[3], txs[2], txs[1], txs[0]}
-	root1 := CalcMerkleRoot(txns)
+	root1, err := CalcMerkleRoot(txns)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
 
 	// now, get the root of a balanced tree that repeats leaves 0 and 1
 	txns = []*bc.Tx{txs[5], txs[4], txs[3], txs[2], txs[1], txs[0], txs[1], txs[0]}
-	root2 := CalcMerkleRoot(txns)
+	root2, err := CalcMerkleRoot(txns)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
 
 	if root1 == root2 {
 		t.Error("forged merkle tree by duplicating some leaves")
@@ -113,11 +122,17 @@ func TestAllDuplicateLeaves(t *testing.T) {
 
 	// first, get the root of an unbalanced tree
 	txs := []*bc.Tx{tx6, tx5, tx4, tx3, tx2, tx1}
-	root1 := CalcMerkleRoot(txs)
+	root1, err := CalcMerkleRoot(txs)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
 
 	// now, get the root of a balanced tree that repeats leaves 5 and 6
 	txs = []*bc.Tx{tx6, tx5, tx6, tx5, tx4, tx3, tx2, tx1}
-	root2 := CalcMerkleRoot(txs)
+	root2, err := CalcMerkleRoot(txs)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
 
 	if root1 == root2 {
 		t.Error("forged merkle tree with all duplicate leaves")


### PR DESCRIPTION
This trickles down to `CalcMerkleRoot` as well. Part of #349. 