### PR TITLE
docs/core/get-started: clean up language on SDK page

### DIFF
--- a/docs/core/get-started/sdk.md
+++ b/docs/core/get-started/sdk.md
@@ -1,10 +1,18 @@
 # Download Chain Core SDKs
 
-Chain Core SDKs enable your appplication to communicate with Chain Core.
+Client libraries for Chain Core are available for the following platforms:
+
+- [Java](#java)
+- [Node.js](#node-js)
+- [Ruby](#ruby)
+
+To ensure compatibility between your application and Chain Core, choose an SDK version whose major and minor components (`major.minor.x`) match your version of Chain Core.
 
 ## Java
 
-The Java SDK is available via Maven, on Sonatype's [Central Repository](http://central.sonatype.org/). Simply add the following to your `pom.xml`:
+The Java SDK is available via Maven, on Sonatype's [Central Repository](https://search.maven.org/#search%7Cga%7C1%7Cchain-sdk-java). Java 7 or greater is required.
+
+**Maven** users should add the following to `pom.xml`:
 
 ```
 <dependencies>
@@ -16,24 +24,30 @@ The Java SDK is available via Maven, on Sonatype's [Central Repository](http://c
 </dependencies>
 ```
 
-You can also [download the JAR](../../java/chain-sdk-latest.jar) as a binary.
-
-## Ruby
-
-The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2.1 or greater is required.
-
-For most applications, you can simply add the following to your `Gemfile`:
+**Gradle** users should add the following to `build.gradle`:
 
 ```
-gem 'chain-sdk', '~> 1.0.1', require: 'chain'
+compile 'com.chain:chain-sdk-java:1.0.1'
 ```
+
+You can also [download the JAR](https://search.maven.org/remotecontent?filepath=com/chain/chain-sdk-java/1.0.1/chain-sdk-java-1.0.1.jar) as a binary.
 
 ## Node.js
 
-The Chain Node.js SDK is available [via npm](https://www.npmjs.com/package/chain-sdk). Make sure to use the most recent version whose major and minor components (major.minor.x) match your version of Chain Core. Node 4 or greater is required.
+The Chain Node.js SDK is available [via npm](https://www.npmjs.com/package/chain-sdk). Node 4 or greater is required.
 
-For most applications, you can simply add Chain to your `package.json` with the following command:
+To install, run the following command from your project directory:
 
 ```
 npm install --save chain-sdk@1.0.2
+```
+
+## Ruby
+
+The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Ruby 2.1 or greater is required.
+
+To install, add the following to your `Gemfile`:
+
+```
+gem 'chain-sdk', '~> 1.0.1', require: 'chain'
 ```


### PR DESCRIPTION
- Add Java Gradle instructions
- Move version compatibility language to the top of the doc
- Add table of contents
- Simplify verbiage