### PR TITLE
core: up max request size to 10MB

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -83,7 +83,7 @@ type RequestLimit struct {
 }
 
 func maxBytes(h http.Handler) http.Handler {
-	const maxReqSize = 1e6 // 1MB
+	const maxReqSize = 1e7 // 10MB
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		// A block can easily be bigger than maxReqSize, but everything
 		// else should be pretty small.


### PR DESCRIPTION
Increase the max request size from 1MB to 10MB. It's pretty common for
people to run into this. Requests can grow unexpectedly large from:

* using batching to submit multiple transactions at once
* spend actions being satisfied using many small outputs
* large reference data objects or large asset definitions
* our JSON wire format with hex-encoded raw transactions

When testing locally, I hit the 1MB limit signing a single transaction
with ~750 issuances, ~750 outputs and a small amount of json metadata
on each issuance (in the asset definition).