### PR TITLE
protocol/bc: do away with witness hashes

### DIFF
--- a/protocol/bc/block_commitment.go
+++ b/protocol/bc/block_commitment.go
@@ -8,8 +8,8 @@ import (
 
 type BlockCommitment struct {
 	// TransactionsMerkleRoot is the root hash of the Merkle binary hash
-	// tree formed by the transaction witness hashes of all transactions
-	// included in the block.
+	// tree formed by the hashes of all transactions included in the
+	// block.
 	TransactionsMerkleRoot Hash
 
 	// AssetsMerkleRoot is the root hash of the Merkle Patricia Tree of

--- a/protocol/bc/transaction_test.go
+++ b/protocol/bc/transaction_test.go
@@ -21,10 +21,9 @@ func TestTransaction(t *testing.T) {
 	assetID := ComputeAssetID(issuanceScript, initialBlockHash, 1, EmptyStringHash)
 
 	cases := []struct {
-		tx          *Tx
-		hex         string
-		hash        [32]byte
-		witnessHash [32]byte
+		tx   *Tx
+		hex  string
+		hash [32]byte
 	}{
 		{
 			tx: NewTx(TxData{
@@ -44,8 +43,7 @@ func TestTransaction(t *testing.T) {
 				"00" + // inputs count
 				"00" + // outputs count
 				"00"), // reference data
-			hash:        mustDecodeHash("74e60d94a75848b48fc79eac11a1d39f41e1b32046cf948929b729a57b75d5be"),
-			witnessHash: mustDecodeHash("87f80a62c95421ab5c42b7e2787b472a84856461dd01397f2c37f096f0ef1ab4"),
+			hash: mustDecodeHash("74e60d94a75848b48fc79eac11a1d39f41e1b32046cf948929b729a57b75d5be"),
 		},
 		{
 			tx: NewTx(TxData{
@@ -94,8 +92,7 @@ func TestTransaction(t *testing.T) {
 				"066f7574707574" + // output 0, reference data
 				"00" + // output 0, output witness
 				"0869737375616e6365"), // reference data
-			hash:        mustDecodeHash("946b6c226d88723020ab50665fbb76191639b5f1fd851b35edb729d4b17373cc"),
-			witnessHash: mustDecodeHash("813b400d2d53cfa89b9cb985b618ef974b81613f1d9a33c8b4f5a6b6c69ef5fe"),
+			hash: mustDecodeHash("946b6c226d88723020ab50665fbb76191639b5f1fd851b35edb729d4b17373cc"),
 		},
 		{
 			tx: NewTx(TxData{
@@ -148,8 +145,7 @@ func TestTransaction(t *testing.T) {
 				"00" + // output 1, reference data
 				"00" + // output 1, output witness
 				"0c646973747269627574696f6e"), // reference data
-			hash:        mustDecodeHash("86556ca6f6181dbb71bcd3cba53fce825f39083c409b7c4afdf40c9912487113"),
-			witnessHash: mustDecodeHash("be907283e04ac6f365bc85af01b1a7945f89bfa4d77ca6429533cb11472322ab"),
+			hash: mustDecodeHash("86556ca6f6181dbb71bcd3cba53fce825f39083c409b7c4afdf40c9912487113"),
 		},
 	}
 	for i, test := range cases {
@@ -160,14 +156,6 @@ func TestTransaction(t *testing.T) {
 		}
 		if test.tx.Hash != test.hash {
 			t.Errorf("test %d: hash = %s want %x", i, test.tx.Hash, test.hash)
-		}
-
-		g, err := test.tx.WitnessHash()
-		if err != nil {
-			t.Fatalf("unexpected error %s", err)
-		}
-		if g != test.witnessHash {
-			t.Errorf("test %d: witness hash = %s want %x", i, g, test.witnessHash)
 		}
 
 		txJSON, err := json.Marshal(test.tx)

--- a/protocol/bc/txinput.go
+++ b/protocol/bc/txinput.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 
-	"chain/crypto/sha3pool"
 	"chain/encoding/blockchain"
 	"chain/errors"
 )
@@ -301,17 +300,6 @@ func (t *TxInput) writeInputWitness(w io.Writer) error {
 		}
 	}
 	return nil
-}
-
-func (t *TxInput) witnessHash() (h Hash, err error) {
-	sha := sha3pool.Get256()
-	defer sha3pool.Put256(sha)
-	err = t.writeInputWitness(sha)
-	if err != nil {
-		return h, err
-	}
-	sha.Read(h[:])
-	return h, nil
 }
 
 func (t *TxInput) SpentOutputID() (o OutputID) {

--- a/protocol/bc/txoutput.go
+++ b/protocol/bc/txoutput.go
@@ -82,10 +82,6 @@ func (to *TxOutput) writeTo(w io.Writer, serflags byte) error {
 	return nil
 }
 
-func (to *TxOutput) witnessHash() Hash {
-	return EmptyStringHash
-}
-
 func (to *TxOutput) WriteCommitment(w io.Writer) error {
 	return to.OutputCommitment.writeExtensibleString(w, to.CommitmentSuffix, to.AssetVersion)
 }

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -166,7 +166,7 @@ func TestGenerateBlock(t *testing.T) {
 
 	// TODO(bobg): verify these hashes are correct
 	var wantTxRoot, wantAssetsRoot bc.Hash
-	copy(wantTxRoot[:], mustDecodeHex("2bf0254a214f4a675b3a7801974fe87c9db1827c2a8dbfd5778012084b3c0a8d"))
+	copy(wantTxRoot[:], mustDecodeHex("3eb04ed5a48a8df5f39e741ac8e4f9b1ca634f281cc91f28a93ed227598608a4"))
 	copy(wantAssetsRoot[:], mustDecodeHex("1593fdd753558fbcaff9ba7529579e5dd638139b6d25537e53e3310d47444946"))
 
 	want := &bc.Block{

--- a/protocol/validation/merkle.go
+++ b/protocol/validation/merkle.go
@@ -24,12 +24,8 @@ func CalcMerkleRoot(transactions []*bc.Tx) (root bc.Hash, err error) {
 		h := sha3pool.Get256()
 		defer sha3pool.Put256(h)
 
-		witHash, err := transactions[0].WitnessHash()
-		if err != nil {
-			return root, err
-		}
 		h.Write(leafPrefix)
-		h.Write(witHash[:])
+		h.Write(transactions[0].Hash[:])
 		h.Read(root[:])
 		return root, nil
 

--- a/protocol/validation/merkle_test.go
+++ b/protocol/validation/merkle_test.go
@@ -20,7 +20,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 				[]byte("00000"),
 			},
 		},
-		want: mustParseHash("13eda1f33bd7ddce6256533374518b2c4d374b3d3608f7a9fcb61c1779b34bab"),
+		want: mustParseHash("16f76c31b0f4035d4e8a7f477690f7b99693dade3acb3c943c1fdff11cd7b38a"),
 	}, {
 		witnesses: [][][]byte{
 			[][]byte{
@@ -32,7 +32,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 				[]byte("111111"),
 			},
 		},
-		want: mustParseHash("dcb76dd841b1787ff3c6590b8bc7b0583b0f17be9661d1842b7c1eb88b9bef1e"),
+		want: mustParseHash("b54ace3b3a4572df03b49996aa4b5f127b3b115d0ad39bc5ad10d8f98610de7b"),
 	}, {
 		witnesses: [][][]byte{
 			[][]byte{
@@ -45,7 +45,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 				[]byte("222222"),
 			},
 		},
-		want: mustParseHash("027bb007a4600d92c8133c54a386e36985b358c324992c1353bc1237170f8a88"),
+		want: mustParseHash("b54ace3b3a4572df03b49996aa4b5f127b3b115d0ad39bc5ad10d8f98610de7b"),
 	}}
 
 	for _, c := range cases {


### PR DESCRIPTION
The merkle tree is now computed from transaction hashes. This is preparatory to landing the code in https://github.com/chain/chain/tree/txgraph