### PR TITLE
core/query/filter: add unicode support

### DIFF
--- a/core/query/filter/parser_test.go
+++ b/core/query/filter/parser_test.go
@@ -19,6 +19,10 @@ func TestParseValid(t *testing.T) {
 			expr: valueExpr{typ: tokString, value: "'hello world'"},
 		},
 		{
+			p:    "'สวัสดีชาวโลก'",
+			expr: valueExpr{typ: tokString, value: "'สวัสดีชาวโลก'"},
+		},
+		{
 			p:    "2000",
 			expr: valueExpr{typ: tokInteger, value: "2000"},
 		},

--- a/core/query/filter/scanner_test.go
+++ b/core/query/filter/scanner_test.go
@@ -54,6 +54,43 @@ func TestScannerValid(t *testing.T) {
 				{pos: 25, lit: "", tok: tokEOF},
 			},
 		},
+		{
+			input: []byte(`comme ci comme ça`),
+			toks: []scannedTok{
+				{pos: 0, lit: "comme", tok: tokIdent},
+				{pos: 6, lit: "ci", tok: tokIdent},
+				{pos: 9, lit: "comme", tok: tokIdent},
+				{pos: 15, lit: "ça", tok: tokIdent},
+				{pos: 18, lit: "", tok: tokEOF},
+			},
+		},
+		{
+			input: []byte(`'comme ci comme ça'`),
+			toks: []scannedTok{
+				{pos: 0, lit: "'comme ci comme ça'", tok: tokString},
+				{pos: 20, lit: "", tok: tokEOF},
+			},
+		},
+		{
+			input: []byte(`asset_definition.fund_manager.résumé`),
+			toks: []scannedTok{
+				{pos: 0, lit: "asset_definition", tok: tokIdent},
+				{pos: 16, lit: ".", tok: tokPunct},
+				{pos: 17, lit: "fund_manager", tok: tokIdent},
+				{pos: 29, lit: ".", tok: tokPunct},
+				{pos: 30, lit: "résumé", tok: tokIdent},
+				{pos: 38, lit: "", tok: tokEOF},
+			},
+		},
+		{
+			input: []byte(`asset_alias = '区块链'`),
+			toks: []scannedTok{
+				{pos: 0, lit: "asset_alias", tok: tokIdent},
+				{pos: 12, lit: "=", tok: tokPunct},
+				{pos: 14, lit: "'区块链'", tok: tokString},
+				{pos: 25, lit: "", tok: tokEOF},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -95,23 +132,7 @@ func TestScannerInvalid(t *testing.T) {
 		},
 		{
 			input: append([]byte(`hello`), 0),
-			err:   parseError{pos: 5, msg: `illegal character NUL`},
-		},
-		{
-			input: []byte(`comme ci comme ça`),
-			err:   parseError{pos: 15, msg: `non-ASCII character`},
-		},
-		{
-			input: []byte(`'comme ci comme ça'`),
-			err:   parseError{pos: 16, msg: `non-ASCII character`},
-		},
-		{
-			input: []byte(`asset_definition.fund_manager.résumé`),
-			err:   parseError{pos: 31, msg: `non-ASCII character`},
-		},
-		{
-			input: []byte(`asset_alias = '区块链'`),
-			err:   parseError{pos: 15, msg: `non-ASCII character`},
+			err:   parseError{pos: 6, msg: `illegal character NUL`},
 		},
 		{
 			input: []byte(`0xwhat`),
@@ -120,6 +141,14 @@ func TestScannerInvalid(t *testing.T) {
 		{
 			input: []byte(`10 = 02`),
 			err:   parseError{pos: 5, msg: `illegal leading 0 in number`},
+		},
+		{
+			input: []byte{0xD8, 0xD8},
+			err:   parseError{pos: 0, msg: `illegal UTF-8 encoding`},
+		},
+		{
+			input: []byte{0xE0, 0xD8, 0xD8},
+			err:   parseError{pos: 0, msg: `illegal UTF-8 encoding`},
 		},
 	}
 

--- a/core/query/query_test.go
+++ b/core/query/query_test.go
@@ -42,7 +42,7 @@ func setupQueryTest(t *testing.T) (context.Context, *query.Indexer, time.Time, t
 	acct1 := coretest.CreateAccount(ctx, t, accounts, "", nil)
 	acct2 := coretest.CreateAccount(ctx, t, accounts, "", nil)
 
-	asset1Tags := map[string]interface{}{"currency": "USD"}
+	asset1Tags := map[string]interface{}{"currency": "USD", "message": "สวัสดีชาวโลก"}
 
 	coretest.CreateAsset(ctx, t, assets, nil, "", asset1Tags)
 
@@ -99,6 +99,21 @@ func TestQueryOutputs(t *testing.T) {
 		{
 			filter: "asset_tags.currency = $1",
 			values: []interface{}{"USD"},
+			when:   time2,
+			want: []assetAccountAmount{
+				{bc.AssetAmount{AssetID: asset1, Amount: 867}, acct1},
+			},
+		},
+		{
+			filter: "asset_tags.message = 'สวัสดีชาวโลก'",
+			when:   time2,
+			want: []assetAccountAmount{
+				{bc.AssetAmount{AssetID: asset1, Amount: 867}, acct1},
+			},
+		},
+		{
+			filter: "asset_tags.message = $1",
+			values: []interface{}{"สวัสดีชาวโลก"},
 			when:   time2,
 			want: []assetAccountAmount{
 				{bc.AssetAmount{AssetID: asset1, Amount: 867}, acct1},


### PR DESCRIPTION
Support UTF-8 characters in strings and identifiers. This does _not_ add
escaping for strings or identifiers so `'` and `\` are still illegal
characters in strings. Any non-alphanumeric characters are still
illegal in identifiers.

Token positions are reported using the byte offset of the beginning of
the token. To retrieve the code point offset, the consumer of the package
can use `utf8.RuneCount(src[:offset])`.