### PR TITLE
all: don't require GOPATH to be set

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,14 +33,14 @@ Set the `CHAIN` environment variable, in `.profile` in your home
 directory, to point to the root of the Chain source code repo:
 
 ```
-export CHAIN=$GOPATH/src/chain
+export CHAIN=$(go env GOPATH)/src/chain
 ```
 
 You should also add `$CHAIN/bin` to your path (as well as
-`$GOPATH/bin`, if it isn’t already):
+`$(go env GOPATH)/bin`, if it isn’t already):
 
 ```
-PATH=$GOPATH/bin:$CHAIN/bin:$PATH
+PATH=$(go env GOPATH)/bin:$CHAIN/bin:$PATH
 ```
 
 You might want to open a new terminal window to pick up the change.
@@ -91,14 +91,14 @@ $ dumpschema
 
 To add or update a Go dependency, do the following:
 
-Copy the code from `$GOPATH/src/x`
+Copy the code from `$(go env GOPATH)/src/x`
 to `$CHAIN/vendor/x`. For example, to vendor the package
 `github.com/kr/pretty`, run
 
 ```
 $ mkdir -p $CHAIN/vendor/github.com/kr
 $ rm -r $CHAIN/vendor/github.com/kr/pretty
-$ cp -r $GOPATH/src/github.com/kr/pretty $CHAIN/vendor/github.com/kr/pretty
+$ cp -r $(go env GOPATH)/src/github.com/kr/pretty $CHAIN/vendor/github.com/kr/pretty
 $ rm -rf $CHAIN/vendor/github.com/kr/pretty/.git
 ```
 

--- a/bin/lbc
+++ b/bin/lbc
@@ -9,8 +9,8 @@ cleanup() {(
 		kill -9 $pid
 	done
 	wait
-	rm -rf $GOPATH/bin/cored
-	rm -rf $GOPATH/bin/corectl
+	rm -rf $(go env GOPATH)/bin/cored
+	rm -rf $(go env GOPATH)/bin/corectl
 	dropdb lbc-gen-core
 	dropdb lbc-s1-core
 	dropdb lbc-s2-core

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -15,9 +15,9 @@ cleanup() {(
 	done
 	wait
 	rm -rf $CHAIN/sdk/java/target
-	rm -rf $GOPATH/bin/cored
-	rm -rf $GOPATH/bin/corectl
-	rm -rf $GOPATH/bin/migratedb
+	rm -rf $(go env GOPATH)/bin/cored
+	rm -rf $(go env GOPATH)/bin/corectl
+	rm -rf $(go env GOPATH)/bin/migratedb
 	dropdb it-core
 )}
 trap cleanup EXIT

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -7,12 +7,12 @@ RUN apk --no-cache add bash clang git g++ make nodejs openjdk8 python perl \
     && wget -q http://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz -O - | tar xzf - \
     && mv /usr/share/apache-maven-$MAVEN_VERSION /usr/share/maven \
     && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
-    && git clone https://github.com/GoASTScanner/gas $GOPATH/src/github.com/GoASTScanner/gas \
-    && cd $GOPATH/src/github.com/GoASTScanner/gas \
+    && git clone https://github.com/GoASTScanner/gas $(go env GOPATH)/src/github.com/GoASTScanner/gas \
+    && cd $(go env GOPATH)/src/github.com/GoASTScanner/gas \
     && git reset --hard d30c5cde3613e9ba0129febda849e4d4df1d57cd \
     && go install github.com/GoASTScanner/gas
 
 ADD bin /usr/bin
-ENV CHAIN $GOPATH/src/chain
+ENV CHAIN $(go env GOPATH)/src/chain
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV MAVEN_HOME /usr/share/maven

--- a/docker/ci/bin/core-tests
+++ b/docker/ci/bin/core-tests
@@ -7,7 +7,7 @@ set -veou pipefail
 # run unit tests
 go version
 go env
-PATH=$GOPATH/bin:$PATH:$CHAIN/bin
+PATH=$(go env GOPATH)/bin:$PATH:$CHAIN/bin
 cd $CHAIN
 go vet $(go list ./...|grep -v vendor)
 go install chain/cmd/vet

--- a/docker/ci/bin/setup-core
+++ b/docker/ci/bin/setup-core
@@ -19,10 +19,10 @@ waitForGenerator() {(
 	done
 )}
 
-PATH=$GOPATH/bin:$PATH:$CHAIN/bin
+PATH=$(go env GOPATH)/bin:$PATH:$CHAIN/bin
 go install -tags 'insecure_disable_https_redirect' chain/cmd/cored
 go install chain/cmd/corectl
-$GOPATH/bin/corectl config-generator
+corectl config-generator
 initlog=`mktemp`
-$GOPATH/bin/cored 2>&1 | tee $initlog &
+cored 2>&1 | tee $initlog &
 waitForGenerator

--- a/docker/testbot/startup.sh
+++ b/docker/testbot/startup.sh
@@ -15,4 +15,4 @@ cd $CHAIN/sdk/java && mvn package && rm -rf $CHAIN/sdk/java/target
     chain/cmd/testbot\
     chain/cmd/benchcore\
 
-exec $GOPATH/bin/testbot
+exec $(go env GOPATH)/bin/testbot

--- a/docker/testbot/tests.sh
+++ b/docker/testbot/tests.sh
@@ -2,6 +2,7 @@
 
 set -eou pipefail
 
+GOPATH=$(go env GOPATH)
 mkdir -p $GOPATH/log/testbot
 initlog=$GOPATH/log/testbot/init.log
 


### PR DESCRIPTION
Starting in Go 1.8, it is possible to install and use Go
without setting GOPATH. Several of our shell scripts and
instructions assume that GOPATH is set (almost always to
determine the location of installed executables), but
this assumption will become invalid soon. (And I think
it's unreasonable to impose setting GOPATH as an extra
requirement just for our environment.) We can fix this
by calling 'go env GOPATH', which prints the computed
value of GOPATH (either the string the user set, or the
default, which happens to be $HOME/go in Go 1.8).