### PR TITLE
testutil: add func DeepEqual, treats empty as equal to nil

### DIFF
--- a/core/accesstoken/accesstoken_test.go
+++ b/core/accesstoken/accesstoken_test.go
@@ -3,7 +3,6 @@ package accesstoken
 import (
 	"context"
 	"encoding/hex"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -11,6 +10,7 @@ import (
 
 	"chain/database/pg/pgtest"
 	"chain/errors"
+	"chain/testutil"
 )
 
 func TestCreate(t *testing.T) {
@@ -92,7 +92,7 @@ func TestList(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(got, c.want) {
+		if !testutil.DeepEqual(got, c.want) {
 			t.Errorf("List(%s, %d) = %+v want %+v", c.after, c.limit, spew.Sdump(got), spew.Sdump(c.want))
 		}
 

--- a/core/account/accounts_test.go
+++ b/core/account/accounts_test.go
@@ -3,7 +3,6 @@ package account
 import (
 	"bytes"
 	"context"
-	"reflect"
 	"testing"
 
 	"chain/crypto/ed25519/chainkd"
@@ -50,7 +49,7 @@ func TestCreateAccountIdempotency(t *testing.T) {
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
-	if !reflect.DeepEqual(account1, account2) {
+	if !testutil.DeepEqual(account1, account2) {
 		t.Errorf("got=%#v, want=%#v", account2, account1)
 	}
 }
@@ -126,7 +125,7 @@ func TestFindByID(t *testing.T) {
 		testutil.FatalErr(t, err)
 	}
 
-	if !reflect.DeepEqual(account.Signer, found) {
+	if !testutil.DeepEqual(account.Signer, found) {
 		t.Errorf("expected found account to be %v, instead found %v", account, found)
 	}
 }
@@ -142,7 +141,7 @@ func TestFindByAlias(t *testing.T) {
 		testutil.FatalErr(t, err)
 	}
 
-	if !reflect.DeepEqual(account.Signer, found) {
+	if !testutil.DeepEqual(account.Signer, found) {
 		t.Errorf("expected found account to be %v, instead found %v", account, found)
 	}
 }

--- a/core/account/annotate_test.go
+++ b/core/account/annotate_test.go
@@ -3,7 +3,6 @@ package account
 import (
 	"context"
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"chain/core/query"
@@ -46,7 +45,7 @@ func TestAnnotateTxs(t *testing.T) {
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
-	if !reflect.DeepEqual(txs, want) {
+	if !testutil.DeepEqual(txs, want) {
 		t.Errorf("AnnotateTxs = %+v want %+v", txs, want)
 	}
 }

--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -3,7 +3,6 @@ package account_test
 import (
 	"context"
 	"database/sql"
-	"reflect"
 	"testing"
 
 	"chain/core/account"
@@ -61,7 +60,7 @@ func TestAccountSourceReserve(t *testing.T) {
 	}
 
 	wantTxIns := []*bc.TxInput{bc.NewSpendInput(out.Hash, out.Index, nil, out.AssetID, out.Amount, out.ControlProgram, nil)}
-	if !reflect.DeepEqual(tx.Inputs, wantTxIns) {
+	if !testutil.DeepEqual(tx.Inputs, wantTxIns) {
 		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tx.Inputs, wantTxIns)
 	}
 	if len(tx.Outputs) != 1 {
@@ -113,7 +112,7 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 
 	wantTxIns := []*bc.TxInput{bc.NewSpendInput(out.Hash, out.Index, nil, out.AssetID, out.Amount, out.ControlProgram, nil)}
 
-	if !reflect.DeepEqual(tx.Inputs, wantTxIns) {
+	if !testutil.DeepEqual(tx.Inputs, wantTxIns) {
 		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tx.Inputs, wantTxIns)
 	}
 }
@@ -176,12 +175,12 @@ func TestAccountSourceReserveIdempotency(t *testing.T) {
 		want     = reserveFunc(wantSrc)
 		separate = reserveFunc(separateSrc)
 	)
-	if !reflect.DeepEqual(got, want) {
+	if !testutil.DeepEqual(got, want) {
 		t.Errorf("reserve result\ngot:\n\t%+v\nwant:\n\t%+v", got, want)
 	}
 
 	// The third reservation attempt should be distinct and not the same as the first two.
-	if reflect.DeepEqual(separate, want) {
+	if testutil.DeepEqual(separate, want) {
 		t.Errorf("reserve result\ngot:\n\t%+v\ndo not want:\n\t%+v", separate, want)
 	}
 }

--- a/core/account/indexer_test.go
+++ b/core/account/indexer_test.go
@@ -2,7 +2,6 @@ package account
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"chain/database/pg/pgtest"
@@ -34,7 +33,7 @@ func TestLoadAccountInfo(t *testing.T) {
 		testutil.FatalErr(t, err)
 	}
 
-	if !reflect.DeepEqual(got[0].AccountID, acc.ID) {
+	if !testutil.DeepEqual(got[0].AccountID, acc.ID) {
 		t.Errorf("got account = %+v want %+v", got[0].AccountID, acc.ID)
 	}
 }

--- a/core/asset/annotate_test.go
+++ b/core/asset/annotate_test.go
@@ -3,7 +3,6 @@ package asset
 import (
 	"context"
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -71,7 +70,7 @@ func TestAnnotateTxs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(txs, want) {
+	if !testutil.DeepEqual(txs, want) {
 		t.Errorf("got:\n%s\nwant:\n%s", spew.Sdump(txs), spew.Sdump(want))
 	}
 }

--- a/core/asset/asset_test.go
+++ b/core/asset/asset_test.go
@@ -3,7 +3,6 @@ package asset
 import (
 	"bytes"
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -55,7 +54,7 @@ func TestDefineAssetIdempotency(t *testing.T) {
 	}
 
 	// asset0 and asset1 should be exactly the same because they use the same client token
-	if !reflect.DeepEqual(asset0, asset1) {
+	if !testutil.DeepEqual(asset0, asset1) {
 		t.Errorf("expected assets to match:\n\n%+v\n\n-----------\n\n%+v", spew.Sdump(asset0), spew.Sdump(asset1))
 	}
 }
@@ -73,7 +72,7 @@ func TestFindAssetByID(t *testing.T) {
 		testutil.FatalErr(t, err)
 	}
 
-	if !reflect.DeepEqual(asset, found) {
+	if !testutil.DeepEqual(asset, found) {
 		t.Errorf("expected %v and %v to match", asset, found)
 	}
 }

--- a/core/asset/block_test.go
+++ b/core/asset/block_test.go
@@ -2,7 +2,6 @@ package asset
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"chain/crypto/ed25519"
@@ -91,7 +90,7 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	}
 
 	// Ensure that the annotated asset got saved to the query indexer.
-	if !reflect.DeepEqual(assetsSaved, []bc.AssetID{remoteAssetID}) {
+	if !testutil.DeepEqual(assetsSaved, []bc.AssetID{remoteAssetID}) {
 		t.Errorf("saved annotated assets got %#v, want %#v", assetsSaved, []bc.AssetID{remoteAssetID})
 	}
 
@@ -113,7 +112,7 @@ func TestIndexNonLocalAssets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(got, want) {
+	if !testutil.DeepEqual(got, want) {
 		t.Errorf("lookupAsset() = %#v, want %#v", got, want)
 	}
 }

--- a/core/mockhsm/mockhsm_test.go
+++ b/core/mockhsm/mockhsm_test.go
@@ -2,7 +2,6 @@ package mockhsm
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -10,6 +9,7 @@ import (
 	"chain/crypto/ed25519"
 	"chain/database/pg/pgtest"
 	"chain/errors"
+	"chain/testutil"
 )
 
 func TestMockHSMChainKDKeys(t *testing.T) {
@@ -103,7 +103,7 @@ func TestKeyWithAlias(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(xpubs[0], xpub) {
+	if !testutil.DeepEqual(xpubs[0], xpub) {
 		t.Fatalf("expected to get %v instead got %v", spew.Sdump(xpub), spew.Sdump(xpubs[0]))
 	}
 
@@ -117,7 +117,7 @@ func TestKeyWithAlias(t *testing.T) {
 		t.Fatalf("list keys with matching filter expected to get 1 instead got %v", len(xpubs))
 	}
 
-	if !reflect.DeepEqual(xpubs[0], xpub) {
+	if !testutil.DeepEqual(xpubs[0], xpub) {
 		t.Fatalf("expected to get %v instead got %v", spew.Sdump(xpub), spew.Sdump(xpubs[0]))
 	}
 

--- a/core/query/balances_test.go
+++ b/core/query/balances_test.go
@@ -1,10 +1,10 @@
 package query
 
 import (
-	"reflect"
 	"testing"
 
 	"chain/core/query/filter"
+	"chain/testutil"
 )
 
 func TestConstructBalancesQuery(t *testing.T) {
@@ -66,7 +66,7 @@ func TestConstructBalancesQuery(t *testing.T) {
 		if query != tc.wantQuery {
 			t.Errorf("case %d: got\n%s\nwant\n%s", i, query, tc.wantQuery)
 		}
-		if !reflect.DeepEqual(values, tc.wantValues) {
+		if !testutil.DeepEqual(values, tc.wantValues) {
 			t.Errorf("case %d: got %#v, want %#v", i, values, tc.wantValues)
 		}
 	}

--- a/core/query/filter/jsonb_test.go
+++ b/core/query/filter/jsonb_test.go
@@ -2,8 +2,9 @@ package filter
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestMatchingObjects(t *testing.T) {
@@ -58,7 +59,7 @@ func TestMatchingObjects(t *testing.T) {
 			t.Fatal(err)
 		}
 		got := matchingObjects(e, placeholderValues)
-		if !reflect.DeepEqual(got, tc.want) {
+		if !testutil.DeepEqual(got, tc.want) {
 			gotJSON, err := json.MarshalIndent(got, "", " ")
 			if err != nil {
 				t.Fatal(err)

--- a/core/query/filter/parser_test.go
+++ b/core/query/filter/parser_test.go
@@ -1,8 +1,9 @@
 package filter
 
 import (
-	"reflect"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestParseValid(t *testing.T) {
@@ -121,7 +122,7 @@ func TestParseValid(t *testing.T) {
 			t.Errorf("%d: %s", i, err)
 			continue
 		}
-		if !reflect.DeepEqual(expr, tc.expr) {
+		if !testutil.DeepEqual(expr, tc.expr) {
 			t.Errorf("%d: parsing %q\ngot=\n%#v\nwant=\n%#v\n", i, tc.p, expr, tc.expr)
 		}
 	}

--- a/core/query/filter/sql_test.go
+++ b/core/query/filter/sql_test.go
@@ -1,8 +1,9 @@
 package filter
 
 import (
-	"reflect"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestAsSQL(t *testing.T) {
@@ -78,7 +79,7 @@ func TestAsSQL(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !reflect.DeepEqual(sqlExpr.Values, tc.conds) {
+		if !testutil.DeepEqual(sqlExpr.Values, tc.conds) {
 			t.Errorf("AsSQL(%q) = %#v, want %#v", tc.q, sqlExpr.Values, tc.conds)
 		}
 	}

--- a/core/query/outputs_test.go
+++ b/core/query/outputs_test.go
@@ -2,7 +2,6 @@ package query
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -10,6 +9,7 @@ import (
 	"chain/database/pg/pgtest"
 	"chain/protocol"
 	"chain/protocol/bc"
+	"chain/testutil"
 )
 
 func TestDecodeOutputsAfter(t *testing.T) {
@@ -30,7 +30,7 @@ func TestDecodeOutputsAfter(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if !reflect.DeepEqual(decoded, &tc.cur) {
+		if !testutil.DeepEqual(decoded, &tc.cur) {
 			t.Errorf("got %#v, want %#v", decoded, &tc.cur)
 		}
 		if decoded.String() != tc.str {
@@ -130,7 +130,7 @@ func TestConstructOutputsQuery(t *testing.T) {
 		if query != tc.wantQuery {
 			t.Errorf("case %d: got %s want %s", i, query, tc.wantQuery)
 		}
-		if !reflect.DeepEqual(values, tc.wantValues) {
+		if !testutil.DeepEqual(values, tc.wantValues) {
 			t.Errorf("case %d: got %#v, want %#v", i, values, tc.wantValues)
 		}
 	}

--- a/core/query/query_test.go
+++ b/core/query/query_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"reflect"
 	"testing"
 	"time"
 
@@ -20,6 +19,7 @@ import (
 	"chain/database/pg/pgtest"
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
+	"chain/testutil"
 )
 
 func setupQueryTest(t *testing.T) (context.Context, *query.Indexer, time.Time, time.Time, string, string, bc.AssetID, bc.AssetID) {
@@ -318,7 +318,7 @@ func TestQueryBalances(t *testing.T) {
 		}
 
 		got := jsonRT(t, balances)
-		if !reflect.DeepEqual(got, want) {
+		if !testutil.DeepEqual(got, want) {
 			t.Errorf("case %d: got:\n%s\nwant:\n%s", i, spew.Sdump(balances), spew.Sdump(tc.want))
 		}
 	}
@@ -327,7 +327,7 @@ func TestQueryBalances(t *testing.T) {
 // jsonRT does a JSON round trip -- it marshals v
 // then unmarshals the resutling JSON into an interface{}.
 // This normalizes the types so it can be more easily compared
-// with reflect.DeepEqual.
+// with testutil.DeepEqual.
 func jsonRT(tb testing.TB, v interface{}) interface{} {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/core/query/transactions_test.go
+++ b/core/query/transactions_test.go
@@ -3,13 +3,13 @@ package query
 import (
 	"context"
 	"math"
-	"reflect"
 	"testing"
 
 	"chain/core/query/filter"
 	"chain/database/pg/pgtest"
 	"chain/errors"
 	"chain/protocol"
+	"chain/testutil"
 )
 
 func TestDecodeTxAfter(t *testing.T) {
@@ -60,7 +60,7 @@ func TestLookupTxAfterNoBlocks(t *testing.T) {
 		FromPosition:    math.MaxInt32,
 		StopBlockHeight: 0,
 	}
-	if !reflect.DeepEqual(cur, want) {
+	if !testutil.DeepEqual(cur, want) {
 		t.Errorf("Got tx after %s, want %s", cur, want)
 	}
 }
@@ -125,7 +125,7 @@ func TestConstructTransactionsQuery(t *testing.T) {
 		if query != tc.wantQuery {
 			t.Errorf("got\n%s\nwant\n%s", query, tc.wantQuery)
 		}
-		if !reflect.DeepEqual(values, tc.wantValues) {
+		if !testutil.DeepEqual(values, tc.wantValues) {
 			t.Errorf("got %#v, want %#v", values, tc.wantValues)
 		}
 	}

--- a/core/rpc/rpc_test.go
+++ b/core/rpc/rpc_test.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestRPCCallJSON(t *testing.T) {
@@ -41,7 +42,7 @@ func TestRPCCallJSON(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer req.Body.Close()
-		if !reflect.DeepEqual(decodedRequestBody, requestBody) {
+		if !testutil.DeepEqual(decodedRequestBody, requestBody) {
 			t.Errorf("got=%#v; want=%#v", decodedRequestBody, requestBody)
 		}
 
@@ -64,7 +65,7 @@ func TestRPCCallJSON(t *testing.T) {
 	}
 
 	// Ensure that the response is as we expect.
-	if !reflect.DeepEqual(response, map[string]string{"response": "example"}) {
+	if !testutil.DeepEqual(response, map[string]string{"response": "example"}) {
 		t.Errorf(`expected map[string]string{"response": "example"}, got %#v`, response)
 	}
 
@@ -84,7 +85,7 @@ func TestRPCCallError(t *testing.T) {
 	client := &Client{BaseURL: server.URL}
 	wantErr := errStatusCode{URL: server.URL + "/error", StatusCode: 500}
 	err := client.Call(context.Background(), "/error", nil, nil)
-	if !reflect.DeepEqual(wantErr, err) {
+	if !testutil.DeepEqual(wantErr, err) {
 		t.Errorf("got=%#v; want=%#v", err, wantErr)
 	}
 }

--- a/core/signers/signers_test.go
+++ b/core/signers/signers_test.go
@@ -3,7 +3,6 @@ package signers
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"chain/crypto/ed25519/chainkd"
@@ -194,7 +193,7 @@ func TestList(t *testing.T) {
 			testutil.FatalErr(t, err)
 		}
 
-		if !reflect.DeepEqual(got, c.want) {
+		if !testutil.DeepEqual(got, c.want) {
 			t.Errorf("List(%s, %s, %d)\n\tgot:  %+v\n\twant: %+v", c.typ, c.prev, c.limit, got, c.want)
 		}
 

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
-	"reflect"
 	"testing"
 	"time"
 
@@ -73,13 +72,13 @@ func TestBuild(t *testing.T) {
 		}},
 	}
 
-	if !reflect.DeepEqual(got.Transaction, want.Transaction) {
+	if !testutil.DeepEqual(got.Transaction, want.Transaction) {
 		t.Errorf("got tx:\n\t%#v\nwant tx:\n\t%#v", got.Transaction, want.Transaction)
 		t.Errorf("got tx inputs:\n\t%#v\nwant tx inputs:\n\t%#v", got.Transaction.Inputs, want.Transaction.Inputs)
 		t.Errorf("got tx outputs:\n\t%#v\nwant tx outputs:\n\t%#v", got.Transaction.Outputs, want.Transaction.Outputs)
 	}
 
-	if !reflect.DeepEqual(got.SigningInstructions, want.SigningInstructions) {
+	if !testutil.DeepEqual(got.SigningInstructions, want.SigningInstructions) {
 		t.Errorf("got signing instructions:\n\t%#v\nwant signing instructions:\n\t%#v", got.SigningInstructions, want.SigningInstructions)
 	}
 
@@ -153,7 +152,7 @@ func TestMaterializeWitnesses(t *testing.T) {
 	}
 
 	got := tpl.Transaction.Inputs[0].Arguments()
-	if !reflect.DeepEqual(got, want) {
+	if !testutil.DeepEqual(got, want) {
 		t.Errorf("got input witness %v, want input witness %v", got, want)
 	}
 }
@@ -233,7 +232,7 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 		testutil.FatalErr(t, err)
 	}
 	got := tpl.Transaction.Inputs[0].Arguments()
-	if !reflect.DeepEqual(got, want) {
+	if !testutil.DeepEqual(got, want) {
 		t.Errorf("got input witness %v, want input witness %v", got, want)
 	}
 
@@ -248,7 +247,7 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 		testutil.FatalErr(t, err)
 	}
 	got = tpl.Transaction.Inputs[0].Arguments()
-	if !reflect.DeepEqual(got, want) {
+	if !testutil.DeepEqual(got, want) {
 		t.Errorf("got input witness %v, want input witness %v", got, want)
 	}
 }

--- a/core/txbuilder/witness_test.go
+++ b/core/txbuilder/witness_test.go
@@ -3,7 +3,6 @@ package txbuilder
 import (
 	"bytes"
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -68,7 +67,7 @@ func TestWitnessJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !reflect.DeepEqual(si, &got) {
+	if !testutil.DeepEqual(si, &got) {
 		t.Errorf("got:\n%s\nwant:\n%s\nJSON was: %s", spew.Sdump(&got), spew.Sdump(si), string(b))
 	}
 }

--- a/core/txdb/snapshot_test.go
+++ b/core/txdb/snapshot_test.go
@@ -3,12 +3,12 @@ package txdb
 import (
 	"context"
 	"math/rand"
-	"reflect"
 	"testing"
 
 	"chain/database/pg/pgtest"
 	"chain/protocol/bc"
 	"chain/protocol/state"
+	"chain/testutil"
 )
 
 type pair struct {
@@ -114,7 +114,7 @@ func TestReadWriteStateSnapshot(t *testing.T) {
 		if loadedSnapshot.Tree.RootHash() != snapshot.Tree.RootHash() {
 			t.Fatalf("%d: Wrote %s to db, read %s from db\n", i, snapshot.Tree.RootHash(), loadedSnapshot.Tree.RootHash())
 		}
-		if !reflect.DeepEqual(loadedSnapshot.Issuances, snapshot.Issuances) {
+		if !testutil.DeepEqual(loadedSnapshot.Issuances, snapshot.Issuances) {
 			t.Fatalf("%d: Wrote %#v issuances to db, read %#v from db\n", i, snapshot.Issuances, loadedSnapshot.Issuances)
 		}
 		snapshot = loadedSnapshot

--- a/core/txdb/txdb_test.go
+++ b/core/txdb/txdb_test.go
@@ -2,7 +2,6 @@ package txdb
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"chain/database/pg/pgtest"
@@ -51,7 +50,7 @@ func TestGetBlock(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(got, want) {
+	if !testutil.DeepEqual(got, want) {
 		t.Errorf("latest block:\ngot:  %+v\nwant: %+v", got, want)
 	}
 }
@@ -83,7 +82,7 @@ func TestInsertBlock(t *testing.T) {
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
-	if !reflect.DeepEqual(got, blk) {
+	if !testutil.DeepEqual(got, blk) {
 		t.Errorf("got %#v, wanted %#v", got, blk)
 	}
 }

--- a/core/txfeed/txfeed_test.go
+++ b/core/txfeed/txfeed_test.go
@@ -2,12 +2,12 @@ package txfeed
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
 	"chain/core/query/filter"
 	"chain/database/pg/pgtest"
 	"chain/errors"
+	"chain/testutil"
 )
 
 func TestInsertTxFeed(t *testing.T) {
@@ -59,7 +59,7 @@ func TestInsertTxFeedRepeatToken(t *testing.T) {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	if !reflect.DeepEqual(result0, result1) {
+	if !testutil.DeepEqual(result0, result1) {
 		t.Errorf("expected requests with matching tokens to yield matching results, instead got result0=%+v and result1=%+v",
 			result0, result1)
 	}

--- a/protocol/bc/block_test.go
+++ b/protocol/bc/block_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+
+	"chain/testutil"
 )
 
 func TestMarshalBlock(t *testing.T) {
@@ -74,7 +75,7 @@ func TestMarshalBlock(t *testing.T) {
 		t.Errorf("unexpected error %s", err)
 	}
 
-	if !reflect.DeepEqual(*b, c) {
+	if !testutil.DeepEqual(*b, c) {
 		t.Errorf("expected marshaled/unmarshaled block to be:\n%sgot:\n%s", spew.Sdump(*b), spew.Sdump(c))
 	}
 

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -5,12 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io/ioutil"
-	"reflect"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
 
 	"chain/errors"
+	"chain/testutil"
 )
 
 func TestTransaction(t *testing.T) {
@@ -180,7 +180,7 @@ func TestTransaction(t *testing.T) {
 		if err := json.Unmarshal(txJSON, &txFromJSON); err != nil {
 			t.Errorf("test %d: error unmarshaling tx from json: %s", i, err)
 		}
-		if !reflect.DeepEqual(test.tx, &txFromJSON) {
+		if !testutil.DeepEqual(test.tx, &txFromJSON) {
 			t.Errorf("test %d: bc.Tx -> json -> bc.Tx: got:\n%s\nwant:\n%s", i, spew.Sdump(&txFromJSON), spew.Sdump(test.tx))
 		}
 
@@ -188,7 +188,7 @@ func TestTransaction(t *testing.T) {
 		if err := tx1.UnmarshalText([]byte(test.hex)); err != nil {
 			t.Errorf("test %d: unexpected err %v", i, err)
 		}
-		if !reflect.DeepEqual(*tx1, test.tx.TxData) {
+		if !testutil.DeepEqual(*tx1, test.tx.TxData) {
 			t.Errorf("test %d: tx1 is:\n%swant:\n%s", i, spew.Sdump(*tx1), spew.Sdump(test.tx.TxData))
 		}
 	}

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -3,7 +3,6 @@ package protocol
 import (
 	"context"
 	"encoding/hex"
-	"reflect"
 	"testing"
 	"time"
 
@@ -37,7 +36,7 @@ func TestGetBlock(t *testing.T) {
 			testutil.FatalErr(t, err)
 		}
 		got, gotErr := c.GetBlock(ctx, c.Height())
-		if !reflect.DeepEqual(got, test.want) {
+		if !testutil.DeepEqual(got, test.want) {
 			t.Errorf("got latest = %+v want %+v", got, test.want)
 		}
 		if (gotErr != nil) != test.wantErr {
@@ -183,7 +182,7 @@ func TestGenerateBlock(t *testing.T) {
 		Transactions: txs,
 	}
 
-	if !reflect.DeepEqual(got, want) {
+	if !testutil.DeepEqual(got, want) {
 		t.Errorf("generated block:\ngot:  %+v\nwant: %+v", got, want)
 	}
 }

--- a/protocol/patricia/patricia_test.go
+++ b/protocol/patricia/patricia_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -13,6 +12,7 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"chain/protocol/bc"
+	"chain/testutil"
 )
 
 func BenchmarkInserts(b *testing.B) {
@@ -138,7 +138,7 @@ func TestLookup(t *testing.T) {
 		root: &node{key: bools("11111111"), hash: &hashes[0], isLeaf: true},
 	}
 	got := tr.lookup(tr.root, bitKey(bits("11111111")))
-	if !reflect.DeepEqual(got, tr.root) {
+	if !testutil.DeepEqual(got, tr.root) {
 		t.Log("lookup on 1-node tree")
 		t.Fatalf("got:\n%swant:\n%s", prettyNode(got, 0), prettyNode(tr.root, 0))
 	}
@@ -163,7 +163,7 @@ func TestLookup(t *testing.T) {
 		},
 	}
 	got = tr.lookup(tr.root, bitKey(bits("11110000")))
-	if !reflect.DeepEqual(got, tr.root.children[0]) {
+	if !testutil.DeepEqual(got, tr.root.children[0]) {
 		t.Log("lookup root's first child")
 		t.Fatalf("got:\n%swant:\n%s", prettyNode(got, 0), prettyNode(tr.root.children[0], 0))
 	}
@@ -186,7 +186,7 @@ func TestLookup(t *testing.T) {
 		},
 	}
 	got = tr.lookup(tr.root, bitKey(bits("11111100")))
-	if !reflect.DeepEqual(got, tr.root.children[1].children[0]) {
+	if !testutil.DeepEqual(got, tr.root.children[1].children[0]) {
 		t.Fatalf("got:\n%swant:\n%s", prettyNode(got, 0), prettyNode(tr.root.children[1].children[0], 0))
 	}
 }
@@ -230,7 +230,7 @@ func TestInsert(t *testing.T) {
 	want := &Tree{
 		root: &node{key: bools("11111111"), hash: &hashes[0], isLeaf: true},
 	}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		log.Printf("want hash? %s", hashes[0])
 		t.Log("insert into empty tree")
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
@@ -241,7 +241,7 @@ func TestInsert(t *testing.T) {
 	want = &Tree{
 		root: &node{key: bools("11111111"), hash: &hashes[1], isLeaf: true},
 	}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Log("inserting the same key updates the value, does not add a new node")
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
@@ -258,7 +258,7 @@ func TestInsert(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Log("different key creates a fork")
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
@@ -282,7 +282,7 @@ func TestInsert(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
@@ -312,7 +312,7 @@ func TestInsert(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Log("a fork is created for each level of similar key")
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
@@ -350,7 +350,7 @@ func TestInsert(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Log("compressed branch node is split")
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
@@ -401,7 +401,7 @@ func TestDelete(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
@@ -417,13 +417,13 @@ func TestDelete(t *testing.T) {
 			},
 		},
 	}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
 	tr.Delete(bits("11110011"))
 	tr.RootHash()
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
@@ -432,14 +432,14 @@ func TestDelete(t *testing.T) {
 	want = &Tree{
 		root: &node{key: bools("11111111"), hash: &hashes[3], isLeaf: true},
 	}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
 	tr.Delete(bits("11111111"))
 	tr.RootHash()
 	want = &Tree{}
-	if !reflect.DeepEqual(tr.root, want.root) {
+	if !testutil.DeepEqual(tr.root, want.root) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 }
@@ -462,7 +462,7 @@ func TestBoolKey(t *testing.T) {
 	for _, c := range cases {
 		g := bitKey(c.b)
 
-		if !reflect.DeepEqual(g, c.w) {
+		if !testutil.DeepEqual(g, c.w) {
 			t.Errorf("Key(0x%x) = %v want %v", c.b, g, c.w)
 		}
 	}
@@ -489,7 +489,7 @@ func TestByteKey(t *testing.T) {
 	for _, c := range cases {
 		g := byteKey(c.b)
 
-		if !reflect.DeepEqual(g, c.w) {
+		if !testutil.DeepEqual(g, c.w) {
 			t.Errorf("byteKey(%#v) = %x want %x", c.b, g, c.w)
 		}
 	}

--- a/protocol/vm/bitwise_test.go
+++ b/protocol/vm/bitwise_test.go
@@ -1,8 +1,9 @@
 package vm
 
 import (
-	"reflect"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestBitwiseOps(t *testing.T) {
@@ -280,7 +281,7 @@ func TestBitwiseOps(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(c.startVM, c.wantVM) {
+		if !testutil.DeepEqual(c.startVM, c.wantVM) {
 			t.Errorf("case %d, op %s: unexpected vm result\n\tgot:  %+v\n\twant: %+v\n", i, ops[c.op].name, c.startVM, c.wantVM)
 		}
 	}

--- a/protocol/vm/control_test.go
+++ b/protocol/vm/control_test.go
@@ -1,8 +1,9 @@
 package vm
 
 import (
-	"reflect"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestControlOps(t *testing.T) {
@@ -239,7 +240,7 @@ func TestControlOps(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(c.startVM, c.wantVM) {
+		if !testutil.DeepEqual(c.startVM, c.wantVM) {
 			t.Errorf("case %d, op %s: unexpected vm result\n\tgot:  %+v\n\twant: %+v\n", i, c.op.String(), c.startVM, c.wantVM)
 		}
 	}

--- a/protocol/vm/crypto_test.go
+++ b/protocol/vm/crypto_test.go
@@ -2,10 +2,10 @@ package vm
 
 import (
 	"encoding/hex"
-	"reflect"
 	"testing"
 
 	"chain/protocol/bc"
+	"chain/testutil"
 )
 
 func TestCheckSig(t *testing.T) {
@@ -487,7 +487,7 @@ func TestCryptoOps(t *testing.T) {
 		}
 
 		c.wantVM.sigHasher = c.startVM.sigHasher
-		if !reflect.DeepEqual(c.startVM, c.wantVM) {
+		if !testutil.DeepEqual(c.startVM, c.wantVM) {
 			t.Errorf("case %d, op %s: unexpected vm result\n\tgot:  %+v\n\twant: %+v\n", i, ops[c.op].name, c.startVM, c.wantVM)
 		}
 	}

--- a/protocol/vm/introspection_test.go
+++ b/protocol/vm/introspection_test.go
@@ -1,10 +1,10 @@
 package vm
 
 import (
-	"reflect"
 	"testing"
 
 	"chain/protocol/bc"
+	"chain/testutil"
 )
 
 func TestNextProgram(t *testing.T) {
@@ -105,7 +105,7 @@ func TestOutpointAndNonceOp(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedStack := [][]byte{zeroHash[:], []byte{}}
-	if !reflect.DeepEqual(vm.dataStack, expectedStack) {
+	if !testutil.DeepEqual(vm.dataStack, expectedStack) {
 		t.Errorf("expected stack %v, got %v", expectedStack, vm.dataStack)
 	}
 
@@ -141,7 +141,7 @@ func TestOutpointAndNonceOp(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedStack = [][]byte{nonce}
-	if !reflect.DeepEqual(vm.dataStack, expectedStack) {
+	if !testutil.DeepEqual(vm.dataStack, expectedStack) {
 		t.Errorf("expected stack %v, got %v", expectedStack, vm.dataStack)
 	}
 }
@@ -520,7 +520,7 @@ func TestIntrospectionOps(t *testing.T) {
 		c.wantVM.pc = 1
 		c.wantVM.nextPC = 1
 		c.wantVM.sigHasher = c.startVM.sigHasher
-		if !reflect.DeepEqual(vm, c.wantVM) {
+		if !testutil.DeepEqual(vm, c.wantVM) {
 			t.Errorf("case %d, op %s: unexpected vm result\n\tgot:  %+v\n\twant: %+v\n", i, ops[c.op].name, c.startVM, c.wantVM)
 		}
 	}

--- a/protocol/vm/numeric_test.go
+++ b/protocol/vm/numeric_test.go
@@ -3,8 +3,9 @@ package vm
 import (
 	"fmt"
 	"math"
-	"reflect"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestNumericOps(t *testing.T) {
@@ -502,7 +503,7 @@ func TestNumericOps(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(c.startVM, c.wantVM) {
+		if !testutil.DeepEqual(c.startVM, c.wantVM) {
 			t.Errorf("case %d, op %s: unexpected vm result\n\tgot:  %+v\n\twant: %+v\n", i, ops[c.op].name, c.startVM, c.wantVM)
 		}
 	}

--- a/protocol/vm/ops_test.go
+++ b/protocol/vm/ops_test.go
@@ -1,10 +1,10 @@
 package vm
 
 import (
-	"reflect"
 	"testing"
 
 	"chain/errors"
+	"chain/testutil"
 )
 
 func TestParseOp(t *testing.T) {
@@ -84,7 +84,7 @@ func TestParseOp(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(got, c.want) {
+		if !testutil.DeepEqual(got, c.want) {
 			t.Errorf("ParseOp(%x, %d) = %+v want %+v", c.prog, c.pc, got, c.want)
 		}
 	}
@@ -125,7 +125,7 @@ func TestParseProgram(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(got, c.want) {
+		if !testutil.DeepEqual(got, c.want) {
 			t.Errorf("ParseProgram(%x) = %+v want %+v", c.prog, got, c.want)
 		}
 	}

--- a/protocol/vm/pushdata_test.go
+++ b/protocol/vm/pushdata_test.go
@@ -2,8 +2,9 @@ package vm
 
 import (
 	"bytes"
-	"reflect"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestPushdataOps(t *testing.T) {
@@ -100,7 +101,7 @@ func TestPushdataOps(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(c.startVM, c.wantVM) {
+		if !testutil.DeepEqual(c.startVM, c.wantVM) {
 			t.Errorf("case %d, op %s: unexpected vm result\n\tgot:  %+v\n\twant: %+v\n", i, ops[c.op].name, c.startVM, c.wantVM)
 		}
 	}

--- a/protocol/vm/splice_test.go
+++ b/protocol/vm/splice_test.go
@@ -1,8 +1,9 @@
 package vm
 
 import (
-	"reflect"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestSpliceOps(t *testing.T) {
@@ -230,7 +231,7 @@ func TestSpliceOps(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(c.startVM, c.wantVM) {
+		if !testutil.DeepEqual(c.startVM, c.wantVM) {
 			t.Errorf("case %d, op %s: unexpected vm result\n\tgot:  %+v\n\twant: %+v\n", i, ops[c.op].name, c.startVM, c.wantVM)
 		}
 	}

--- a/protocol/vm/stack_test.go
+++ b/protocol/vm/stack_test.go
@@ -1,8 +1,9 @@
 package vm
 
 import (
-	"reflect"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestStackOps(t *testing.T) {
@@ -324,7 +325,7 @@ func TestStackOps(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(c.startVM, c.wantVM) {
+		if !testutil.DeepEqual(c.startVM, c.wantVM) {
 			t.Errorf("case %d, op %s: unexpected vm result\n\tgot:  %+v\n\twant: %+v\n", i, ops[c.op].name, c.startVM, c.wantVM)
 		}
 	}

--- a/protocol/vm/vm_test.go
+++ b/protocol/vm/vm_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"testing/quick"
 
 	"chain/errors"
 	"chain/protocol/bc"
+	"chain/testutil"
 )
 
 type tracebuf struct {
@@ -434,7 +434,7 @@ func TestStep(t *testing.T) {
 			continue
 		}
 
-		if !reflect.DeepEqual(c.startVM, c.wantVM) {
+		if !testutil.DeepEqual(c.startVM, c.wantVM) {
 			t.Errorf("step test %d:\n\tgot vm:  %+v\n\twant vm: %+v", i, c.startVM, c.wantVM)
 		}
 	}

--- a/testutil/deepequal.go
+++ b/testutil/deepequal.go
@@ -2,10 +2,9 @@ package testutil
 
 import "reflect"
 
-// DeepEqual is similar to reflect.DeepEqual, but treats
-// nil and []T{} as equal.
-// (Note, it's also a more naive implementation that doesn't detect
-// cycles).
+// DeepEqual is similar to reflect.DeepEqual, but treats nil as equal
+// to empty maps and slices.
+// (It's also a more naive implementation that doesn't detect cycles).
 func DeepEqual(x, y interface{}) bool {
 	vx := reflect.ValueOf(x)
 	vy := reflect.ValueOf(y)
@@ -13,7 +12,7 @@ func DeepEqual(x, y interface{}) bool {
 }
 
 func deepValueEqual(x, y reflect.Value) bool {
-	if isNilish(x) && isNilish(y) {
+	if isEmpty(x) && isEmpty(y) {
 		return true
 	}
 	if !x.IsValid() {
@@ -114,7 +113,7 @@ func deepValueEqual(x, y reflect.Value) bool {
 	return false
 }
 
-func isNilish(v reflect.Value) bool {
+func isEmpty(v reflect.Value) bool {
 	if !v.IsValid() {
 		return true
 	}

--- a/testutil/deepequal.go
+++ b/testutil/deepequal.go
@@ -1,0 +1,129 @@
+package testutil
+
+import "reflect"
+
+// Similar to reflect.DeepEqual, but treats nil and []T{} as equal.
+// (Note, it's also a more naive implementation that doesn't detect
+// cycles).
+
+func DeepEqual(x, y interface{}) bool {
+	vx := reflect.ValueOf(x)
+	vy := reflect.ValueOf(y)
+	return deepValueEqual(vx, vy)
+}
+
+func deepValueEqual(x, y reflect.Value) bool {
+	if isNilish(x) && isNilish(y) {
+		return true
+	}
+	if !x.IsValid() {
+		return !y.IsValid()
+	}
+	if !y.IsValid() {
+		return false
+	}
+
+	tx := x.Type()
+	ty := y.Type()
+	if tx != ty {
+		return false
+	}
+	switch tx.Kind() {
+	case reflect.Bool:
+		return x.Bool() == y.Bool()
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return x.Int() == y.Int()
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return x.Uint() == y.Uint()
+
+	case reflect.Float32, reflect.Float64:
+		return x.Float() == y.Float()
+
+	case reflect.Complex64, reflect.Complex128:
+		return x.Complex() == y.Complex()
+
+	case reflect.String:
+		return x.String() == y.String()
+
+	case reflect.Array:
+		for i := 0; i < tx.Len(); i++ {
+			if !deepValueEqual(x.Index(i), y.Index(i)) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Slice:
+		ttx := tx.Elem()
+		tty := ty.Elem()
+		if ttx != tty {
+			return false
+		}
+		if x.Len() != y.Len() {
+			return false
+		}
+		for i := 0; i < x.Len(); i++ {
+			if !deepValueEqual(x.Index(i), y.Index(i)) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Interface:
+		if x.IsNil() {
+			return y.IsNil()
+		}
+		if y.IsNil() {
+			return false
+		}
+		return deepValueEqual(x.Elem(), y.Elem())
+
+	case reflect.Ptr:
+		if x.Pointer() == y.Pointer() {
+			return true
+		}
+		return deepValueEqual(x.Elem(), y.Elem())
+
+	case reflect.Struct:
+		for i := 0; i < tx.NumField(); i++ {
+			if !deepValueEqual(x.Field(i), y.Field(i)) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Map:
+		if x.Pointer() == y.Pointer() {
+			return true
+		}
+		if x.Len() != y.Len() {
+			return false
+		}
+		for _, k := range x.MapKeys() {
+			if !deepValueEqual(x.MapIndex(k), y.MapIndex(k)) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Func:
+		return x.IsNil() && y.IsNil()
+	}
+	return false
+}
+
+func isNilish(v reflect.Value) bool {
+	if !v.IsValid() {
+		return true
+	}
+	switch v.Type().Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+
+	case reflect.Slice, reflect.Map:
+		return v.IsNil() || v.Len() == 0
+	}
+	return false
+}

--- a/testutil/deepequal.go
+++ b/testutil/deepequal.go
@@ -2,10 +2,10 @@ package testutil
 
 import "reflect"
 
-// Similar to reflect.DeepEqual, but treats nil and []T{} as equal.
+// DeepEqual is similar to reflect.DeepEqual, but treats
+// nil and []T{} as equal.
 // (Note, it's also a more naive implementation that doesn't detect
 // cycles).
-
 func DeepEqual(x, y interface{}) bool {
 	vx := reflect.ValueOf(x)
 	vy := reflect.ValueOf(y)

--- a/testutil/deepequal_test.go
+++ b/testutil/deepequal_test.go
@@ -1,0 +1,40 @@
+package testutil
+
+import "testing"
+
+func TestDeepEqual(t *testing.T) {
+	type s struct {
+		a int
+		b string
+	}
+
+	cases := []struct {
+		a, b interface{}
+		want bool
+	}{
+		{1, 1, true},
+		{1, 2, false},
+		{nil, nil, true},
+		{nil, []byte{}, true},
+		{nil, []byte{1}, false},
+		{[]byte{1}, []byte{1}, true},
+		{[]byte{1}, []byte{2}, false},
+		{[]byte{1}, []byte{1, 2}, false},
+		{[]byte{1}, []string{"1"}, false},
+		{[3]byte{}, [4]byte{}, false},
+		{[3]byte{1}, [3]byte{1, 0, 0}, true},
+		{s{}, s{}, true},
+		{s{a: 1}, s{}, false},
+		{s{b: "foo"}, s{}, false},
+		{"foo", "foo", true},
+		{"foo", "bar", false},
+		{"foo", nil, false},
+	}
+
+	for i, c := range cases {
+		got := DeepEqual(c.a, c.b)
+		if got != c.want {
+			t.Errorf("case %d: got %v want %v", i, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
The new function treats `nil` as equal to zero-length slices and maps, and is otherwise mostly the same as `reflect.DeepEqual`. This slightly more relaxed definition of equality should reduce the time wasted on hard-to-track-down encoding errors that sometimes convert e.g. `[]byte{}` to `nil` and vice versa.

This PR also replaces uses of `reflect.DeepEqual` in `core` and `protocol` with `testutil.DeepEqual`.