### PR TITLE
docker/ci: fix CHAIN env variable

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -13,6 +13,6 @@ RUN apk --no-cache add bash clang git g++ make nodejs openjdk8 python perl \
     && go install github.com/GoASTScanner/gas
 
 ADD bin /usr/bin
-ENV CHAIN $(go env GOPATH)/src/chain
+ENV CHAIN ${GOPATH:-$HOME/go}/src/chain
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV MAVEN_HOME /usr/share/maven


### PR DESCRIPTION
Unfortunately, it turns out that docker's ENV instruction cannot run
commands. As such, in this one area it is better to use simple variables
rather than `go env GOPATH`.