### PR TITLE
core/asset: drop 'mutable_definition' column

### DIFF
--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -104,4 +104,7 @@ var migrations = []migration{
 			ALTER COLUMN definition SET NOT NULL;
 		ALTER TABLE assets ADD COLUMN vm_version bigint NOT NULL;
 	`},
+	{Name: "2017-01-19.0.asset.drop-mutable-flag.sql", SQL: `
+		ALTER TABLE assets DROP COLUMN definition_mutable;
+	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.0
--- Dumped by pg_dump version 9.6.0
+-- Dumped from database version 9.6.1
+-- Dumped by pg_dump version 9.6.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -273,7 +273,6 @@ CREATE TABLE asset_tags (
 CREATE TABLE assets (
     id bytea NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    definition_mutable boolean DEFAULT false NOT NULL,
     sort_id text DEFAULT next_chain_id('asset'::text) NOT NULL,
     issuance_program bytea NOT NULL,
     client_token text,
@@ -881,3 +880,4 @@ insert into migrations (filename, hash) values ('2017-01-05.0.core.rename_block_
 insert into migrations (filename, hash) values ('2017-01-10.0.signers.xpubs-type.sql', '4a4d6c736a2bf65e69abbdc87771faa1dc17a0106b2651a6a58af067708d095a');
 insert into migrations (filename, hash) values ('2017-01-11.0.core.hash-bytea.sql', '9f7f15df3479c38f193884a2d3cb7ae8001ed08607f9cc661fd5c420e248688d');
 insert into migrations (filename, hash) values ('2017-01-13.0.core.asset-definition-bytea.sql', 'f49458c5c8873d919ec35be4683074be0b04913c95f5ab1bf1402aa2b4847cf5');
+insert into migrations (filename, hash) values ('2017-01-19.0.asset.drop-mutable-flag.sql', '7850023d44c545c155c0ee372e7cdfef1859b40221bd94307b836503c26dd3de');


### PR DESCRIPTION
Drop the `mutable_definition` column from the assets table. We don't
allow mutable asset definitions. This column is never read and is always
set to the default.