### PR TITLE
core: disable some endpoints in production

### DIFF
--- a/cmd/cored/dev.go
+++ b/cmd/cored/dev.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	reset = env.String("RESET", "")
-	prod  = "no"
+	prod  = false
 )
 
 func resetInDevIfRequested(db pg.DB) {

--- a/cmd/cored/prod.go
+++ b/cmd/cored/prod.go
@@ -8,7 +8,7 @@ import (
 	"chain/database/pg"
 )
 
-var prod = "yes"
+var prod = true
 
 func resetInDevIfRequested(db pg.DB) {}
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -35,6 +35,7 @@ var (
 	ErrBadQuorum       = errors.New("quorum must be greater than 0 if there are signers")
 
 	Version, BuildCommit, BuildDate string
+	Production                      bool
 )
 
 // Config encapsulates Core-level, persistent configuration options.

--- a/core/errors.go
+++ b/core/errors.go
@@ -89,7 +89,7 @@ var (
 		config.ErrBadSignerURL:         errorInfo{400, "CH106", "Block signer URL is invalid"},
 		config.ErrBadSignerPubkey:      errorInfo{400, "CH107", "Block signer pubkey is invalid"},
 		config.ErrBadQuorum:            errorInfo{400, "CH108", "Quorum must be greater than 0 if there are signers"},
-		errProdReset:                   errorInfo{400, "CH110", "Reset can only be called in a development system"},
+		errProduction:                  errorInfo{400, "CH110", "This endpoint can only be called in a development system"},
 		errNoClientTokens:              errorInfo{400, "CH120", "Cannot enable client authentication with no client tokens"},
 		blocksigner.ErrConsensusChange: errorInfo{400, "CH150", "Refuse to sign block with consensus change"},
 

--- a/core/hsm.go
+++ b/core/hsm.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (h *Handler) mockhsmCreateKey(ctx context.Context, in struct{ Alias string }) (result *mockhsm.XPub, err error) {
-	return h.HSM.XCreate(ctx, in.Alias)
+	return h.MockHSM.XCreate(ctx, in.Alias)
 }
 
 func (h *Handler) mockhsmListKeys(ctx context.Context, query requestQuery) (page, error) {
@@ -19,7 +19,7 @@ func (h *Handler) mockhsmListKeys(ctx context.Context, query requestQuery) (page
 		limit = defGenericPageSize
 	}
 
-	xpubs, after, err := h.HSM.ListKeys(ctx, query.Aliases, query.After, limit)
+	xpubs, after, err := h.MockHSM.ListKeys(ctx, query.Aliases, query.After, limit)
 	if err != nil {
 		return page{}, err
 	}
@@ -39,7 +39,7 @@ func (h *Handler) mockhsmListKeys(ctx context.Context, query requestQuery) (page
 }
 
 func (h *Handler) mockhsmDelKey(ctx context.Context, xpub chainkd.XPub) error {
-	return h.HSM.DeleteChainKDKey(ctx, xpub)
+	return h.MockHSM.DeleteChainKDKey(ctx, xpub)
 }
 
 func (h *Handler) mockhsmSignTemplates(ctx context.Context, x struct {
@@ -60,7 +60,7 @@ func (h *Handler) mockhsmSignTemplates(ctx context.Context, x struct {
 }
 
 func (h *Handler) mockhsmSignTemplate(ctx context.Context, xpub chainkd.XPub, path [][]byte, data [32]byte) ([]byte, error) {
-	sigBytes, err := h.HSM.XSign(ctx, xpub, path, data[:])
+	sigBytes, err := h.MockHSM.XSign(ctx, xpub, path, data[:])
 	if err == mockhsm.ErrNoKey {
 		return nil, nil
 	}

--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -84,7 +84,7 @@ func TestMockHSM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h := &Handler{HSM: mockhsm}
+	h := &Handler{MockHSM: mockhsm}
 	outTmpls := h.mockhsmSignTemplates(ctx, struct {
 		Txs   []*txbuilder.Template `json:"transactions"`
 		XPubs []chainkd.XPub        `json:"xpubs"`


### PR DESCRIPTION
Disable the reset and mock HSM endpoints in production. The reset code
won't even be included in the binary in production, but the API endpoint
should also be disabled.