### PR TITLE
core/query: define annotated accounts & assets

### DIFF
--- a/core/account/indexer.go
+++ b/core/account/indexer.go
@@ -27,11 +27,7 @@ type Saver interface {
 	SaveAnnotatedAccount(context.Context, *query.AnnotatedAccount) error
 }
 
-func (m *Manager) indexAnnotatedAccount(ctx context.Context, a *Account) error {
-	if m.indexer == nil {
-		return nil
-	}
-
+func Annotated(a *Account) (*query.AnnotatedAccount, error) {
 	aa := &query.AnnotatedAccount{
 		ID:     a.ID,
 		Alias:  a.Alias,
@@ -40,7 +36,7 @@ func (m *Manager) indexAnnotatedAccount(ctx context.Context, a *Account) error {
 
 	tags, err := json.Marshal(a.Tags)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	rawTags := json.RawMessage(tags)
 	aa.Tags = &rawTags
@@ -57,7 +53,17 @@ func (m *Manager) indexAnnotatedAccount(ctx context.Context, a *Account) error {
 			AccountDerivationPath: jsonPath,
 		})
 	}
+	return aa, nil
+}
 
+func (m *Manager) indexAnnotatedAccount(ctx context.Context, a *Account) error {
+	if m.indexer == nil {
+		return nil
+	}
+	aa, err := Annotated(a)
+	if err != nil {
+		return err
+	}
 	return m.indexer.SaveAnnotatedAccount(ctx, aa)
 }
 

--- a/core/account/indexer.go
+++ b/core/account/indexer.go
@@ -2,12 +2,14 @@ package account
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/lib/pq"
 
+	"chain/core/query"
 	"chain/core/signers"
 	"chain/database/pg"
-	"chain/encoding/json"
+	chainjson "chain/encoding/json"
 	"chain/errors"
 	"chain/protocol/bc"
 	"chain/protocol/state"
@@ -22,33 +24,41 @@ const PinName = "account"
 // If the Core is configured not to provide search services,
 // SaveAnnotatedAccount can be a no-op.
 type Saver interface {
-	SaveAnnotatedAccount(context.Context, string, map[string]interface{}) error
+	SaveAnnotatedAccount(context.Context, *query.AnnotatedAccount) error
 }
 
 func (m *Manager) indexAnnotatedAccount(ctx context.Context, a *Account) error {
 	if m.indexer == nil {
 		return nil
 	}
-	var keys []map[string]interface{}
+
+	aa := &query.AnnotatedAccount{
+		ID:     a.ID,
+		Alias:  a.Alias,
+		Quorum: a.Quorum,
+	}
+
+	tags, err := json.Marshal(a.Tags)
+	if err != nil {
+		return err
+	}
+	rawTags := json.RawMessage(tags)
+	aa.Tags = &rawTags
+
 	path := signers.Path(a.Signer, signers.AccountKeySpace)
-	var jsonPath []json.HexBytes
+	var jsonPath []chainjson.HexBytes
 	for _, p := range path {
 		jsonPath = append(jsonPath, p)
 	}
 	for _, xpub := range a.XPubs {
-		keys = append(keys, map[string]interface{}{
-			"root_xpub":               xpub,
-			"account_xpub":            xpub.Derive(path),
-			"account_derivation_path": jsonPath,
+		aa.Keys = append(aa.Keys, &query.AccountKey{
+			RootXPub:              xpub,
+			AccountXPub:           xpub.Derive(path),
+			AccountDerivationPath: jsonPath,
 		})
 	}
-	return m.indexer.SaveAnnotatedAccount(ctx, a.ID, map[string]interface{}{
-		"id":     a.ID,
-		"alias":  a.Alias,
-		"keys":   keys,
-		"tags":   a.Tags,
-		"quorum": a.Quorum,
-	})
+
+	return m.indexer.SaveAnnotatedAccount(ctx, aa)
 }
 
 type rawOutput struct {

--- a/core/asset/annotate_test.go
+++ b/core/asset/annotate_test.go
@@ -10,6 +10,7 @@ import (
 	"chain/core/query"
 	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg/pgtest"
+	"chain/protocol/bc"
 	"chain/protocol/prottest"
 	"chain/testutil"
 )
@@ -39,14 +40,14 @@ func TestAnnotateTxs(t *testing.T) {
 	txs := []*query.AnnotatedTx{
 		{
 			Inputs: []*query.AnnotatedInput{
-				{AssetID: asset1.AssetID[:]},
-				{AssetID: asset2.AssetID[:]},
-				{AssetID: []byte{0xba, 0xd0}},
+				{AssetID: asset1.AssetID},
+				{AssetID: asset2.AssetID},
+				{AssetID: bc.AssetID{0xba, 0xd0}},
 			},
 			Outputs: []*query.AnnotatedOutput{
-				{AssetID: asset1.AssetID[:]},
-				{AssetID: asset2.AssetID[:]},
-				{AssetID: []byte{0xba, 0xd0}},
+				{AssetID: asset1.AssetID},
+				{AssetID: asset2.AssetID},
+				{AssetID: bc.AssetID{0xba, 0xd0}},
 			},
 		},
 	}
@@ -55,14 +56,14 @@ func TestAnnotateTxs(t *testing.T) {
 	want := []*query.AnnotatedTx{
 		{
 			Inputs: []*query.AnnotatedInput{
-				{AssetID: asset1.AssetID[:], AssetTags: &rawtags1, AssetIsLocal: true, AssetDefinition: &rawdef1},
-				{AssetID: asset2.AssetID[:], AssetTags: &rawtags2, AssetIsLocal: true, AssetDefinition: &empty},
-				{AssetID: []byte{0xba, 0xd0}, AssetTags: &empty, AssetDefinition: &empty},
+				{AssetID: asset1.AssetID, AssetTags: &rawtags1, AssetIsLocal: true, AssetDefinition: &rawdef1},
+				{AssetID: asset2.AssetID, AssetTags: &rawtags2, AssetIsLocal: true, AssetDefinition: &empty},
+				{AssetID: bc.AssetID{0xba, 0xd0}, AssetTags: &empty, AssetDefinition: &empty},
 			},
 			Outputs: []*query.AnnotatedOutput{
-				{AssetID: asset1.AssetID[:], AssetTags: &rawtags1, AssetIsLocal: true, AssetDefinition: &rawdef1},
-				{AssetID: asset2.AssetID[:], AssetTags: &rawtags2, AssetIsLocal: true, AssetDefinition: &empty},
-				{AssetID: []byte{0xba, 0xd0}, AssetTags: &empty, AssetDefinition: &empty},
+				{AssetID: asset1.AssetID, AssetTags: &rawtags1, AssetIsLocal: true, AssetDefinition: &rawdef1},
+				{AssetID: asset2.AssetID, AssetTags: &rawtags2, AssetIsLocal: true, AssetDefinition: &empty},
+				{AssetID: bc.AssetID{0xba, 0xd0}, AssetTags: &empty, AssetDefinition: &empty},
 			},
 		},
 	}

--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -330,6 +330,12 @@ func assetQuery(ctx context.Context, db pg.DB, pred string, args ...interface{})
 			return nil, errors.Wrap(err)
 		}
 	}
+	if len(a.rawDefinition) > 0 {
+		err := json.Unmarshal(a.rawDefinition, &a.definition)
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+	}
 
 	return &a, nil
 }

--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -27,11 +27,7 @@ type Saver interface {
 	SaveAnnotatedAsset(context.Context, *query.AnnotatedAsset, string) error
 }
 
-func (reg *Registry) indexAnnotatedAsset(ctx context.Context, a *Asset) error {
-	if reg.indexer == nil {
-		return nil
-	}
-
+func Annotated(a *Asset) (*query.AnnotatedAsset, error) {
 	jsonTags := json.RawMessage(`{}`)
 	jsonDefinition := json.RawMessage(`{}`)
 	if len(a.RawDefinition()) > 0 {
@@ -40,7 +36,7 @@ func (reg *Registry) indexAnnotatedAsset(ctx context.Context, a *Asset) error {
 	if a.Tags != nil {
 		b, err := json.Marshal(a.Tags)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		jsonTags = b
 	}
@@ -82,6 +78,17 @@ func (reg *Registry) indexAnnotatedAsset(ctx context.Context, a *Asset) error {
 			}
 			aa.Quorum = quorum
 		}
+	}
+	return aa, nil
+}
+
+func (reg *Registry) indexAnnotatedAsset(ctx context.Context, a *Asset) error {
+	if reg.indexer == nil {
+		return nil
+	}
+	aa, err := Annotated(a)
+	if err != nil {
+		return err
 	}
 	return reg.indexer.SaveAnnotatedAsset(ctx, aa, a.sortID)
 }

--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -42,7 +42,7 @@ func Annotated(a *Asset) (*query.AnnotatedAsset, error) {
 	}
 
 	aa := &query.AnnotatedAsset{
-		ID:              a.AssetID[:],
+		ID:              a.AssetID,
 		VMVersion:       a.VMVersion,
 		Definition:      &jsonDefinition,
 		Tags:            &jsonTags,

--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -2,12 +2,14 @@ package asset
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/lib/pq"
 
+	"chain/core/query"
 	"chain/core/signers"
 	"chain/database/pg"
-	"chain/encoding/json"
+	chainjson "chain/encoding/json"
 	"chain/errors"
 	"chain/protocol/bc"
 	"chain/protocol/vmutil"
@@ -22,58 +24,66 @@ const PinName = "asset"
 // If the Core is configured not to provide search services,
 // SaveAnnotatedAsset can be a no-op.
 type Saver interface {
-	SaveAnnotatedAsset(context.Context, bc.AssetID, map[string]interface{}, string) error
+	SaveAnnotatedAsset(context.Context, *query.AnnotatedAsset, string) error
 }
 
 func (reg *Registry) indexAnnotatedAsset(ctx context.Context, a *Asset) error {
 	if reg.indexer == nil {
 		return nil
 	}
-	m := map[string]interface{}{
-		"id":               a.AssetID,
-		"alias":            a.Alias,
-		"raw_definition":   json.HexBytes(a.RawDefinition()),
-		"vm_version":       a.VMVersion,
-		"issuance_program": json.HexBytes(a.IssuanceProgram),
-		"tags":             a.Tags,
-		"is_local":         "no",
+
+	jsonTags := json.RawMessage(`{}`)
+	jsonDefinition := json.RawMessage(`{}`)
+	if len(a.RawDefinition()) > 0 {
+		jsonDefinition = json.RawMessage(a.RawDefinition())
 	}
-	adef, err := a.Definition()
-	if err == nil {
-		m["definition"] = adef
+	if a.Tags != nil {
+		b, err := json.Marshal(a.Tags)
+		if err != nil {
+			return err
+		}
+		jsonTags = b
+	}
+
+	aa := &query.AnnotatedAsset{
+		ID:              a.AssetID[:],
+		VMVersion:       a.VMVersion,
+		Definition:      &jsonDefinition,
+		Tags:            &jsonTags,
+		RawDefinition:   chainjson.HexBytes(a.RawDefinition()),
+		IssuanceProgram: chainjson.HexBytes(a.IssuanceProgram),
+	}
+	if a.Alias != nil {
+		aa.Alias = *a.Alias
 	}
 	if a.Signer != nil {
-		var keys []map[string]interface{}
 		path := signers.Path(a.Signer, signers.AssetKeySpace)
-		var jsonPath []json.HexBytes
+		var jsonPath []chainjson.HexBytes
 		for _, p := range path {
 			jsonPath = append(jsonPath, p)
 		}
 		for _, xpub := range a.Signer.XPubs {
 			derived := xpub.Derive(path)
-			keys = append(keys, map[string]interface{}{
-				"root_xpub":             xpub,
-				"asset_pubkey":          derived,
-				"asset_derivation_path": jsonPath,
+			aa.Keys = append(aa.Keys, &query.AssetKey{
+				RootXPub:            xpub,
+				AssetPubkey:         derived[:],
+				AssetDerivationPath: jsonPath,
 			})
 		}
-		m["keys"] = keys
-		m["quorum"] = a.Signer.Quorum
-		m["is_local"] = "yes"
+		aa.Quorum = a.Signer.Quorum
+		aa.IsLocal = true
 	} else {
 		pubkeys, quorum, err := vmutil.ParseP2SPMultiSigProgram(a.IssuanceProgram)
 		if err == nil {
-			var keys []map[string]interface{}
 			for _, pubkey := range pubkeys {
-				keys = append(keys, map[string]interface{}{
-					"asset_pubkey": json.HexBytes(pubkey),
+				aa.Keys = append(aa.Keys, &query.AssetKey{
+					AssetPubkey: chainjson.HexBytes(pubkey[:]),
 				})
 			}
-			m["keys"] = keys
-			m["quorum"] = quorum
+			aa.Quorum = quorum
 		}
 	}
-	return reg.indexer.SaveAnnotatedAsset(ctx, a.AssetID, m, a.sortID)
+	return reg.indexer.SaveAnnotatedAsset(ctx, aa, a.sortID)
 }
 
 func (reg *Registry) ProcessBlocks(ctx context.Context) {

--- a/core/asset/block_test.go
+++ b/core/asset/block_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"chain/core/query"
 	"chain/crypto/ed25519"
 	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg/pgtest"
@@ -16,10 +17,10 @@ const rawdef = `{
   "currency": "USD"
 }`
 
-type fakeSaver func(context.Context, bc.AssetID, map[string]interface{}, string) error
+type fakeSaver func(context.Context, *query.AnnotatedAsset, string) error
 
-func (f fakeSaver) SaveAnnotatedAsset(ctx context.Context, assetID bc.AssetID, obj map[string]interface{}, sortID string) error {
-	return f(ctx, assetID, obj, sortID)
+func (f fakeSaver) SaveAnnotatedAsset(ctx context.Context, aa *query.AnnotatedAsset, sortID string) error {
+	return f(ctx, aa, sortID)
 }
 
 func TestIndexNonLocalAssets(t *testing.T) {
@@ -78,8 +79,10 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	remoteAssetID := b.Transactions[0].Inputs[0].AssetID()
 
 	var assetsSaved []bc.AssetID
-	r.indexer = fakeSaver(func(ctx context.Context, assetID bc.AssetID, obj map[string]interface{}, sortID string) error {
-		assetsSaved = append(assetsSaved, assetID)
+	r.indexer = fakeSaver(func(ctx context.Context, aa *query.AnnotatedAsset, sortID string) error {
+		var aid bc.AssetID
+		copy(aid[:], aa.ID)
+		assetsSaved = append(assetsSaved, aid)
 		return nil
 	})
 

--- a/core/asset/block_test.go
+++ b/core/asset/block_test.go
@@ -81,7 +81,7 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	var assetsSaved []bc.AssetID
 	r.indexer = fakeSaver(func(ctx context.Context, aa *query.AnnotatedAsset, sortID string) error {
 		var aid bc.AssetID
-		copy(aid[:], aa.ID)
+		copy(aid[:], aa.ID[:])
 		assetsSaved = append(assetsSaved, aid)
 		return nil
 	})

--- a/core/query.go
+++ b/core/query.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"encoding/json"
 	"math"
 
 	"chain/core/query"
@@ -34,22 +33,12 @@ func (h *Handler) listAccounts(ctx context.Context, in requestQuery) (page, erro
 		return page{}, errors.Wrap(err, "running acc query")
 	}
 
-	result := make([]*accountResponse, 0, len(accounts))
-	for _, a := range accounts {
-		var r accountResponse
-		err := json.Unmarshal(a, &r)
-		if err != nil {
-			return page{}, errors.Wrap(err, "unmarshaling stored account")
-		}
-		result = append(result, &r)
-	}
-
 	// Pull in the accounts by the IDs
 	out := in
 	out.After = after
 	return page{
-		Items:    httpjson.Array(result),
-		LastPage: len(result) < limit,
+		Items:    httpjson.Array(accounts),
+		LastPage: len(accounts) < limit,
 		Next:     out,
 	}, nil
 }
@@ -77,21 +66,11 @@ func (h *Handler) listAssets(ctx context.Context, in requestQuery) (page, error)
 		return page{}, errors.Wrap(err, "running asset query")
 	}
 
-	result := make([]*assetResponse, 0, len(assets))
-	for _, a := range assets {
-		var r assetResponse
-		err := json.Unmarshal(a, &r)
-		if err != nil {
-			return page{}, errors.Wrap(err, "unmarshaling stored asset")
-		}
-		result = append(result, &r)
-	}
-
 	out := in
 	out.After = after
 	return page{
-		Items:    httpjson.Array(result),
-		LastPage: len(result) < limit,
+		Items:    httpjson.Array(assets),
+		LastPage: len(assets) < limit,
 		Next:     out,
 	}, nil
 }

--- a/core/query/annotated.go
+++ b/core/query/annotated.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"chain/crypto/ed25519/chainkd"
 	chainjson "chain/encoding/json"
 	"chain/protocol/bc"
 	"chain/protocol/vmutil"
@@ -66,6 +67,39 @@ type AnnotatedOutput struct {
 type SpentOutput struct {
 	TransactionID chainjson.HexBytes `json:"transaction_id"`
 	Position      uint32             `json:"position"`
+}
+
+type AnnotatedAccount struct {
+	ID     string           `json:"id"`
+	Alias  string           `json:"alias,omitempty"`
+	Keys   []*AccountKey    `json:"keys"`
+	Quorum int              `json:"quorum"`
+	Tags   *json.RawMessage `json:"tags"`
+}
+
+type AccountKey struct {
+	RootXPub              chainkd.XPub         `json:"root_xpub"`
+	AccountXPub           chainkd.XPub         `json:"account_xpub"`
+	AccountDerivationPath []chainjson.HexBytes `json:"account_derivation_path"`
+}
+
+type AnnotatedAsset struct {
+	ID              chainjson.HexBytes `json:"id"`
+	Alias           string             `json:"alias,omitempty"`
+	VMVersion       uint64             `json:"vm_version"`
+	IssuanceProgram chainjson.HexBytes `json:"issuance_program"`
+	Keys            []*AssetKey        `json:"keys"`
+	Quorum          int                `json:"quorum"`
+	Definition      *json.RawMessage   `json:"definition"`
+	RawDefinition   chainjson.HexBytes `json:"raw_definition"`
+	Tags            *json.RawMessage   `json:"tags"`
+	IsLocal         Bool               `json:"is_local"`
+}
+
+type AssetKey struct {
+	RootXPub            chainkd.XPub         `json:"root_xpub"`
+	AssetPubkey         chainjson.HexBytes   `json:"asset_pubkey"`
+	AssetDerivationPath []chainjson.HexBytes `json:"asset_derivation_path"`
 }
 
 type Bool bool

--- a/core/query/assets.go
+++ b/core/query/assets.go
@@ -3,17 +3,17 @@ package query
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strconv"
 
 	"chain/core/query/filter"
 	"chain/errors"
-	"chain/protocol/bc"
 )
 
 // SaveAnnotatedAsset saves an annotated asset to the query indexes.
-func (ind *Indexer) SaveAnnotatedAsset(ctx context.Context, assetID bc.AssetID, asset map[string]interface{}, sortID string) error {
+func (ind *Indexer) SaveAnnotatedAsset(ctx context.Context, asset *AnnotatedAsset, sortID string) error {
 	b, err := json.Marshal(asset)
 	if err != nil {
 		return errors.Wrap(err)
@@ -23,12 +23,12 @@ func (ind *Indexer) SaveAnnotatedAsset(ctx context.Context, assetID bc.AssetID, 
 		INSERT INTO annotated_assets (id, data, sort_id) VALUES($1, $2, $3)
 		ON CONFLICT (id) DO UPDATE SET data = $2, sort_id = $3
 	`
-	_, err = ind.db.Exec(ctx, q, assetID.String(), b, sortID)
+	_, err = ind.db.Exec(ctx, q, hex.EncodeToString(asset.ID), b, sortID)
 	return errors.Wrap(err, "saving annotated asset")
 }
 
 // Assets queries the blockchain for annotated assets matching the query.
-func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []interface{}, after string, limit int) ([][]byte, string, error) {
+func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []interface{}, after string, limit int) ([]*AnnotatedAsset, string, error) {
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
 	}
@@ -44,7 +44,7 @@ func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []inter
 	}
 	defer rows.Close()
 
-	assets := make([][]byte, 0, limit)
+	assets := make([]*AnnotatedAsset, 0, limit)
 	for rows.Next() {
 		var (
 			sortID   string
@@ -55,8 +55,14 @@ func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []inter
 			return nil, "", errors.Wrap(err, "scanning annotated asset row")
 		}
 
+		aa := new(AnnotatedAsset)
+		err = json.Unmarshal(rawAsset, aa)
+		if err != nil {
+			return nil, "", errors.Wrap(err, "unmarshaling raw asset")
+		}
+
 		after = sortID
-		assets = append(assets, rawAsset)
+		assets = append(assets, aa)
 	}
 	err = rows.Err()
 	if err != nil {

--- a/core/query/assets.go
+++ b/core/query/assets.go
@@ -3,7 +3,6 @@ package query
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -23,7 +22,7 @@ func (ind *Indexer) SaveAnnotatedAsset(ctx context.Context, asset *AnnotatedAsse
 		INSERT INTO annotated_assets (id, data, sort_id) VALUES($1, $2, $3)
 		ON CONFLICT (id) DO UPDATE SET data = $2, sort_id = $3
 	`
-	_, err = ind.db.Exec(ctx, q, hex.EncodeToString(asset.ID), b, sortID)
+	_, err = ind.db.Exec(ctx, q, asset.ID, b, sortID)
 	return errors.Wrap(err, "saving annotated asset")
 }
 

--- a/core/query/index.go
+++ b/core/query/index.go
@@ -161,7 +161,7 @@ func (ind *Indexer) insertAnnotatedOutputs(ctx context.Context, b *bc.Block, ann
 			}
 
 			outCopy := *out
-			outCopy.TransactionID = tx.Hash[:]
+			outCopy.TransactionID = tx.Hash
 			serializedData, err := json.Marshal(outCopy)
 			if err != nil {
 				return errors.Wrap(err, "serializing annotated output")
@@ -170,7 +170,7 @@ func (ind *Indexer) insertAnnotatedOutputs(ctx context.Context, b *bc.Block, ann
 			outputTxPositions = append(outputTxPositions, uint32(pos))
 			outputIndexes = append(outputIndexes, uint32(outIndex))
 			outputTxHashes = append(outputTxHashes, tx.Hash[:])
-			outputIDs = append(outputIDs, outCopy.OutputID)
+			outputIDs = append(outputIDs, outCopy.OutputID.Hash[:])
 			outputData = append(outputData, string(serializedData))
 		}
 	}

--- a/core/query/query_test.go
+++ b/core/query/query_test.go
@@ -2,7 +2,6 @@ package query_test
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/json"
 	"testing"
 	"time"
@@ -189,9 +188,8 @@ func TestQueryOutputs(t *testing.T) {
 		}
 		for j, w := range tc.want {
 			var found bool
-			wantAssetID := w.AssetID.String()
 			for _, output := range outputs {
-				if wantAssetID == hex.EncodeToString(output.AssetID) && w.Amount == output.Amount && w.AccountID == output.AccountID {
+				if w.AssetID == output.AssetID && w.Amount == output.Amount && w.AccountID == output.AccountID {
 					found = true
 					break
 				}


### PR DESCRIPTION
Add typed structs for annotated accounts and annotated assets instead of
using a freeform `map[string]interface{}`. This will be helpful when
replacing the jsonb `data` columns with a structured schema.

Finishing up the work from #407.