### PR TITLE
encoding/blockchain: save and restore unconsumed extensible-string suffixes

### DIFF
--- a/core/txdb/txdb_test.go
+++ b/core/txdb/txdb_test.go
@@ -33,17 +33,21 @@ func TestGetBlock(t *testing.T) {
 			Version:           1,
 			Height:            1,
 			PreviousBlockHash: [32]byte{'1', '2', '3'},
-			TransactionsMerkleRoot: bc.Hash{
-				'A', 'B', 'C', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			TimestampMS:       100,
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: bc.Hash{
+					'A', 'B', 'C', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				},
+				AssetsMerkleRoot: bc.Hash{
+					'X', 'Y', 'Z', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				},
+				ConsensusProgram: []byte("test-output-script"),
 			},
-			AssetsMerkleRoot: bc.Hash{
-				'X', 'Y', 'Z', 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{[]byte("test-sig-script")},
 			},
-			TimestampMS:      100,
-			Witness:          [][]byte{[]byte("test-sig-script")},
-			ConsensusProgram: []byte("test-output-script"),
 		},
 		Transactions: []*bc.Tx{
 			bc.NewTx(bc.TxData{Version: 1, ReferenceData: []byte("test-tx")}),

--- a/encoding/blockchain/blockchain.go
+++ b/encoding/blockchain/blockchain.go
@@ -155,7 +155,7 @@ func WriteExtensibleString(w io.Writer, suffix []byte, f func(io.Writer) error) 
 // ReadExtensibleString reads a varint31 length prefix and that many
 // bytes from r. It then calls the given function to consume those
 // bytes, returning any unconsumed suffix.
-func ReadExtensibleString(r io.Reader, f func(io.Reader) error) ([]byte, int, error) {
+func ReadExtensibleString(r io.Reader, f func(io.Reader) error) (suffix []byte, n int, err error) {
 	s, n, err := ReadVarstr31(r)
 	if err != nil {
 		return nil, n, err
@@ -165,7 +165,7 @@ func ReadExtensibleString(r io.Reader, f func(io.Reader) error) ([]byte, int, er
 	if err != nil {
 		return nil, n, err
 	}
-	suffix, err := ioutil.ReadAll(sr)
+	suffix, err = ioutil.ReadAll(sr)
 	return suffix, n, err
 }
 

--- a/protocol/bc/block_commitment.go
+++ b/protocol/bc/block_commitment.go
@@ -1,0 +1,48 @@
+package bc
+
+import (
+	"io"
+
+	"chain/encoding/blockchain"
+)
+
+type BlockCommitment struct {
+	// TransactionsMerkleRoot is the root hash of the Merkle binary hash
+	// tree formed by the transaction witness hashes of all transactions
+	// included in the block.
+	TransactionsMerkleRoot Hash
+
+	// AssetsMerkleRoot is the root hash of the Merkle Patricia Tree of
+	// the set of unspent outputs with asset version 1 after applying
+	// the block.
+	AssetsMerkleRoot Hash
+
+	// ConsensusProgram is the predicate for validating the next block.
+	ConsensusProgram []byte
+}
+
+func (bc *BlockCommitment) readFrom(r io.Reader) error {
+	_, err := io.ReadFull(r, bc.TransactionsMerkleRoot[:])
+	if err != nil {
+		return err
+	}
+	_, err = io.ReadFull(r, bc.AssetsMerkleRoot[:])
+	if err != nil {
+		return err
+	}
+	bc.ConsensusProgram, _, err = blockchain.ReadVarstr31(r)
+	return err
+}
+
+func (bc *BlockCommitment) writeTo(w io.Writer) error {
+	_, err := w.Write(bc.TransactionsMerkleRoot[:])
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(bc.AssetsMerkleRoot[:])
+	if err != nil {
+		return err
+	}
+	_, err = blockchain.WriteVarstr31(w, bc.ConsensusProgram)
+	return err
+}

--- a/protocol/bc/block_witness.go
+++ b/protocol/bc/block_witness.go
@@ -1,0 +1,23 @@
+package bc
+
+import (
+	"io"
+
+	"chain/encoding/blockchain"
+)
+
+type BlockWitness struct {
+	// Witness is a vector of arguments to the previous block's
+	// ConsensusProgram for validating this block.
+	Witness [][]byte
+}
+
+func (bw *BlockWitness) readFrom(r io.Reader) (err error) {
+	bw.Witness, _, err = blockchain.ReadVarstrList(r)
+	return err
+}
+
+func (bw *BlockWitness) writeTo(w io.Writer) error {
+	_, err := blockchain.WriteVarstrList(w, bw.Witness)
+	return err
+}

--- a/protocol/bc/sighasher.go
+++ b/protocol/bc/sighasher.go
@@ -28,11 +28,10 @@ func (s *SigHasher) Hash(idx uint32) Hash {
 
 	var outHash Hash
 	inp := s.txData.Inputs[idx]
-	si, ok := inp.TypedInput.(*SpendInput)
-	if ok {
+	if si, ok := inp.TypedInput.(*SpendInput); ok {
 		// inp is a spend
 		var ocBuf bytes.Buffer
-		si.OutputCommitment.writeContents(&ocBuf, inp.AssetVersion)
+		si.OutputCommitment.writeContents(&ocBuf, si.OutputCommitmentSuffix, inp.AssetVersion)
 		sha3pool.Sum256(outHash[:], ocBuf.Bytes())
 	} else {
 		// inp is an issuance

--- a/protocol/bc/spend.go
+++ b/protocol/bc/spend.go
@@ -6,6 +6,9 @@ type SpendInput struct {
 	Outpoint
 	OutputCommitment
 
+	// The unconsumed suffix of the output commitment
+	OutputCommitmentSuffix []byte
+
 	// Witness
 	Arguments [][]byte
 }

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -63,7 +63,9 @@ func (c *Chain) GenerateBlock(ctx context.Context, prev *bc.Block, snapshot *sta
 			Height:            prev.Height + 1,
 			PreviousBlockHash: prev.Hash(),
 			TimestampMS:       timestampMS,
-			ConsensusProgram:  prev.ConsensusProgram,
+			BlockCommitment: bc.BlockCommitment{
+				ConsensusProgram: prev.ConsensusProgram,
+			},
 		},
 	}
 
@@ -221,11 +223,13 @@ func NewInitialBlock(pubkeys []ed25519.PublicKey, nSigs int, timestamp time.Time
 
 	b := &bc.Block{
 		BlockHeader: bc.BlockHeader{
-			Version:                bc.NewBlockVersion,
-			Height:                 1,
-			TimestampMS:            bc.Millis(timestamp),
-			ConsensusProgram:       script,
-			TransactionsMerkleRoot: root,
+			Version:     bc.NewBlockVersion,
+			Height:      1,
+			TimestampMS: bc.Millis(timestamp),
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: root,
+				ConsensusProgram:       script,
+			},
 		},
 	}
 	return b, nil

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -171,13 +171,15 @@ func TestGenerateBlock(t *testing.T) {
 
 	want := &bc.Block{
 		BlockHeader: bc.BlockHeader{
-			Version:                bc.NewBlockVersion,
-			Height:                 2,
-			PreviousBlockHash:      b1.Hash(),
-			TransactionsMerkleRoot: wantTxRoot,
-			AssetsMerkleRoot:       wantAssetsRoot,
-			TimestampMS:            bc.Millis(now),
-			ConsensusProgram:       b1.ConsensusProgram,
+			Version:           bc.NewBlockVersion,
+			Height:            2,
+			PreviousBlockHash: b1.Hash(),
+			TimestampMS:       bc.Millis(now),
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: wantTxRoot,
+				AssetsMerkleRoot:       wantAssetsRoot,
+				ConsensusProgram:       b1.ConsensusProgram,
+			},
 		},
 		Transactions: txs,
 	}

--- a/protocol/recover_test.go
+++ b/protocol/recover_test.go
@@ -63,13 +63,15 @@ func createEmptyBlock(block *bc.Block, snapshot *state.Snapshot) *bc.Block {
 
 	return &bc.Block{
 		BlockHeader: bc.BlockHeader{
-			Version:                bc.NewBlockVersion,
-			Height:                 block.Height + 1,
-			PreviousBlockHash:      block.Hash(),
-			TimestampMS:            bc.Millis(time.Now()),
-			ConsensusProgram:       block.ConsensusProgram,
-			TransactionsMerkleRoot: root,
-			AssetsMerkleRoot:       snapshot.Tree.RootHash(),
+			Version:           bc.NewBlockVersion,
+			Height:            block.Height + 1,
+			PreviousBlockHash: block.Hash(),
+			TimestampMS:       bc.Millis(time.Now()),
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: root,
+				AssetsMerkleRoot:       snapshot.Tree.RootHash(),
+				ConsensusProgram:       block.ConsensusProgram,
+			},
 		},
 	}
 }

--- a/protocol/validation/block_test.go
+++ b/protocol/validation/block_test.go
@@ -16,9 +16,11 @@ var emptyMerkleRoot = mustParseHash("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43
 func TestValidateBlockHeader(t *testing.T) {
 	ctx := context.Background()
 	prev := &bc.Block{BlockHeader: bc.BlockHeader{
-		Height:           1,
-		TimestampMS:      5,
-		ConsensusProgram: []byte{byte(vm.OP_5), byte(vm.OP_ADD), byte(vm.OP_9), byte(vm.OP_EQUAL)},
+		Height:      1,
+		TimestampMS: 5,
+		BlockCommitment: bc.BlockCommitment{
+			ConsensusProgram: []byte{byte(vm.OP_5), byte(vm.OP_ADD), byte(vm.OP_9), byte(vm.OP_EQUAL)},
+		},
 	}}
 	prevHash := prev.Hash()
 	cases := []struct {
@@ -28,73 +30,101 @@ func TestValidateBlockHeader(t *testing.T) {
 	}{{
 		desc: "bad prev block hash",
 		header: bc.BlockHeader{
-			PreviousBlockHash:      bc.Hash{},
-			TransactionsMerkleRoot: emptyMerkleRoot,
-			Height:                 2,
-			Witness:                [][]byte{{0x04}},
+			PreviousBlockHash: bc.Hash{},
+			Height:            2,
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: emptyMerkleRoot,
+			},
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{{0x04}},
+			},
 		},
 		want: ErrBadPrevHash,
 	}, {
 		desc: "bad block height",
 		header: bc.BlockHeader{
-			PreviousBlockHash:      prevHash,
-			TransactionsMerkleRoot: emptyMerkleRoot,
-			Height:                 3,
-			Witness:                [][]byte{{0x04}},
+			PreviousBlockHash: prevHash,
+			Height:            3,
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: emptyMerkleRoot,
+			},
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{{0x04}},
+			},
 		},
 		want: ErrBadHeight,
 	}, {
 		desc: "bad block timestamp",
 		header: bc.BlockHeader{
-			PreviousBlockHash:      prevHash,
-			TransactionsMerkleRoot: emptyMerkleRoot,
-			Height:                 2,
-			TimestampMS:            3,
-			Witness:                [][]byte{{0x04}},
+			PreviousBlockHash: prevHash,
+			Height:            2,
+			TimestampMS:       3,
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: emptyMerkleRoot,
+			},
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{{0x04}},
+			},
 		},
 		want: ErrBadTimestamp,
 	}, {
 		desc: "fake initial block",
 		header: bc.BlockHeader{
-			PreviousBlockHash:      prevHash,
-			TransactionsMerkleRoot: emptyMerkleRoot,
-			Height:                 1,
-			TimestampMS:            6,
-			ConsensusProgram:       []byte{byte(vm.OP_5), byte(vm.OP_ADD), byte(vm.OP_9), byte(vm.OP_EQUAL)},
-			Witness:                [][]byte{{0x04}},
+			PreviousBlockHash: prevHash,
+			Height:            1,
+			TimestampMS:       6,
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: emptyMerkleRoot,
+				ConsensusProgram:       []byte{byte(vm.OP_5), byte(vm.OP_ADD), byte(vm.OP_9), byte(vm.OP_EQUAL)},
+			},
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{{0x04}},
+			},
 		},
 		want: ErrBadHeight,
 	}, {
 		desc: "bad block output script",
 		header: bc.BlockHeader{
-			PreviousBlockHash:      prevHash,
-			TransactionsMerkleRoot: emptyMerkleRoot,
-			Height:                 2,
-			TimestampMS:            6,
-			ConsensusProgram:       []byte{byte(vm.OP_FAIL)},
-			Witness:                [][]byte{{0x04}},
+			PreviousBlockHash: prevHash,
+			Height:            2,
+			TimestampMS:       6,
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: emptyMerkleRoot,
+				ConsensusProgram:       []byte{byte(vm.OP_FAIL)},
+			},
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{{0x04}},
+			},
 		},
 		want: ErrBadScript,
 	}, {
 		desc: "bad block signature script",
 		header: bc.BlockHeader{
-			PreviousBlockHash:      prevHash,
-			TransactionsMerkleRoot: emptyMerkleRoot,
-			Height:                 2,
-			TimestampMS:            6,
-			ConsensusProgram:       []byte{byte(vm.OP_5), byte(vm.OP_ADD), byte(vm.OP_9), byte(vm.OP_EQUAL)},
-			Witness:                [][]byte{{0x03}},
+			PreviousBlockHash: prevHash,
+			Height:            2,
+			TimestampMS:       6,
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: emptyMerkleRoot,
+				ConsensusProgram:       []byte{byte(vm.OP_5), byte(vm.OP_ADD), byte(vm.OP_9), byte(vm.OP_EQUAL)},
+			},
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{{0x03}},
+			},
 		},
 		want: ErrBadSig,
 	}, {
 		desc: "valid header",
 		header: bc.BlockHeader{
-			PreviousBlockHash:      prevHash,
-			TransactionsMerkleRoot: emptyMerkleRoot,
-			Height:                 2,
-			TimestampMS:            6,
-			ConsensusProgram:       []byte{byte(vm.OP_5), byte(vm.OP_ADD), byte(vm.OP_9), byte(vm.OP_EQUAL)},
-			Witness:                [][]byte{{0x04}},
+			PreviousBlockHash: prevHash,
+			Height:            2,
+			TimestampMS:       6,
+			BlockCommitment: bc.BlockCommitment{
+				TransactionsMerkleRoot: emptyMerkleRoot,
+				ConsensusProgram:       []byte{byte(vm.OP_5), byte(vm.OP_ADD), byte(vm.OP_9), byte(vm.OP_EQUAL)},
+			},
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{{0x04}},
+			},
 		},
 		want: nil,
 	}}

--- a/protocol/vm/introspection_test.go
+++ b/protocol/vm/introspection_test.go
@@ -10,7 +10,9 @@ import (
 func TestNextProgram(t *testing.T) {
 	block := &bc.Block{
 		BlockHeader: bc.BlockHeader{
-			ConsensusProgram: []byte{0x1, 0x2, 0x3},
+			BlockCommitment: bc.BlockCommitment{
+				ConsensusProgram: []byte{0x1, 0x2, 0x3},
+			},
 		},
 	}
 	prog, err := Assemble("NEXTPROGRAM 0x010203 EQUAL")

--- a/protocol/vm/vm_test.go
+++ b/protocol/vm/vm_test.go
@@ -254,10 +254,18 @@ func TestVerifyTxInput(t *testing.T) {
 
 func TestVerifyBlockHeader(t *testing.T) {
 	block := &bc.Block{
-		BlockHeader: bc.BlockHeader{Witness: [][]byte{{2}, {3}}},
+		BlockHeader: bc.BlockHeader{
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{{2}, {3}},
+			},
+		},
 	}
 	prevBlock := &bc.Block{
-		BlockHeader: bc.BlockHeader{ConsensusProgram: []byte{byte(OP_ADD), byte(OP_5), byte(OP_NUMEQUAL)}},
+		BlockHeader: bc.BlockHeader{
+			BlockCommitment: bc.BlockCommitment{
+				ConsensusProgram: []byte{byte(OP_ADD), byte(OP_5), byte(OP_NUMEQUAL)},
+			},
+		},
 	}
 
 	got, gotErr := VerifyBlockHeader(&prevBlock.BlockHeader, block)
@@ -270,7 +278,11 @@ func TestVerifyBlockHeader(t *testing.T) {
 	}
 
 	block = &bc.Block{
-		BlockHeader: bc.BlockHeader{Witness: [][]byte{make([]byte, 50000)}},
+		BlockHeader: bc.BlockHeader{
+			BlockWitness: bc.BlockWitness{
+				Witness: [][]byte{make([]byte, 50000)},
+			},
+		},
 	}
 
 	_, gotErr = VerifyBlockHeader(&prevBlock.BlockHeader, block)
@@ -496,8 +508,16 @@ func TestVerifyBlockHeaderQuickCheck(t *testing.T) {
 				ok = false
 			}
 		}()
-		prev := &bc.BlockHeader{ConsensusProgram: program}
-		block := &bc.Block{BlockHeader: bc.BlockHeader{Witness: witnesses}}
+		prev := &bc.BlockHeader{
+			BlockCommitment: bc.BlockCommitment{
+				ConsensusProgram: program,
+			},
+		}
+		block := &bc.Block{BlockHeader: bc.BlockHeader{
+			BlockWitness: bc.BlockWitness{
+				Witness: witnesses,
+			},
+		}}
 		verifyBlockHeader(prev, block)
 		return true
 	}


### PR DESCRIPTION
Remove the `all` parameter from `ReadExtensibleString`, which now always returns the unconsumed suffix. `WriteExtensibleString` now takes a suffix to always append.

Types with fields parsed from an extensible string now also store the unrecognized suffix to add back when writing.

Block commitment and witness types are moved to their own files, for improved clarity.

Closes https://github.com/chain/chain/issues/366 - unrecognized extensible string suffixes were being dropped