### PR TITLE
protocol/tx: replace a call to io.CopyN with a fixed-length read and write

### DIFF
--- a/protocol/tx/entry.go
+++ b/protocol/tx/entry.go
@@ -43,7 +43,9 @@ func entryID(e entry) (entryRef, error) {
 	if err != nil {
 		return entryRef{}, err
 	}
-	io.CopyN(h, bh, 32)
+	var innerHash bc.Hash
+	bh.Read(innerHash[:])
+	h.Write(innerHash[:])
 
 	var hash entryRef
 	h.Read(hash[:])


### PR DESCRIPTION
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkHashEmptyTx-8        13705         5998          -56.23%
BenchmarkHashNonemptyTx-8     56714         28370         -49.98%
```