### PR TITLE
core: handle null raw_transactions

### DIFF
--- a/core/transact.go
+++ b/core/transact.go
@@ -103,6 +103,10 @@ func (h *Handler) build(ctx context.Context, buildReqs []*buildRequest) (interfa
 }
 
 func (h *Handler) submitSingle(ctx context.Context, tpl *txbuilder.Template, waitUntil string) (interface{}, error) {
+	if tpl.Transaction == nil {
+		return nil, errors.Wrap(txbuilder.ErrMissingRawTx)
+	}
+
 	err := h.finalizeTxWait(ctx, tpl, waitUntil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "tx %s", tpl.Transaction.Hash())
@@ -178,10 +182,6 @@ func CleanupSubmittedTxs(ctx context.Context, db pg.DB) {
 // on the blockchain.  context.DeadlineExceeded means ctx is an
 // expiring context that timed out.
 func (h *Handler) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Template, waitUntil string) error {
-	if txTemplate.Transaction == nil {
-		return errors.Wrap(txbuilder.ErrMissingRawTx)
-	}
-
 	// Use the current generator height as the lower bound of the block height
 	// that the transaction may appear in.
 	generatorHeight, _ := fetch.GeneratorHeight()

--- a/sdk/java/src/test/java/com/chain/integration/FailureTest.java
+++ b/sdk/java/src/test/java/com/chain/integration/FailureTest.java
@@ -94,6 +94,9 @@ public class FailureTest {
     try {
       Transaction.submit(client, new Transaction.Template());
     } catch (APIException e) {
+      if (!"CH730".equals(e.code)) {
+          throw new Exception("expecting CH730 code, got " + e.code);
+      }
       return;
     }
     throw new Exception("expecting APIException");

--- a/sdk/java/src/test/java/com/chain/integration/FailureTest.java
+++ b/sdk/java/src/test/java/com/chain/integration/FailureTest.java
@@ -95,7 +95,7 @@ public class FailureTest {
       Transaction.submit(client, new Transaction.Template());
     } catch (APIException e) {
       if (!"CH730".equals(e.code)) {
-          throw new Exception("expecting CH730 code, got " + e.code);
+        throw new Exception("expecting CH730 code, got " + e.code);
       }
       return;
     }


### PR DESCRIPTION
Previously, we correctly checked for a null `raw_transaction` on a
template, and returned a descriptive error. But higher in the call
stack we'd try to wrap the error with the transaction hash. Trying
to call Hash() on the nil transaction would panic.

Fixes #405.