### PR TITLE
docs: update deploy instructions

### DIFF
--- a/bin/upload-docs
+++ b/bin/upload-docs
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -ef -o pipefail
 
-# TODO: when production is viable target, add commandline option to upload to
-# the production bucket.
 bucket="chain-staging.chain.com"
 if [ "$1" = "prod" ];
 then

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,9 @@ $ aws configure
 
 Before uploading documentation, make sure your local state reflects the correct documentation. The `main` branch is generally not safe for this purpose, since it may contain documentation updates that reflect changes that have yet to make it into an official relase.
 
-The state of production documentation is tracked in the `docs-release` branch. This branch that reflects the last known safe version of the documentation. Typically, it will contain the contents of `main`, **minus** updates to the `docs` and `sdk` directories that reflect unreleased updates. Since this contents of `docs-release` are assembled ad hoc, the history of this branch is unimportant. It's fine to use force-pushes that ensure that the branch is only one commit away from a commit in `main`.
+The state of production documentation is tracked in the `docs-release` branch. This branch that reflects the last known safe version of the documentation. Typically, it will contain the contents of `main`, **minus** updates to the `docs` and `sdk` directories that reflect unreleased updates.
+
+Since this contents of `docs-release` are assembled ad hoc, the history of this branch is relatively unimportant. It's fine to use force-pushes to synchronize the branch with `main`. Our current convention is to find a stable baseline commit on `main`, and then add cherry-picked commits that refer to commits in `main` that contain releasable updates to the `docs` and `sdk` directories.
 
 #### Uploading the docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,11 +2,9 @@
 
 ## Development
 
-To view docs with their associated HTML, styles and fonts, we use a tool
-called `md2html`.
+To view docs with their associated HTML, styles and fonts, we use a tool called `md2html`.
 
-Make sure all Chain Core commands have been installed by following the
-installation instructions in the [repo README](../Readme.md#installation).
+Make sure all Chain Core commands have been installed by following the installation instructions in the [repo README](../Readme.md#installation).
 
 Once installed, run `md2html` from the root directory of the rep:
 
@@ -15,15 +13,13 @@ $ cd $CHAIN
 $ go install ./cmd/md2html && md2html
 ```
 
-The converted documentation is served at
-[http://localhost:8080/docs](http://localhost:8080/docs).
+The converted documentation is served at [http://localhost:8080/docs](http://localhost:8080/docs).
 
 ## Deployment
 
 ### Chain Core
 
-Documentation is bundled into Chain Core inside the `$CHAIN/generated` folder.
-To bundle the latest docs, run:
+Documentation is bundled into Chain Core inside the `$CHAIN/generated` folder. To bundle the latest docs, run:
 
 ```sh
 $ cd $CHAIN
@@ -32,27 +28,39 @@ $ ./bin/bundle-docs
 
 ### Web
 
-#### Dependencies
+#### Prerequisites
 
-* [AWS CLI](https://aws.amazon.com/cli/)
-* AWS credentials with access to the appropriate buckets
+Prepare the following:
 
-To upload the latest docs to S3, log in to `aws` with the command:
+* Install [AWS CLI](https://aws.amazon.com/cli/)
+* Have AWS credentials with access to the appropriate buckets
+
+Log into `aws` with the command:
 
 ```sh
 $ aws configure
 ```
 
-Once configured, you can upload the docs to the staging bucket with:
+#### The `docs-release` branch
 
-```sh
-$ cd $CHAIN
-$ ./bin/upload-docs
+Before uploading documentation, make sure your local state reflects the correct documentation. The `main` branch is generally not safe for this purpose, since it may contain documentation updates that reflect changes that have yet to make it into an official relase.
+
+The state of production documentation is tracked in the `docs-release` branch. This branch that reflects the last known safe version of the documentation. Typically, it will contain the contents of `main`, **minus** updates to the `docs` and `sdk` directories that reflect unreleased updates. Since this contents of `docs-release` are assembled ad hoc, the history of this branch is unimportant. It's fine to use force-pushes that ensure that the branch is only one commit away from a commit in `main`.
+
+#### Uploading the docs
+
+Staging:
+
+```
+cd $CHAIN
+git checkout docs-release
+./bin/upload-docs
 ```
 
-To upload to the production bucket instead, run `upload-docs` with `prod` as
-an argument:
+Production:
 
-```sh
-$ ./bin/upload-docs prod
+```
+cd $CHAIN
+git checkout docs-release
+./bin/upload-docs prod
 ```


### PR DESCRIPTION
We're noticing that the `main` branch is not always the appropriate source for our online documentation, because it often contains updates to the source docs that reflect changes that haven't been released yet. Therefore, this commit proposes a new `docs-release` branch that is prepared ad hoc before documentation is uploaded to our public website.