### PR TITLE
protocol/vm: simplify vm interface

### DIFF
--- a/core/generator/generator_test.go
+++ b/core/generator/generator_test.go
@@ -11,7 +11,6 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
 	"chain/protocol/state"
-	"chain/protocol/validation"
 	"chain/protocol/vm"
 	"chain/testutil"
 )
@@ -84,10 +83,7 @@ func TestGetAndAddBlockSignatures(t *testing.T) {
 		testutil.FatalErr(t, err)
 	}
 
-	ok, err := vm.VerifyBlockHeader(&tip.BlockHeader, block)
-	if err == nil && !ok {
-		err = validation.ErrFalseVMResult
-	}
+	err = vm.VerifyBlockHeader(&tip.BlockHeader, block)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/protocol/validation/block.go
+++ b/protocol/validation/block.go
@@ -34,10 +34,7 @@ var (
 // then calls ValidateBlock.
 func ValidateBlockForAccept(ctx context.Context, snapshot *state.Snapshot, initialBlockHash bc.Hash, prevBlock, block *bc.Block, validateTx func(*bc.Tx) error) error {
 	if prevBlock != nil {
-		ok, err := vm.VerifyBlockHeader(&prevBlock.BlockHeader, block)
-		if err == nil && !ok {
-			err = ErrFalseVMResult
-		}
+		err := vm.VerifyBlockHeader(&prevBlock.BlockHeader, block)
 		if err != nil {
 			pkScriptStr, _ := vm.Disassemble(prevBlock.ConsensusProgram)
 			witnessStrs := make([]string, 0, len(block.Witness))

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -12,13 +12,8 @@ import (
 	"chain/protocol/vmutil"
 )
 
-var (
-	// ErrBadTx is returned for transactions failing validation
-	ErrBadTx = errors.New("invalid transaction")
-
-	// ErrFalseVMResult is one of the ways for a transaction to fail validation
-	ErrFalseVMResult = errors.New("false VM result")
-)
+// ErrBadTx is returned for transactions failing validation
+var ErrBadTx = errors.New("invalid transaction")
 
 var (
 	// "suberrors" for ErrBadTx
@@ -251,10 +246,7 @@ func CheckTxWellFormed(tx *bc.Tx) error {
 	}
 
 	for i := range tx.Inputs {
-		ok, err := vm.VerifyTxInput(tx, uint32(i))
-		if err == nil && !ok {
-			err = ErrFalseVMResult
-		}
+		err := vm.VerifyTxInput(tx, uint32(i))
 		if err != nil {
 			return badTxErrf(err, "validation failed in script execution, input %d", i)
 		}

--- a/protocol/vm/control.go
+++ b/protocol/vm/control.go
@@ -78,7 +78,7 @@ func opCheckPredicate(vm *virtualMachine) error {
 	vm.deferCost(-stackCost(childVM.dataStack))
 	vm.deferCost(-stackCost(childVM.altStack))
 
-	return vm.pushBool(childErr == nil, true)
+	return vm.pushBool(childErr == nil && !childVM.falseResult(), true)
 }
 
 func opJump(vm *virtualMachine) error {

--- a/protocol/vm/control.go
+++ b/protocol/vm/control.go
@@ -72,17 +72,13 @@ func opCheckPredicate(vm *virtualMachine) error {
 	}
 	vm.dataStack = vm.dataStack[:l-n]
 
-	ok, childErr := childVM.run()
+	childErr := childVM.run()
 
 	vm.deferCost(-childVM.runLimit)
 	vm.deferCost(-stackCost(childVM.dataStack))
 	vm.deferCost(-stackCost(childVM.altStack))
 
-	err = vm.pushBool(childErr == nil && ok, true)
-	if err != nil {
-		return err
-	}
-	return nil
+	return vm.pushBool(childErr == nil, true)
 }
 
 func opJump(vm *virtualMachine) error {

--- a/protocol/vm/crypto_test.go
+++ b/protocol/vm/crypto_test.go
@@ -71,15 +71,17 @@ func TestCheckSig(t *testing.T) {
 			program:  prog,
 			runLimit: 50000,
 		}
-		ok, err := vm.run()
-		if (err != nil) != c.err {
-			if c.err {
-				t.Errorf("case %d: expected error, got none", i)
-			} else {
-				t.Errorf("case %d: expected no error, got %s", i, err)
+		err = vm.run()
+		if c.err {
+			if err == nil {
+				t.Errorf("case %d: expected error, got ok result", i)
 			}
-		} else if ok != c.ok {
-			t.Errorf("case %d: ok is %v, expected %v", i, ok, c.ok)
+		} else if c.ok {
+			if err != nil {
+				t.Errorf("case %d: expected ok result, got error %s", i, err)
+			}
+		} else if err != ErrFalseVMResult {
+			t.Errorf("case %d: expected false VM result, got error %s", i, err)
 		}
 	}
 }

--- a/protocol/vm/crypto_test.go
+++ b/protocol/vm/crypto_test.go
@@ -80,7 +80,7 @@ func TestCheckSig(t *testing.T) {
 			if err != nil {
 				t.Errorf("case %d: expected ok result, got error %s", i, err)
 			}
-		} else if err != ErrFalseVMResult {
+		} else if !vm.falseResult() {
 			t.Errorf("case %d: expected false VM result, got error %s", i, err)
 		}
 	}

--- a/protocol/vm/introspection_test.go
+++ b/protocol/vm/introspection_test.go
@@ -39,6 +39,9 @@ func TestNextProgram(t *testing.T) {
 		program:  prog,
 	}
 	err = vm.run()
+	if err == nil && vm.falseResult() {
+		err = ErrFalseVMResult
+	}
 	switch err {
 	case nil:
 		t.Error("got ok result, expected failure")
@@ -79,6 +82,9 @@ func TestBlockTime(t *testing.T) {
 		program:  prog,
 	}
 	err = vm.run()
+	if err == nil && vm.falseResult() {
+		err = ErrFalseVMResult
+	}
 	switch err {
 	case nil:
 		t.Error("got ok result, expected failure")
@@ -518,8 +524,6 @@ func TestIntrospectionOps(t *testing.T) {
 			// ok
 		case nil:
 			t.Errorf("case %d, op %s: got no error, want %v", i, ops[c.op].name, c.wantErr)
-		case ErrFalseVMResult:
-			// ignore
 		default:
 			t.Errorf("case %d, op %s: got err = %v want %v", i, ops[c.op].name, err, c.wantErr)
 		}

--- a/protocol/vm/introspection_test.go
+++ b/protocol/vm/introspection_test.go
@@ -24,11 +24,9 @@ func TestNextProgram(t *testing.T) {
 		block:    block,
 		program:  prog,
 	}
-	ok, err := vm.run()
+	err = vm.run()
 	if err != nil {
 		t.Errorf("got error %s, expected none", err)
-	} else if !ok {
-		t.Error("got failure result, expected ok")
 	}
 
 	prog, err = Assemble("NEXTPROGRAM 0x0102 EQUAL")
@@ -40,11 +38,14 @@ func TestNextProgram(t *testing.T) {
 		block:    block,
 		program:  prog,
 	}
-	ok, err = vm.run()
-	if err != nil {
-		t.Errorf("got error %s, expected none", err)
-	} else if ok {
+	err = vm.run()
+	switch err {
+	case nil:
 		t.Error("got ok result, expected failure")
+	case ErrFalseVMResult:
+		// ok
+	default:
+		t.Errorf("got error %s, expected ErrFalseVMResult", err)
 	}
 }
 
@@ -63,11 +64,9 @@ func TestBlockTime(t *testing.T) {
 		block:    block,
 		program:  prog,
 	}
-	ok, err := vm.run()
+	err = vm.run()
 	if err != nil {
 		t.Errorf("got error %s, expected none", err)
-	} else if !ok {
-		t.Error("got failure result, expected ok")
 	}
 
 	prog, err = Assemble("BLOCKTIME 3263826 NUMEQUAL")
@@ -79,11 +78,14 @@ func TestBlockTime(t *testing.T) {
 		block:    block,
 		program:  prog,
 	}
-	ok, err = vm.run()
-	if err != nil {
-		t.Errorf("got error %s, expected none", err)
-	} else if ok {
+	err = vm.run()
+	switch err {
+	case nil:
 		t.Error("got ok result, expected failure")
+	case ErrFalseVMResult:
+		// ok
+	default:
+		t.Errorf("got error %s, expected ErrFalseVMResult", err)
 	}
 }
 
@@ -510,10 +512,16 @@ func TestIntrospectionOps(t *testing.T) {
 			vm.mainprog = prog
 		}
 		vm.program = prog
-		_, err := vm.run()
-		if err != c.wantErr {
+		err := vm.run()
+		switch err {
+		case c.wantErr:
+			// ok
+		case nil:
+			t.Errorf("case %d, op %s: got no error, want %v", i, ops[c.op].name, c.wantErr)
+		case ErrFalseVMResult:
+			// ignore
+		default:
 			t.Errorf("case %d, op %s: got err = %v want %v", i, ops[c.op].name, err, c.wantErr)
-			continue
 		}
 		if c.wantErr != nil {
 			continue

--- a/protocol/vm/numeric_test.go
+++ b/protocol/vm/numeric_test.go
@@ -580,8 +580,6 @@ func TestRangeErrs(t *testing.T) {
 			if !c.expectRangeErr {
 				t.Errorf("case %d (%s): got unexpected range error", i, c.prog)
 			}
-		case ErrFalseVMResult:
-			// ignore
 		default:
 			if c.expectRangeErr {
 				t.Errorf("case %d (%s): expected range error, got %s", i, c.prog, err)

--- a/protocol/vm/numeric_test.go
+++ b/protocol/vm/numeric_test.go
@@ -570,13 +570,24 @@ func TestRangeErrs(t *testing.T) {
 			program:  prog,
 			runLimit: 50000,
 		}
-		_, err := vm.run()
-		if c.expectRangeErr {
-			if err != ErrRange {
-				t.Errorf("case %d (%s): expected range error, got %s", i, c.prog, err)
+		err := vm.run()
+		switch err {
+		case nil:
+			if c.expectRangeErr {
+				t.Errorf("case %d (%s): expected range error, got none", i, c.prog)
 			}
-		} else if err != nil {
-			t.Errorf("case %d (%s): expected no error, got %s", i, c.prog, err)
+		case ErrRange:
+			if !c.expectRangeErr {
+				t.Errorf("case %d (%s): got unexpected range error", i, c.prog)
+			}
+		case ErrFalseVMResult:
+			// ignore
+		default:
+			if c.expectRangeErr {
+				t.Errorf("case %d (%s): expected range error, got %s", i, c.prog, err)
+			} else {
+				t.Errorf("case %d (%s): got unexpected error %s", i, c.prog, err)
+			}
 		}
 	}
 }

--- a/protocol/vm/vm_test.go
+++ b/protocol/vm/vm_test.go
@@ -158,6 +158,9 @@ func doOKNotOK(t *testing.T, expectOK bool) {
 			dataStack: append([][]byte{}, c.args...),
 		}
 		err = vm.run()
+		if err == nil && vm.falseResult() {
+			err = ErrFalseVMResult
+		}
 		if expectOK && err != nil {
 			trace.dump()
 			t.Errorf("case %d [%s]: expected success, got error %s", i, progSrc, err)

--- a/protocol/vm/vm_test.go
+++ b/protocol/vm/vm_test.go
@@ -21,12 +21,12 @@ func (t tracebuf) dump() {
 	os.Stdout.Write(t.Bytes())
 }
 
-// Programs that run without error and return a true result.
+// Programs that run without error.
 func TestProgramOK(t *testing.T) {
 	doOKNotOK(t, true)
 }
 
-// Programs that run without error and return a false result.
+// Programs that return an ErrFalseVMResult.
 func TestProgramNotOK(t *testing.T) {
 	doOKNotOK(t, false)
 }
@@ -157,19 +157,13 @@ func doOKNotOK(t *testing.T, expectOK bool) {
 			runLimit:  initialRunLimit,
 			dataStack: append([][]byte{}, c.args...),
 		}
-		ok, err := vm.run()
-		if err == nil {
-			if ok != expectOK {
-				trace.dump()
-				t.Errorf("case %d [%s]: expected %v result, got %v", i, progSrc, expectOK, ok)
-			}
-		} else {
+		err = vm.run()
+		if expectOK && err != nil {
 			trace.dump()
-			t.Errorf("case %d [%s]: unexpected error: %s", i, progSrc, err)
-		}
-		if testing.Verbose() && (ok == expectOK) && err == nil {
+			t.Errorf("case %d [%s]: expected success, got error %s", i, progSrc, err)
+		} else if !expectOK && err != ErrFalseVMResult {
 			trace.dump()
-			fmt.Println("")
+			t.Errorf("case %d [%s]: expected ErrFalseVMResult, got %s", i, progSrc, err)
 		}
 	}
 }
@@ -177,7 +171,6 @@ func doOKNotOK(t *testing.T, expectOK bool) {
 func TestVerifyTxInput(t *testing.T) {
 	cases := []struct {
 		input   *bc.TxInput
-		want    bool
 		wantErr error
 	}{{
 		input: bc.NewSpendInput(
@@ -188,7 +181,6 @@ func TestVerifyTxInput(t *testing.T) {
 			[]byte{byte(OP_ADD), byte(OP_5), byte(OP_NUMEQUAL)},
 			nil,
 		),
-		want: true,
 	}, {
 		input: bc.NewIssuanceInput(
 			nil,
@@ -199,7 +191,6 @@ func TestVerifyTxInput(t *testing.T) {
 			[][]byte{{2}, {3}},
 			nil,
 		),
-		want: true,
 	}, {
 		input: &bc.TxInput{
 			TypedInput: &bc.IssuanceInput{
@@ -239,14 +230,10 @@ func TestVerifyTxInput(t *testing.T) {
 			Inputs: []*bc.TxInput{c.input},
 		}}
 
-		got, gotErr := VerifyTxInput(tx, 0)
+		gotErr := VerifyTxInput(tx, 0)
 
 		if errors.Root(gotErr) != c.wantErr {
 			t.Errorf("VerifyTxInput(%d) err = %v want %v", i, gotErr, c.wantErr)
-		}
-
-		if got != c.want {
-			t.Errorf("VerifyTxInput(%d) = %v want %v", i, got, c.want)
 		}
 	}
 }
@@ -267,13 +254,9 @@ func TestVerifyBlockHeader(t *testing.T) {
 		},
 	}
 
-	got, gotErr := VerifyBlockHeader(&prevBlock.BlockHeader, block)
+	gotErr := VerifyBlockHeader(&prevBlock.BlockHeader, block)
 	if gotErr != nil {
 		t.Errorf("unexpected error: %v", gotErr)
-	}
-
-	if !got {
-		t.Error("expected true result")
 	}
 
 	block = &bc.Block{
@@ -284,7 +267,7 @@ func TestVerifyBlockHeader(t *testing.T) {
 		},
 	}
 
-	_, gotErr = VerifyBlockHeader(&prevBlock.BlockHeader, block)
+	gotErr = VerifyBlockHeader(&prevBlock.BlockHeader, block)
 	if errors.Root(gotErr) != ErrRunLimitExceeded {
 		t.Error("expected block to exceed run limit")
 	}
@@ -293,18 +276,16 @@ func TestVerifyBlockHeader(t *testing.T) {
 func TestRun(t *testing.T) {
 	cases := []struct {
 		vm      *virtualMachine
-		want    bool
 		wantErr error
 	}{{
-		vm:   &virtualMachine{runLimit: 50000, program: []byte{byte(OP_TRUE)}},
-		want: true,
+		vm: &virtualMachine{runLimit: 50000, program: []byte{byte(OP_TRUE)}},
 	}, {
 		vm:      &virtualMachine{runLimit: 50000, program: []byte{byte(OP_ADD)}},
 		wantErr: ErrDataStackUnderflow,
 	}}
 
 	for i, c := range cases {
-		got, gotErr := c.vm.run()
+		gotErr := c.vm.run()
 
 		if gotErr != c.wantErr {
 			t.Errorf("run test %d: got err = %v want %v", i, gotErr, c.wantErr)
@@ -313,10 +294,6 @@ func TestRun(t *testing.T) {
 
 		if c.wantErr != nil {
 			continue
-		}
-
-		if got != c.want {
-			t.Errorf("run test %d: got = %v want %v", i, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
Instead of returning an `ok` bool and an error, fold the `!ok` case into the error by returning the new value `ErrFalseVMResult`.