### PR TITLE
core/query: restore outpoint annotation in txinputs

### DIFF
--- a/core/query/annotated.go
+++ b/core/query/annotated.go
@@ -85,7 +85,7 @@ func (b *Bool) UnmarshalJSON(raw []byte) error {
 	return nil
 }
 
-func buildAnnotatedTransaction(orig *bc.Tx, b *bc.Block, indexInBlock uint32, outpoints map[bc.OutputID]*bc.Outpoint) *AnnotatedTx {
+func buildAnnotatedTransaction(orig *bc.Tx, b *bc.Block, indexInBlock uint32, outpoints map[bc.OutputID]bc.Outpoint) *AnnotatedTx {
 	blockHash := b.Hash()
 	referenceData := json.RawMessage(orig.ReferenceData)
 	if len(referenceData) == 0 {
@@ -111,7 +111,7 @@ func buildAnnotatedTransaction(orig *bc.Tx, b *bc.Block, indexInBlock uint32, ou
 	return tx
 }
 
-func buildAnnotatedInput(orig *bc.TxInput, outpoints map[bc.OutputID]*bc.Outpoint) *AnnotatedInput {
+func buildAnnotatedInput(orig *bc.TxInput, outpoints map[bc.OutputID]bc.Outpoint) *AnnotatedInput {
 	aid := orig.AssetID()
 
 	referenceData := json.RawMessage(orig.ReferenceData)
@@ -135,8 +135,8 @@ func buildAnnotatedInput(orig *bc.TxInput, outpoints map[bc.OutputID]*bc.Outpoin
 		in.ControlProgram = prog
 		in.SpentOutputID = prevoutID.Bytes()
 
-		outpoint := outpoints[prevoutID]
-		if outpoint != nil {
+		outpoint, ok := outpoints[prevoutID]
+		if ok {
 			in.SpentOutput = &SpentOutput{
 				TransactionID: outpoint.Hash[:],
 				Position:      outpoint.Index,

--- a/core/query/annotated.go
+++ b/core/query/annotated.go
@@ -134,7 +134,7 @@ func buildAnnotatedInput(orig *bc.TxInput, outpoints map[bc.OutputID]*bc.Outpoin
 		in.Type = "spend"
 		in.ControlProgram = prog
 		in.SpentOutputID = prevoutID.Bytes()
-		
+
 		outpoint := outpoints[prevoutID]
 		if outpoint != nil {
 			in.SpentOutput = &SpentOutput{

--- a/core/query/index.go
+++ b/core/query/index.go
@@ -123,7 +123,8 @@ func (ind *Indexer) loadOutpoints(ctx context.Context, outputIDs pq.ByteaArray) 
 	`
 	results := make(map[bc.OutputID]bc.Outpoint)
 	err := pg.ForQueryRows(ctx, ind.db, q, outputIDs, func(txHash bc.Hash, outputIndex uint32) {
-		// We compute outid on the fly instead of receiving it from DB to save 40% of bandwidth.
+		// We compute outid on the fly instead of receiving it from DB to save 47% of bandwidth:
+		// DB is sending (hash256, int32) instead of (hash, int32, hash).
 		outid := bc.ComputeOutputID(txHash, outputIndex)
 		results[outid] = bc.Outpoint{
 			Hash:  txHash,

--- a/core/query/index.go
+++ b/core/query/index.go
@@ -71,7 +71,7 @@ func (ind *Indexer) insertAnnotatedTxs(ctx context.Context, b *bc.Block) ([]*Ann
 	for pos, tx := range b.Transactions {
 		hashes = append(hashes, tx.Hash[:])
 		positions = append(positions, uint32(pos))
-		annotatedTxsDecoded = append(annotatedTxsDecoded, buildAnnotatedTransaction(tx, b, uint32(pos)))
+		annotatedTxsDecoded = append(annotatedTxsDecoded, buildAnnotatedTransaction(ind, ctx, tx, b, uint32(pos)))
 	}
 
 	for _, annotator := range ind.annotators {

--- a/docs/internal/api-spec.swagger.yml
+++ b/docs/internal/api-spec.swagger.yml
@@ -359,6 +359,8 @@ definitions:
       spent_output_id:
         type: string
         description: The unique ID of the output being spent.
+      spent_output:
+        $ref: '#/definitions/SpentOutput'
       account_id:
         type: string
         description: The unique ID of the account. Only present if `SpentOutput`
@@ -384,6 +386,20 @@ definitions:
         description: Either "yes" or "no". "yes" if `type` is "issue" and
           `asset_is_local` is "yes", OR if `type` is "spend" and
           `account_is_local` is "yes". "no" otherwise.
+
+  SpentOutput:
+    type: object
+    required:
+      - transaction_id
+      - position
+    properties:
+      transaction_id:
+        type: string
+        description: The unique ID of the transaction containing the output.
+      position:
+        type: integer
+        description: The position of the output within the containing
+          tranasction’s outputs.
 
   TransactionOutput:
     type: object

--- a/docs/internal/api-spec.swagger.yml
+++ b/docs/internal/api-spec.swagger.yml
@@ -396,10 +396,11 @@ definitions:
       transaction_id:
         type: string
         description: The unique ID of the transaction containing the output.
+          This field is deprecated, use `spent_output_id` instead.
       position:
         type: integer
         description: The position of the output within the containing
-          tranasction’s outputs.
+          tranasction’s outputs. This field is deprecated, use `spent_output_id` instead.
 
   TransactionOutput:
     type: object

--- a/sdk/java/src/main/java/com/chain/api/Transaction.java
+++ b/sdk/java/src/main/java/com/chain/api/Transaction.java
@@ -198,6 +198,12 @@ public class Transaction {
     public String spentOutputId;
 
     /**
+     * The output consumed by this input. Null if the input is an issuance.
+     */
+    @SerializedName("spent_output")
+    public OutputPointer spentOutput;
+
+    /**
      * The id of the account transferring the asset (possibly null if the input is an issuance or an unspent output is specified).
      */
     @SerializedName("account_id")
@@ -335,6 +341,17 @@ public class Transaction {
      */
     @SerializedName("is_local")
     public String isLocal;
+  }
+
+  /**
+   * An OutputPointer consists of a transaction ID and an output position, and
+   * uniquely identifies an output on the blockchain.
+   */
+  public static class OutputPointer {
+    @SerializedName("transaction_id")
+    public String transactionId;
+
+    public int position;
   }
 
   /**

--- a/sdk/java/src/test/java/com/chain/integration/TransactionTest.java
+++ b/sdk/java/src/test/java/com/chain/integration/TransactionTest.java
@@ -103,6 +103,7 @@ public class TransactionTest {
     assertNull(input.accountTags);
     assertEquals("yes", input.isLocal);
     assertNull(input.spentOutputId);
+    assertNull(input.spentOutput);
     assertNotNull(input.issuanceProgram);
     assertNotNull(input.referenceData);
 
@@ -153,6 +154,9 @@ public class TransactionTest {
 
     input = tx.inputs.get(0);
     assertNotNull(input.spentOutputId);
+    assertNotNull(input.spentOutput);
+    assertNotNull(input.spentOutput.position);
+    assertNotNull(input.spentOutput.transactionId);
 
     Transaction.Template retirement =
         new Transaction.Builder()

--- a/sdk/ruby/lib/chain/transaction.rb
+++ b/sdk/ruby/lib/chain/transaction.rb
@@ -155,6 +155,11 @@ module Chain
       # @return [String]
       attrib :spent_output_id
 
+      # @!attribute [r] spent_output
+      # The output consumed by this input.
+      # @return [SpentOutput]
+      attrib(:spent_output) { |raw| SpentOutput.new(raw) }
+
       # @!attribute [r] account_id
       # The id of the account transferring the asset (possibly null if the
       # input is an issuance or an unspent output is specified).
@@ -196,6 +201,18 @@ module Chain
       # A flag indicating if the input is local.
       # @return [Boolean]
       attrib :is_local
+
+      class SpentOutput < ResponseObject
+        # @!attribute [r] transaction_id
+        # Unique transaction identifier.
+        # @return [String]
+        attrib :transaction_id
+
+        # @!attribute [r] position
+        # Position of an output within the transaction.
+        # @return [Integer]
+        attrib :position
+      end
     end
 
     class Output < ResponseObject


### PR DESCRIPTION
This addresses https://github.com/chain/chain/issues/439

1. TxInputs have `spent_output{transaction_id,position}` struct side by side with `spent_output_id`.
2. Support for this struct is returned to Java and Ruby SDKs. NodeSDK is unchanged because it was implicitly forwarding JSON results as is to the user.
3. Annotation done by batch collection of a mapping `outputid -> outpoint` for all transactions in a block.
4. OutputID is not queried from DB, but instead computed from Outpoint. This adds extra hashing overhead per input, but reduces DB traffic by ≈50% (33 bytes vs 65 bytes per input). **Not sure if it's the right call, so please advise!**

PTAL @kr @jeffomatic @jbowens 