### PR TITLE
core/migrate: drop unspent ids from account_utxos

### DIFF
--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -285,4 +285,7 @@ var migrations = []migration{
 			ALTER COLUMN tags SET NOT NULL,
 			DROP COLUMN data;
 	`},
+	{Name: "2017-02-30.0.account.remove-unspent-ids.sql", SQL: `
+		ALTER TABLE account_utxos DROP COLUMN unspent_id;
+	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.1
--- Dumped by pg_dump version 9.6.1
+-- Dumped from database version 9.5.2
+-- Dumped by pg_dump version 9.5.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -196,8 +196,7 @@ CREATE TABLE account_utxos (
     control_program_index bigint NOT NULL,
     control_program bytea NOT NULL,
     confirmed_in bigint NOT NULL,
-    output_id bytea NOT NULL,
-    unspent_id bytea NOT NULL
+    output_id bytea NOT NULL
 );
 
 
@@ -579,14 +578,14 @@ CREATE TABLE txfeeds (
 
 
 --
--- Name: signers key_index; Type: DEFAULT; Schema: public; Owner: -
+-- Name: key_index; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY signers ALTER COLUMN key_index SET DEFAULT nextval('signers_key_index_seq'::regclass);
 
 
 --
--- Name: access_tokens access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: access_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY access_tokens
@@ -594,7 +593,7 @@ ALTER TABLE ONLY access_tokens
 
 
 --
--- Name: account_control_programs account_control_programs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: account_control_programs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY account_control_programs
@@ -602,7 +601,7 @@ ALTER TABLE ONLY account_control_programs
 
 
 --
--- Name: accounts account_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: account_tags_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY accounts
@@ -610,7 +609,7 @@ ALTER TABLE ONLY accounts
 
 
 --
--- Name: account_utxos account_utxos_output_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: account_utxos_output_id_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY account_utxos
@@ -618,7 +617,7 @@ ALTER TABLE ONLY account_utxos
 
 
 --
--- Name: account_utxos account_utxos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: account_utxos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY account_utxos
@@ -626,15 +625,7 @@ ALTER TABLE ONLY account_utxos
 
 
 --
--- Name: account_utxos account_utxos_unspent_id_key; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY account_utxos
-    ADD CONSTRAINT account_utxos_unspent_id_key UNIQUE (unspent_id);
-
-
---
--- Name: accounts accounts_alias_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: accounts_alias_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY accounts
@@ -642,7 +633,7 @@ ALTER TABLE ONLY accounts
 
 
 --
--- Name: annotated_accounts annotated_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: annotated_accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY annotated_accounts
@@ -650,7 +641,7 @@ ALTER TABLE ONLY annotated_accounts
 
 
 --
--- Name: annotated_assets annotated_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: annotated_assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY annotated_assets
@@ -658,7 +649,7 @@ ALTER TABLE ONLY annotated_assets
 
 
 --
--- Name: annotated_inputs annotated_inputs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: annotated_inputs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY annotated_inputs
@@ -666,7 +657,7 @@ ALTER TABLE ONLY annotated_inputs
 
 
 --
--- Name: annotated_outputs annotated_outputs_output_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: annotated_outputs_output_id_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY annotated_outputs
@@ -674,7 +665,7 @@ ALTER TABLE ONLY annotated_outputs
 
 
 --
--- Name: annotated_outputs annotated_outputs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: annotated_outputs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY annotated_outputs
@@ -682,7 +673,7 @@ ALTER TABLE ONLY annotated_outputs
 
 
 --
--- Name: annotated_txs annotated_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: annotated_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY annotated_txs
@@ -690,7 +681,7 @@ ALTER TABLE ONLY annotated_txs
 
 
 --
--- Name: asset_tags asset_tags_asset_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: asset_tags_asset_id_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY asset_tags
@@ -698,7 +689,7 @@ ALTER TABLE ONLY asset_tags
 
 
 --
--- Name: assets assets_alias_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: assets_alias_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY assets
@@ -706,7 +697,7 @@ ALTER TABLE ONLY assets
 
 
 --
--- Name: assets assets_client_token_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: assets_client_token_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY assets
@@ -714,7 +705,7 @@ ALTER TABLE ONLY assets
 
 
 --
--- Name: assets assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: assets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY assets
@@ -722,7 +713,7 @@ ALTER TABLE ONLY assets
 
 
 --
--- Name: block_processors block_processors_name_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: block_processors_name_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY block_processors
@@ -730,7 +721,7 @@ ALTER TABLE ONLY block_processors
 
 
 --
--- Name: blocks blocks_height_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: blocks_height_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY blocks
@@ -738,7 +729,7 @@ ALTER TABLE ONLY blocks
 
 
 --
--- Name: blocks blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY blocks
@@ -746,7 +737,7 @@ ALTER TABLE ONLY blocks
 
 
 --
--- Name: config config_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: config_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY config
@@ -754,7 +745,7 @@ ALTER TABLE ONLY config
 
 
 --
--- Name: generator_pending_block generator_pending_block_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: generator_pending_block_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY generator_pending_block
@@ -762,7 +753,7 @@ ALTER TABLE ONLY generator_pending_block
 
 
 --
--- Name: leader leader_singleton_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: leader_singleton_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY leader
@@ -770,7 +761,7 @@ ALTER TABLE ONLY leader
 
 
 --
--- Name: migrations migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY migrations
@@ -778,7 +769,7 @@ ALTER TABLE ONLY migrations
 
 
 --
--- Name: mockhsm mockhsm_alias_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: mockhsm_alias_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY mockhsm
@@ -786,7 +777,7 @@ ALTER TABLE ONLY mockhsm
 
 
 --
--- Name: mockhsm mockhsm_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: mockhsm_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY mockhsm
@@ -794,7 +785,7 @@ ALTER TABLE ONLY mockhsm
 
 
 --
--- Name: query_blocks query_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: query_blocks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY query_blocks
@@ -802,7 +793,7 @@ ALTER TABLE ONLY query_blocks
 
 
 --
--- Name: signers signers_client_token_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: signers_client_token_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY signers
@@ -810,7 +801,7 @@ ALTER TABLE ONLY signers
 
 
 --
--- Name: signers signers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: signers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY signers
@@ -818,7 +809,7 @@ ALTER TABLE ONLY signers
 
 
 --
--- Name: mockhsm sort_id_index; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: sort_id_index; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY mockhsm
@@ -826,7 +817,7 @@ ALTER TABLE ONLY mockhsm
 
 
 --
--- Name: snapshots state_trees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: state_trees_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY snapshots
@@ -834,7 +825,7 @@ ALTER TABLE ONLY snapshots
 
 
 --
--- Name: submitted_txs submitted_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: submitted_txs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY submitted_txs
@@ -842,7 +833,7 @@ ALTER TABLE ONLY submitted_txs
 
 
 --
--- Name: txfeeds txfeeds_alias_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: txfeeds_alias_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY txfeeds
@@ -850,7 +841,7 @@ ALTER TABLE ONLY txfeeds
 
 
 --
--- Name: txfeeds txfeeds_client_token_key; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: txfeeds_client_token_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY txfeeds
@@ -858,7 +849,7 @@ ALTER TABLE ONLY txfeeds
 
 
 --
--- Name: txfeeds txfeeds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+-- Name: txfeeds_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY txfeeds
@@ -939,7 +930,7 @@ insert into migrations (filename, hash) values ('2016-11-28.0.core.submitted-txs
 insert into migrations (filename, hash) values ('2017-01-05.0.core.rename_block_key.sql', 'ba6a62e498236ec9d2f13238a945829a5cab83f897068fef57a2c152a2e36037');
 insert into migrations (filename, hash) values ('2017-01-10.0.signers.xpubs-type.sql', '4a4d6c736a2bf65e69abbdc87771faa1dc17a0106b2651a6a58af067708d095a');
 insert into migrations (filename, hash) values ('2017-01-11.0.core.hash-bytea.sql', '9f7f15df3479c38f193884a2d3cb7ae8001ed08607f9cc661fd5c420e248688d');
-insert into migrations (filename, hash) values ('2017-01-13.0.core.asset-definition-bytea.sql', 'f49458c5c8873d919ec35be4683074be0b04913c95f5ab1bf1402aa2b4847cf5');
+insert into migrations (filename, hash) values ('2017-01-13.0.core.asset-definition-bytea.sql', '996baf781c0b67f5ffa0bf0fa388f1f8fdbdec8b5cbf5f8b8ad292abf90d6e92');
 insert into migrations (filename, hash) values ('2017-01-19.0.asset.drop-mutable-flag.sql', '7850023d44c545c155c0ee372e7cdfef1859b40221bd94307b836503c26dd3de');
 insert into migrations (filename, hash) values ('2017-01-20.0.core.add-output-id-to-outputs.sql', '4c8531c06e62405d2989e0651a7ef6c2ebd0b2b269b57c179e9e36f7fdbb715b');
 insert into migrations (filename, hash) values ('2017-01-25.0.account.cp-expiry.sql', 'a2076b7b3ac3f844d17e13eea57fea01216c868a63f9df7b9df24cac9c4b82a4');
@@ -947,3 +938,4 @@ insert into migrations (filename, hash) values ('2017-01-30.0.txdb.snapshots-tim
 insert into migrations (filename, hash) values ('2017-01-30.1.core.add-block-hsm-config.sql', '9d609586b2fd33c45e530c4237a24f303a3b5753e5ccf3cd740958511aea4992');
 insert into migrations (filename, hash) values ('2017-01-31.0.query.drop-outpoint-index.sql', '461ab638954f5eb53e83587da96f2d83e031d17ab3408685a4460b60edf522a1');
 insert into migrations (filename, hash) values ('2017-01-31.1.query.annotated-schema.sql', 'e0421d1bbbbbb14188be0b06f0056e2121d3b364c30fb633c47c3055416bf806');
+insert into migrations (filename, hash) values ('2017-02-30.0.account.remove-unspent-ids.sql', 'd0686de697e821b313ccd38865f76032b7f541d8f5747c42ae445a40e9642a50');


### PR DESCRIPTION
This detangles the schema updates from #463. (It is also blocked by #463.) 

It also includes a heck of a hot of schema dumping noise because we're flipping between dumping with postgres 9.5 and 9.6