### PR TITLE
protocol/bc: new files for TypedInputs

### DIFF
--- a/protocol/bc/issuance.go
+++ b/protocol/bc/issuance.go
@@ -1,0 +1,59 @@
+package bc
+
+import "chain/crypto/sha3pool"
+
+type IssuanceInput struct {
+	// Commitment
+	Nonce  []byte
+	Amount uint64
+	// Note: as long as we require serflags=0x7, we don't need to
+	// explicitly store the asset ID here even though it's technically
+	// part of the input commitment. We can compute it instead from
+	// values in the witness (which, with serflags other than 0x7,
+	// might not be present).
+
+	// Witness
+	InitialBlock    Hash
+	AssetDefinition []byte
+	VMVersion       uint64
+	IssuanceProgram []byte
+	Arguments       [][]byte
+}
+
+func (ii *IssuanceInput) IsIssuance() bool { return true }
+
+func (ii *IssuanceInput) AssetID() AssetID {
+	return ComputeAssetID(ii.IssuanceProgram, ii.InitialBlock, ii.VMVersion, ii.AssetDefinitionHash())
+}
+
+func (ii *IssuanceInput) AssetDefinitionHash() (defhash Hash) {
+	sha := sha3pool.Get256()
+	defer sha3pool.Put256(sha)
+	sha.Write(ii.AssetDefinition)
+	sha.Read(defhash[:])
+	return
+}
+
+func NewIssuanceInput(
+	nonce []byte,
+	amount uint64,
+	referenceData []byte,
+	initialBlock Hash,
+	issuanceProgram []byte,
+	arguments [][]byte,
+	assetDefinition []byte,
+) *TxInput {
+	return &TxInput{
+		AssetVersion:  1,
+		ReferenceData: referenceData,
+		TypedInput: &IssuanceInput{
+			Nonce:           nonce,
+			Amount:          amount,
+			InitialBlock:    initialBlock,
+			AssetDefinition: assetDefinition,
+			VMVersion:       1,
+			IssuanceProgram: issuanceProgram,
+			Arguments:       arguments,
+		},
+	}
+}

--- a/protocol/bc/spend.go
+++ b/protocol/bc/spend.go
@@ -1,0 +1,35 @@
+package bc
+
+// SpendInput satisfies the TypedInput interface and represents a spend transaction.
+type SpendInput struct {
+	// Commitment
+	Outpoint
+	OutputCommitment
+
+	// Witness
+	Arguments [][]byte
+}
+
+func (si *SpendInput) IsIssuance() bool { return false }
+
+func NewSpendInput(txhash Hash, index uint32, arguments [][]byte, assetID AssetID, amount uint64, controlProgram, referenceData []byte) *TxInput {
+	return &TxInput{
+		AssetVersion:  1,
+		ReferenceData: referenceData,
+		TypedInput: &SpendInput{
+			Outpoint: Outpoint{
+				Hash:  txhash,
+				Index: index,
+			},
+			OutputCommitment: OutputCommitment{
+				AssetAmount: AssetAmount{
+					AssetID: assetID,
+					Amount:  amount,
+				},
+				VMVersion:      1,
+				ControlProgram: controlProgram,
+			},
+			Arguments: arguments,
+		},
+	}
+}

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -19,82 +19,9 @@ type (
 	TypedInput interface {
 		IsIssuance() bool
 	}
-
-	SpendInput struct {
-		// Commitment
-		Outpoint
-		OutputCommitment
-
-		// Witness
-		Arguments [][]byte
-	}
-
-	IssuanceInput struct {
-		// Commitment
-		Nonce  []byte
-		Amount uint64
-		// Note: as long as we require serflags=0x7, we don't need to
-		// explicitly store the asset ID here even though it's technically
-		// part of the input commitment. We can compute it instead from
-		// values in the witness (which, with serflags other than 0x7,
-		// might not be present).
-
-		// Witness
-		InitialBlock    Hash
-		AssetDefinition []byte
-		VMVersion       uint64
-		IssuanceProgram []byte
-		Arguments       [][]byte
-	}
 )
 
 var errBadAssetID = errors.New("asset ID does not match other issuance parameters")
-
-func NewSpendInput(txhash Hash, index uint32, arguments [][]byte, assetID AssetID, amount uint64, controlProgram, referenceData []byte) *TxInput {
-	return &TxInput{
-		AssetVersion:  1,
-		ReferenceData: referenceData,
-		TypedInput: &SpendInput{
-			Outpoint: Outpoint{
-				Hash:  txhash,
-				Index: index,
-			},
-			OutputCommitment: OutputCommitment{
-				AssetAmount: AssetAmount{
-					AssetID: assetID,
-					Amount:  amount,
-				},
-				VMVersion:      1,
-				ControlProgram: controlProgram,
-			},
-			Arguments: arguments,
-		},
-	}
-}
-
-func NewIssuanceInput(
-	nonce []byte,
-	amount uint64,
-	referenceData []byte,
-	initialBlock Hash,
-	issuanceProgram []byte,
-	arguments [][]byte,
-	assetDefinition []byte,
-) *TxInput {
-	return &TxInput{
-		AssetVersion:  1,
-		ReferenceData: referenceData,
-		TypedInput: &IssuanceInput{
-			Nonce:           nonce,
-			Amount:          amount,
-			InitialBlock:    initialBlock,
-			AssetDefinition: assetDefinition,
-			VMVersion:       1,
-			IssuanceProgram: issuanceProgram,
-			Arguments:       arguments,
-		},
-	}
-}
 
 func (t *TxInput) AssetAmount() AssetAmount {
 	if ii, ok := t.TypedInput.(*IssuanceInput); ok {
@@ -364,20 +291,4 @@ func (t *TxInput) Outpoint() (o Outpoint) {
 		o = si.Outpoint
 	}
 	return o
-}
-
-func (si *SpendInput) IsIssuance() bool { return false }
-
-func (ii *IssuanceInput) IsIssuance() bool { return true }
-
-func (ii *IssuanceInput) AssetID() AssetID {
-	return ComputeAssetID(ii.IssuanceProgram, ii.InitialBlock, ii.VMVersion, ii.AssetDefinitionHash())
-}
-
-func (ii *IssuanceInput) AssetDefinitionHash() (defhash Hash) {
-	sha := sha3pool.Get256()
-	defer sha3pool.Put256(sha)
-	sha.Write(ii.AssetDefinition)
-	sha.Read(defhash[:])
-	return
 }


### PR DESCRIPTION
Part of #349. In 349, there are other changes to both `IssuanceInput` and `SpendInput`, but I don't make those changes here.