### PR TITLE
core/query: use SQL table to typecheck thoroughly

### DIFF
--- a/core/query/accounts.go
+++ b/core/query/accounts.go
@@ -33,6 +33,10 @@ func (ind *Indexer) Accounts(ctx context.Context, p filter.Predicate, vals []int
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
 	}
+	err := filter.TypeCheck(p, accountsTable)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "typechecking")
+	}
 	expr, err := filter.AsSQL(p, accountsTable, vals)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "converting to SQL")

--- a/core/query/accounts.go
+++ b/core/query/accounts.go
@@ -33,7 +33,7 @@ func (ind *Indexer) Accounts(ctx context.Context, p filter.Predicate, vals []int
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, accountsTable)
+	err := filter.TypeCheck(p, accountsTable, vals)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "typechecking")
 	}

--- a/core/query/accounts.go
+++ b/core/query/accounts.go
@@ -29,11 +29,15 @@ func (ind *Indexer) SaveAnnotatedAccount(ctx context.Context, account *Annotated
 }
 
 // Accounts queries the blockchain for accounts matching the query `q`.
-func (ind *Indexer) Accounts(ctx context.Context, p filter.Predicate, vals []interface{}, after string, limit int) ([]*AnnotatedAccount, string, error) {
+func (ind *Indexer) Accounts(ctx context.Context, filt string, vals []interface{}, after string, limit int) ([]*AnnotatedAccount, string, error) {
+	p, err := filter.Parse(filt)
+	if err != nil {
+		return nil, "", err
+	}
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, accountsTable, vals)
+	err = filter.TypeCheck(p, accountsTable, vals)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "typechecking")
 	}

--- a/core/query/accounts.go
+++ b/core/query/accounts.go
@@ -30,16 +30,12 @@ func (ind *Indexer) SaveAnnotatedAccount(ctx context.Context, account *Annotated
 
 // Accounts queries the blockchain for accounts matching the query `q`.
 func (ind *Indexer) Accounts(ctx context.Context, filt string, vals []interface{}, after string, limit int) ([]*AnnotatedAccount, string, error) {
-	p, err := filter.Parse(filt)
+	p, err := filter.Parse(filt, accountsTable, vals)
 	if err != nil {
 		return nil, "", err
 	}
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
-	}
-	err = filter.TypeCheck(p, accountsTable, vals)
-	if err != nil {
-		return nil, "", errors.Wrap(err, "typechecking")
 	}
 	expr, err := filter.AsSQL(p, accountsTable, vals)
 	if err != nil {

--- a/core/query/assets.go
+++ b/core/query/assets.go
@@ -34,7 +34,7 @@ func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []inter
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, assetsTable)
+	err := filter.TypeCheck(p, assetsTable, vals)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "typechecking")
 	}

--- a/core/query/assets.go
+++ b/core/query/assets.go
@@ -30,11 +30,15 @@ func (ind *Indexer) SaveAnnotatedAsset(ctx context.Context, asset *AnnotatedAsse
 }
 
 // Assets queries the blockchain for annotated assets matching the query.
-func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []interface{}, after string, limit int) ([]*AnnotatedAsset, string, error) {
+func (ind *Indexer) Assets(ctx context.Context, filt string, vals []interface{}, after string, limit int) ([]*AnnotatedAsset, string, error) {
+	p, err := filter.Parse(filt)
+	if err != nil {
+		return nil, "", err
+	}
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, assetsTable, vals)
+	err = filter.TypeCheck(p, assetsTable, vals)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "typechecking")
 	}

--- a/core/query/assets.go
+++ b/core/query/assets.go
@@ -31,16 +31,12 @@ func (ind *Indexer) SaveAnnotatedAsset(ctx context.Context, asset *AnnotatedAsse
 
 // Assets queries the blockchain for annotated assets matching the query.
 func (ind *Indexer) Assets(ctx context.Context, filt string, vals []interface{}, after string, limit int) ([]*AnnotatedAsset, string, error) {
-	p, err := filter.Parse(filt)
+	p, err := filter.Parse(filt, assetsTable, vals)
 	if err != nil {
 		return nil, "", err
 	}
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
-	}
-	err = filter.TypeCheck(p, assetsTable, vals)
-	if err != nil {
-		return nil, "", errors.Wrap(err, "typechecking")
 	}
 	expr, err := filter.AsSQL(p, assetsTable, vals)
 	if err != nil {

--- a/core/query/assets.go
+++ b/core/query/assets.go
@@ -34,6 +34,10 @@ func (ind *Indexer) Assets(ctx context.Context, p filter.Predicate, vals []inter
 	if len(vals) != p.Parameters {
 		return nil, "", ErrParameterCountMismatch
 	}
+	err := filter.TypeCheck(p, assetsTable)
+	if err != nil {
+		return nil, "", errors.Wrap(err, "typechecking")
+	}
 	expr, err := filter.AsSQL(p, assetsTable, vals)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "converting to SQL")

--- a/core/query/balances.go
+++ b/core/query/balances.go
@@ -14,16 +14,12 @@ import (
 
 // Balances performs a balances query against the annotated_outputs.
 func (ind *Indexer) Balances(ctx context.Context, filt string, vals []interface{}, sumBy []filter.Field, timestampMS uint64) ([]interface{}, error) {
-	p, err := filter.Parse(filt)
+	p, err := filter.Parse(filt, outputsTable, vals)
 	if err != nil {
 		return nil, err
 	}
 	if len(vals) != p.Parameters {
 		return nil, ErrParameterCountMismatch
-	}
-	err = filter.TypeCheck(p, outputsTable, vals)
-	if err != nil {
-		return nil, errors.Wrap(err, "typechecking")
 	}
 	expr, err := filter.AsSQL(p, outputsTable, vals)
 	if err != nil {

--- a/core/query/balances.go
+++ b/core/query/balances.go
@@ -17,6 +17,10 @@ func (ind *Indexer) Balances(ctx context.Context, p filter.Predicate, vals []int
 	if len(vals) != p.Parameters {
 		return nil, ErrParameterCountMismatch
 	}
+	err := filter.TypeCheck(p, outputsTable)
+	if err != nil {
+		return nil, errors.Wrap(err, "typechecking")
+	}
 	expr, err := filter.AsSQL(p, outputsTable, vals)
 	if err != nil {
 		return nil, err

--- a/core/query/balances.go
+++ b/core/query/balances.go
@@ -13,11 +13,15 @@ import (
 )
 
 // Balances performs a balances query against the annotated_outputs.
-func (ind *Indexer) Balances(ctx context.Context, p filter.Predicate, vals []interface{}, sumBy []filter.Field, timestampMS uint64) ([]interface{}, error) {
+func (ind *Indexer) Balances(ctx context.Context, filt string, vals []interface{}, sumBy []filter.Field, timestampMS uint64) ([]interface{}, error) {
+	p, err := filter.Parse(filt)
+	if err != nil {
+		return nil, err
+	}
 	if len(vals) != p.Parameters {
 		return nil, ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, outputsTable, vals)
+	err = filter.TypeCheck(p, outputsTable, vals)
 	if err != nil {
 		return nil, errors.Wrap(err, "typechecking")
 	}

--- a/core/query/balances.go
+++ b/core/query/balances.go
@@ -17,7 +17,7 @@ func (ind *Indexer) Balances(ctx context.Context, p filter.Predicate, vals []int
 	if len(vals) != p.Parameters {
 		return nil, ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, outputsTable)
+	err := filter.TypeCheck(p, outputsTable, vals)
 	if err != nil {
 		return nil, errors.Wrap(err, "typechecking")
 	}

--- a/core/query/balances_test.go
+++ b/core/query/balances_test.go
@@ -45,7 +45,7 @@ func TestConstructBalancesQuery(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		p, err := filter.Parse(tc.predicate)
+		p, err := filter.Parse(tc.predicate, outputsTable, tc.values)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/core/query/filter/parser.go
+++ b/core/query/filter/parser.go
@@ -13,8 +13,9 @@ var ErrBadFilter = errors.New("invalid query filter")
 
 // Predicate represents a parsed filter predicate.
 type Predicate struct {
-	expr       expr
-	Parameters int
+	expr          expr
+	selectorTypes map[string]Type
+	Parameters    int
 }
 
 // String returns a cleaned, canonical representation of the
@@ -39,14 +40,15 @@ func Parse(predicate string, tbl *SQLTable, vals []interface{}) (p Predicate, er
 	if err != nil {
 		return p, errors.WithDetail(ErrBadFilter, err.Error())
 	}
-	err = typeCheck(expr, tbl, vals)
+	selectorTypes, err := typeCheck(expr, tbl, vals)
 	if err != nil {
 		return p, errors.WithDetail(ErrBadFilter, err.Error())
 	}
 
 	return Predicate{
-		Parameters: parser.maxPlaceholder,
-		expr:       expr,
+		expr:          expr,
+		selectorTypes: selectorTypes,
+		Parameters:    parser.maxPlaceholder,
 	}, nil
 }
 

--- a/core/query/filter/parser.go
+++ b/core/query/filter/parser.go
@@ -39,10 +39,6 @@ func Parse(predicate string) (p Predicate, err error) {
 	if err != nil {
 		return p, errors.WithDetail(ErrBadFilter, err.Error())
 	}
-	err = typeCheck(expr)
-	if err != nil {
-		return p, errors.WithDetail(ErrBadFilter, err.Error())
-	}
 
 	return Predicate{
 		Parameters: parser.maxPlaceholder,
@@ -64,7 +60,7 @@ func (f Field) String() string {
 func ParseField(s string) (f Field, err error) {
 	expr, _, err := parse(s)
 	if err != nil {
-		return f, err
+		return f, errors.WithDetail(ErrBadFilter, err.Error())
 	}
 	if expr == nil {
 		return f, errors.WithDetail(ErrBadFilter, "empty field expression")

--- a/core/query/filter/parser.go
+++ b/core/query/filter/parser.go
@@ -34,8 +34,12 @@ func (p Predicate) MarshalText() ([]byte, error) {
 
 // Parse parses a predicate and returns an internal representation of the
 // predicate or an error if it fails to parse.
-func Parse(predicate string) (p Predicate, err error) {
+func Parse(predicate string, tbl *SQLTable, vals []interface{}) (p Predicate, err error) {
 	expr, parser, err := parse(predicate)
+	if err != nil {
+		return p, errors.WithDetail(ErrBadFilter, err.Error())
+	}
+	err = typeCheck(expr, tbl, vals)
 	if err != nil {
 		return p, errors.WithDetail(ErrBadFilter, err.Error())
 	}

--- a/core/query/filter/sql.go
+++ b/core/query/filter/sql.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/lib/pq"
 
@@ -84,10 +83,6 @@ func jsonbPath(f expr) []string {
 	default:
 		panic(fmt.Errorf("unexpected field of type %T", e))
 	}
-}
-
-func selectorPath(f expr) string {
-	return strings.Join(jsonbPath(f), ".")
 }
 
 type SQLType int

--- a/core/query/filter/sql.go
+++ b/core/query/filter/sql.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/lib/pq"
 
@@ -83,6 +84,10 @@ func jsonbPath(f expr) []string {
 	default:
 		panic(fmt.Errorf("unexpected field of type %T", e))
 	}
+}
+
+func selectorPath(f expr) string {
+	return strings.Join(jsonbPath(f), ".")
 }
 
 type SQLType int

--- a/core/query/filter/sql_test.go
+++ b/core/query/filter/sql_test.go
@@ -12,10 +12,12 @@ var (
 		Name:  "annotated_inputs",
 		Alias: "inp",
 		Columns: map[string]*SQLColumn{
-			"a":        {Name: "a", Type: String, SQLType: SQLText},
-			"b":        {Name: "b", Type: String, SQLType: SQLText},
-			"type":     {Name: "type", Type: String, SQLType: SQLText},
-			"asset_id": {Name: "asset_id", Type: String, SQLType: SQLBytea},
+			"a":            {Name: "a", Type: String, SQLType: SQLText},
+			"b":            {Name: "b", Type: String, SQLType: SQLText},
+			"type":         {Name: "type", Type: String, SQLType: SQLText},
+			"amount":       {Name: "amount", Type: Integer, SQLType: SQLBigint},
+			"asset_id":     {Name: "asset_id", Type: String, SQLType: SQLBytea},
+			"account_tags": {Name: "account_tags", Type: Object, SQLType: SQLJSONB},
 		},
 		ForeignKeys: map[string]*SQLForeignKey{},
 	}
@@ -32,7 +34,7 @@ var (
 		Alias: "txs",
 		Columns: map[string]*SQLColumn{
 			"id":       {Name: "tx_hash", Type: String, SQLType: SQLBytea},
-			"ref":      {Name: "ref", Type: String, SQLType: SQLJSONB},
+			"ref":      {Name: "ref", Type: Object, SQLType: SQLJSONB},
 			"position": {Name: "position", Type: Integer, SQLType: SQLInteger},
 			"is_local": {Name: "local", Type: Bool, SQLType: SQLBool},
 		},

--- a/core/query/filter/typecheck.go
+++ b/core/query/filter/typecheck.go
@@ -45,7 +45,8 @@ func typeCheck(expr expr, tbl *SQLTable, vals []interface{}) error {
 	if err != nil {
 		return err
 	}
-	typ, err := typeCheckExpr(expr, tbl, valTypes)
+	selectorTypes := make(map[string]Type)
+	typ, err := typeCheckExpr(expr, tbl, valTypes, selectorTypes)
 	if err != nil {
 		return err
 	}
@@ -55,22 +56,40 @@ func typeCheck(expr expr, tbl *SQLTable, vals []interface{}) error {
 	return nil
 }
 
-func typeCheckExpr(expr expr, tbl *SQLTable, valTypes []Type) (typ Type, err error) {
+func typeCheckExpr(expr expr, tbl *SQLTable, valTypes []Type, selectorTypes map[string]Type) (typ Type, err error) {
 	if expr == nil { // no expr is a valid, bool type
 		return Bool, nil
 	}
 
 	switch e := expr.(type) {
 	case parenExpr:
-		return typeCheckExpr(e.inner, tbl, valTypes)
+		return typeCheckExpr(e.inner, tbl, valTypes, selectorTypes)
 	case binaryExpr:
-		leftTyp, err := typeCheckExpr(e.l, tbl, valTypes)
+		leftTyp, err := typeCheckExpr(e.l, tbl, valTypes, selectorTypes)
 		if err != nil {
 			return leftTyp, err
 		}
-		rightTyp, err := typeCheckExpr(e.r, tbl, valTypes)
+		rightTyp, err := typeCheckExpr(e.r, tbl, valTypes, selectorTypes)
 		if err != nil {
 			return rightTyp, err
+		}
+
+		// All our operands require left and right types to be equal. If
+		// one of our types is known but the other is not, we need to
+		// remember the type.
+		if !knownType(leftTyp) && knownType(rightTyp) {
+			err := assertType(e.l, rightTyp, selectorTypes)
+			if err != nil {
+				return leftTyp, err
+			}
+			leftTyp = rightTyp
+		}
+		if !knownType(rightTyp) && knownType(leftTyp) {
+			err := assertType(e.r, leftTyp, selectorTypes)
+			if err != nil {
+				return leftTyp, err
+			}
+			rightTyp = leftTyp
 		}
 
 		switch e.op.name {
@@ -94,9 +113,6 @@ func typeCheckExpr(expr expr, tbl *SQLTable, valTypes []Type) (typ Type, err err
 			panic(fmt.Errorf("unsupported operator: %s", e.op.name))
 		}
 	case placeholderExpr:
-		if len(valTypes) == 0 {
-			return Any, nil
-		}
 		if e.num <= 0 || e.num > len(valTypes) {
 			return typ, fmt.Errorf("unbound placeholder: $%d", e.num)
 		}
@@ -117,20 +133,30 @@ func typeCheckExpr(expr expr, tbl *SQLTable, valTypes []Type) (typ Type, err err
 			panic(fmt.Errorf("value expr with invalid token type: %s", e.typ))
 		}
 	case selectorExpr:
-		typ, err = typeCheckExpr(e.objExpr, tbl, valTypes)
+		typ, err = typeCheckExpr(e.objExpr, tbl, valTypes, selectorTypes)
 		if err != nil {
 			return typ, err
 		}
 		if !isType(typ, Object) {
 			return typ, errors.New("selector `.` can only be used on objects")
 		}
+		// We know e.objExpr is being used as an object, so record that
+		// e.objExpr's json path must be an object.
+		err = assertType(e.objExpr, Object, selectorTypes)
+		if err != nil {
+			return typ, err
+		}
+
+		// Unfortunately, we can't know the type of the field within the
+		// object yet. Depending on the context, we might be able to assign it
+		// a type later in assertType.
 		return Any, nil
 	case envExpr:
 		fk, ok := tbl.ForeignKeys[e.ident]
 		if !ok {
 			return typ, fmt.Errorf("invalid environment `%s`", e.ident)
 		}
-		typ, err = typeCheckExpr(e.expr, fk.Table, valTypes)
+		typ, err = typeCheckExpr(e.expr, fk.Table, valTypes, selectorTypes)
 		if err != nil {
 			return typ, err
 		}
@@ -140,5 +166,26 @@ func typeCheckExpr(expr expr, tbl *SQLTable, valTypes []Type) (typ Type, err err
 		return Bool, nil
 	default:
 		panic(fmt.Errorf("unrecognized expr type %T", expr))
+	}
+}
+
+func assertType(expr expr, typ Type, selectorTypes map[string]Type) error {
+	switch e := expr.(type) {
+	case attrExpr:
+		return nil
+	case parenExpr:
+		return assertType(e.inner, typ, selectorTypes)
+	case selectorExpr:
+		path := selectorPath(expr)
+		boundTyp, ok := selectorTypes[path]
+		if ok && boundTyp != typ {
+			return fmt.Errorf("%q used as both %s and %s", path, boundTyp, typ)
+		}
+		selectorTypes[path] = typ
+		return nil
+	default:
+		// This should be impossible because all other expressions are
+		// strongly typed.
+		panic(fmt.Errorf("unexpected assertType on %T", expr))
 	}
 }

--- a/core/query/filter/typecheck_test.go
+++ b/core/query/filter/typecheck_test.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"errors"
 	"testing"
 
 	"chain/testutil"
@@ -8,20 +9,23 @@ import (
 
 func TestTypeCheckInvalid(t *testing.T) {
 	testCases := []struct {
-		p string
+		p   string
+		err error
 	}{
-		{p: `1 = 'hello world'`},
-		{p: `inputs('hello')`},
-		{p: `inputs(1=1).bar`},
-		{p: `'hello'.foo`},
-		{p: `inputs(amount = asset_id)`},
-		{p: `inputs(100 = asset_id)`},
-		{p: `inputs(wat)`},
-		{p: `wat(asset_id = 'a')`},
-		{p: `position(asset_id = 'a')`},
-		{p: `position.huh`},
-		{p: `ref.something = 'abc' OR ref.something = 123`},
-		{p: `ref.buyer.id = 'abc' OR ref.buyer = 'hello'`},
+		{p: `1 = 'hello world'`, err: errors.New("= expects operands of matching types")},
+		{p: `inputs('hello')`, err: errors.New("inputs(...) body must have type bool")},
+		{p: `inputs(1=1).bar`, err: errors.New("selector `.` can only be used on objects")},
+		{p: `'hello'.foo`, err: errors.New("selector `.` can only be used on objects")},
+		{p: `inputs(amount = asset_id)`, err: errors.New("= expects operands of matching types")},
+		{p: `inputs(100 = asset_id)`, err: errors.New("= expects operands of matching types")},
+		{p: `inputs(wat)`, err: errors.New("invalid attribute: wat")},
+		{p: `wat(asset_id = 'a')`, err: errors.New("invalid environment `wat`")},
+		{p: `position(asset_id = 'a')`, err: errors.New("invalid environment `position`")},
+		{p: `('a' = 'a') = (1 = 1)`, err: errors.New("= expects integer or string operands")},
+		{p: `1 OR 2`, err: errors.New("OR expects bool operands")},
+		{p: `position.huh`, err: errors.New("selector `.` can only be used on objects")},
+		{p: `ref.something = 'abc' OR ref.something = 123`, err: errors.New("\"ref.something\" used as both string and integer")},
+		{p: `ref.buyer.id = 'abc' OR ref.buyer = 'hello'`, err: errors.New("\"ref.buyer\" used as both object and string")},
 	}
 
 	for _, tc := range testCases {
@@ -31,9 +35,9 @@ func TestTypeCheckInvalid(t *testing.T) {
 		}
 
 		m := make(map[string]Type)
-		typ, err := typeCheckExpr(expr, transactionsSQLTable, nil, m)
-		if err == nil {
-			t.Errorf("typeCheckExpr(%s) = %s, want error", expr, typ)
+		_, err = typeCheckExpr(expr, transactionsSQLTable, nil, m)
+		if !testutil.DeepEqual(err, tc.err) {
+			t.Errorf("typeCheckExpr(%s) = %s, want error %s", expr, err, tc.err)
 		}
 	}
 }

--- a/core/query/filter/typecheck_test.go
+++ b/core/query/filter/typecheck_test.go
@@ -24,7 +24,7 @@ func TestTypeCheckInvalid(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		typ, err := typeCheckExpr(expr, transactionsSQLTable)
+		typ, err := typeCheckExpr(expr, transactionsSQLTable, nil)
 		if err == nil {
 			t.Errorf("typeCheckExpr(%s) = %s, want error", expr, typ)
 		}
@@ -33,8 +33,9 @@ func TestTypeCheckInvalid(t *testing.T) {
 
 func TestTypeCheckValid(t *testing.T) {
 	testCases := []struct {
-		p   string
-		typ Type
+		p        string
+		typ      Type
+		valTypes []Type
 	}{
 		{p: `1`, typ: Integer},
 		{p: `'hello world'`, typ: String},
@@ -47,6 +48,8 @@ func TestTypeCheckValid(t *testing.T) {
 		{p: `($1 = 'hello') OR (ref.something = $1)`, typ: Bool},
 		{p: `inputs(account_tags.domestic AND account_tags.type = 'revolving')`, typ: Bool},
 		{p: `inputs(account_tags.state = account_tags.shipping_address.state)`, typ: Bool},
+		{p: `$1`, valTypes: []Type{String}, typ: String},
+		{p: `$1 = $2`, valTypes: []Type{String, String}, typ: Bool},
 	}
 
 	for _, tc := range testCases {
@@ -55,7 +58,7 @@ func TestTypeCheckValid(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		typ, err := typeCheckExpr(expr, transactionsSQLTable)
+		typ, err := typeCheckExpr(expr, transactionsSQLTable, tc.valTypes)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/core/query/filter/typecheck_test.go
+++ b/core/query/filter/typecheck_test.go
@@ -34,8 +34,7 @@ func TestTypeCheckInvalid(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		m := make(map[string]Type)
-		_, err = typeCheckExpr(expr, transactionsSQLTable, nil, m)
+		_, err = typeCheck(expr, transactionsSQLTable, nil)
 		if !testutil.DeepEqual(err, tc.err) {
 			t.Errorf("typeCheckExpr(%s) = %s, want error %s", expr, err, tc.err)
 		}
@@ -59,6 +58,8 @@ func TestTypeCheckValid(t *testing.T) {
 		{p: `($1 = 'hello') OR (ref.something = $1)`, valTypes: []Type{String}, typ: Bool},
 		{p: `inputs(account_tags.domestic AND account_tags.type = 'revolving')`, typ: Bool},
 		{p: `inputs(account_tags.state = account_tags.shipping_address.state)`, typ: Bool},
+		{p: `inputs(account_tags.a_boolean_field)`, typ: Bool},
+		{p: `ref.a_boolean_field AND ref.another_boolean_field`, typ: Bool},
 		{p: `$1`, valTypes: []Type{String}, typ: String},
 		{p: `$1 = $2`, valTypes: []Type{String, String}, typ: Bool},
 	}

--- a/core/query/filter/typecheck_test.go
+++ b/core/query/filter/typecheck_test.go
@@ -1,8 +1,9 @@
 package filter
 
 import (
-	"chain/testutil"
 	"testing"
+
+	"chain/testutil"
 )
 
 func TestTypeCheckInvalid(t *testing.T) {
@@ -47,11 +48,11 @@ func TestTypeCheckValid(t *testing.T) {
 		{p: `'hello world'`, typ: String},
 		{p: `is_local`, typ: Bool},
 		{p: `1 = 1`, typ: Bool},
-		{p: `$1 = '292 Ivy St'`, typ: Bool, valTypes: []Type{String}},
+		{p: `$1 = '292 Ivy St'`, valTypes: []Type{String}, typ: Bool},
 		{p: `'hello' = 'world'`, typ: Bool},
 		{p: `id = id`, typ: Bool},
-		{p: `$1 = 'hello' OR ref.something = $1`, typ: Bool, valTypes: []Type{String}},
-		{p: `($1 = 'hello') OR (ref.something = $1)`, typ: Bool, valTypes: []Type{String}},
+		{p: `$1 = 'hello' OR ref.something = $1`, valTypes: []Type{String}, typ: Bool},
+		{p: `($1 = 'hello') OR (ref.something = $1)`, valTypes: []Type{String}, typ: Bool},
 		{p: `inputs(account_tags.domestic AND account_tags.type = 'revolving')`, typ: Bool},
 		{p: `inputs(account_tags.state = account_tags.shipping_address.state)`, typ: Bool},
 		{p: `$1`, valTypes: []Type{String}, typ: String},

--- a/core/query/outputs.go
+++ b/core/query/outputs.go
@@ -50,6 +50,10 @@ func (ind *Indexer) Outputs(ctx context.Context, p filter.Predicate, vals []inte
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
 	}
+	err := filter.TypeCheck(p, outputsTable)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "typechecking")
+	}
 	expr, err := filter.AsSQL(p, outputsTable, vals)
 	if err != nil {
 		return nil, nil, err

--- a/core/query/outputs.go
+++ b/core/query/outputs.go
@@ -47,16 +47,12 @@ func DecodeOutputsAfter(str string) (c *OutputsAfter, err error) {
 }
 
 func (ind *Indexer) Outputs(ctx context.Context, filt string, vals []interface{}, timestampMS uint64, after *OutputsAfter, limit int) ([]*AnnotatedOutput, *OutputsAfter, error) {
-	p, err := filter.Parse(filt)
+	p, err := filter.Parse(filt, outputsTable, vals)
 	if err != nil {
 		return nil, nil, err
 	}
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
-	}
-	err = filter.TypeCheck(p, outputsTable, vals)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "typechecking")
 	}
 	expr, err := filter.AsSQL(p, outputsTable, vals)
 	if err != nil {

--- a/core/query/outputs.go
+++ b/core/query/outputs.go
@@ -46,11 +46,15 @@ func DecodeOutputsAfter(str string) (c *OutputsAfter, err error) {
 	}, nil
 }
 
-func (ind *Indexer) Outputs(ctx context.Context, p filter.Predicate, vals []interface{}, timestampMS uint64, after *OutputsAfter, limit int) ([]*AnnotatedOutput, *OutputsAfter, error) {
+func (ind *Indexer) Outputs(ctx context.Context, filt string, vals []interface{}, timestampMS uint64, after *OutputsAfter, limit int) ([]*AnnotatedOutput, *OutputsAfter, error) {
+	p, err := filter.Parse(filt)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, outputsTable, vals)
+	err = filter.TypeCheck(p, outputsTable, vals)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "typechecking")
 	}

--- a/core/query/outputs.go
+++ b/core/query/outputs.go
@@ -50,7 +50,7 @@ func (ind *Indexer) Outputs(ctx context.Context, p filter.Predicate, vals []inte
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, outputsTable)
+	err := filter.TypeCheck(p, outputsTable, vals)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "typechecking")
 	}

--- a/core/query/outputs_test.go
+++ b/core/query/outputs_test.go
@@ -54,11 +54,8 @@ func TestOutputsAfter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	q, err := filter.Parse(`asset_id = 'deadbeef'`)
-	if err != nil {
-		t.Fatal(err)
-	}
 
+	const q = `asset_id = 'deadbeef'`
 	indexer := NewIndexer(db, &protocol.Chain{}, nil)
 	results, after, err := indexer.Outputs(ctx, q, nil, 25, nil, 2)
 	if err != nil {

--- a/core/query/outputs_test.go
+++ b/core/query/outputs_test.go
@@ -116,7 +116,7 @@ func TestConstructOutputsQuery(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		f, err := filter.Parse(tc.filter)
+		f, err := filter.Parse(tc.filter, outputsTable, tc.values)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/core/query/query_test.go
+++ b/core/query/query_test.go
@@ -175,11 +175,7 @@ func TestQueryOutputs(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		f, err := filter.Parse(tc.filter)
-		if err != nil {
-			t.Fatal(err)
-		}
-		outputs, _, err := indexer.Outputs(ctx, f, tc.values, bc.Millis(tc.when), nil, 1000)
+		outputs, _, err := indexer.Outputs(ctx, tc.filter, tc.values, bc.Millis(tc.when), nil, 1000)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -308,10 +304,6 @@ func TestQueryBalances(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		p, err := filter.Parse(tc.predicate)
-		if err != nil {
-			t.Fatal(err)
-		}
 		var fields []filter.Field
 		for _, s := range tc.sumBy {
 			f, err := filter.ParseField(s)
@@ -321,7 +313,7 @@ func TestQueryBalances(t *testing.T) {
 			fields = append(fields, f)
 		}
 
-		balances, err := indexer.Balances(ctx, p, tc.values, fields, bc.Millis(tc.when))
+		balances, err := indexer.Balances(ctx, tc.predicate, tc.values, fields, bc.Millis(tc.when))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/core/query/transactions.go
+++ b/core/query/transactions.go
@@ -75,6 +75,10 @@ func (ind *Indexer) Transactions(ctx context.Context, p filter.Predicate, vals [
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
 	}
+	err := filter.TypeCheck(p, transactionsTable)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "typechecking")
+	}
 	expr, err := filter.AsSQL(p, transactionsTable, vals)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "converting to SQL")

--- a/core/query/transactions.go
+++ b/core/query/transactions.go
@@ -70,12 +70,16 @@ func (ind *Indexer) LookupTxAfter(ctx context.Context, begin, end uint64) (TxAft
 }
 
 // Transactions queries the blockchain for transactions matching the
-// filter predicate `p`.
-func (ind *Indexer) Transactions(ctx context.Context, p filter.Predicate, vals []interface{}, after TxAfter, limit int, asc bool) ([]*AnnotatedTx, *TxAfter, error) {
+// filter predicate `filt`.
+func (ind *Indexer) Transactions(ctx context.Context, filt string, vals []interface{}, after TxAfter, limit int, asc bool) ([]*AnnotatedTx, *TxAfter, error) {
+	p, err := filter.Parse(filt)
+	if err != nil {
+		return nil, nil, err
+	}
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, transactionsTable, vals)
+	err = filter.TypeCheck(p, transactionsTable, vals)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "typechecking")
 	}

--- a/core/query/transactions.go
+++ b/core/query/transactions.go
@@ -50,6 +50,11 @@ func DecodeTxAfter(str string) (c TxAfter, err error) {
 	return TxAfter{FromBlockHeight: from, FromPosition: uint32(pos), StopBlockHeight: stop}, nil
 }
 
+func ValidateTransactionFilter(filt string) error {
+	_, err := filter.Parse(filt, transactionsTable, nil)
+	return err
+}
+
 // LookupTxAfter looks up the transaction `after` for the provided time range.
 func (ind *Indexer) LookupTxAfter(ctx context.Context, begin, end uint64) (TxAfter, error) {
 	const q = `
@@ -72,16 +77,12 @@ func (ind *Indexer) LookupTxAfter(ctx context.Context, begin, end uint64) (TxAft
 // Transactions queries the blockchain for transactions matching the
 // filter predicate `filt`.
 func (ind *Indexer) Transactions(ctx context.Context, filt string, vals []interface{}, after TxAfter, limit int, asc bool) ([]*AnnotatedTx, *TxAfter, error) {
-	p, err := filter.Parse(filt)
+	p, err := filter.Parse(filt, transactionsTable, vals)
 	if err != nil {
 		return nil, nil, err
 	}
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
-	}
-	err = filter.TypeCheck(p, transactionsTable, vals)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "typechecking")
 	}
 	expr, err := filter.AsSQL(p, transactionsTable, vals)
 	if err != nil {

--- a/core/query/transactions.go
+++ b/core/query/transactions.go
@@ -75,7 +75,7 @@ func (ind *Indexer) Transactions(ctx context.Context, p filter.Predicate, vals [
 	if len(vals) != p.Parameters {
 		return nil, nil, ErrParameterCountMismatch
 	}
-	err := filter.TypeCheck(p, transactionsTable)
+	err := filter.TypeCheck(p, transactionsTable, vals)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "typechecking")
 	}

--- a/core/query/transactions_test.go
+++ b/core/query/transactions_test.go
@@ -113,7 +113,7 @@ EXISTS(SELECT 1 FROM annotated_outputs AS out WHERE out."tx_hash" = txs."tx_hash
 	}
 
 	for _, tc := range testCases {
-		f, err := filter.Parse(tc.filter)
+		f, err := filter.Parse(tc.filter, transactionsTable, tc.values)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/core/query/transactions_test.go
+++ b/core/query/transactions_test.go
@@ -92,7 +92,7 @@ EXISTS(SELECT 1 FROM annotated_inputs AS inp WHERE inp."tx_hash" = txs."tx_hash"
 			after:  TxAfter{FromBlockHeight: 2, FromPosition: 20, StopBlockHeight: 1},
 			asc:    false,
 			wantQuery: `SELECT block_height, tx_pos, data FROM annotated_txs AS txs WHERE 
-EXISTS(SELECT 1 FROM annotated_outputs AS out WHERE out."tx_hash" = txs."tx_hash" AND (out."account_id" = $1 OR out."reference_data"->>'corporate' = $2))
+EXISTS(SELECT 1 FROM annotated_outputs AS out WHERE out."tx_hash" = txs."tx_hash" AND (out."account_id" = $1 OR (out."reference_data"->>'corporate') = $2))
  AND (txs.block_height, txs.tx_pos) < ($3, $4) AND txs.block_height >= $5 ORDER BY txs.block_height DESC, txs.tx_pos DESC LIMIT 100`,
 			wantValues: []interface{}{
 				`acc123`, `corp`, uint64(2), uint32(20), uint64(1),
@@ -104,7 +104,7 @@ EXISTS(SELECT 1 FROM annotated_outputs AS out WHERE out."tx_hash" = txs."tx_hash
 			after:  TxAfter{FromBlockHeight: 2, FromPosition: 20, StopBlockHeight: 1},
 			asc:    true,
 			wantQuery: `SELECT block_height, tx_pos, data FROM annotated_txs AS txs WHERE 
-EXISTS(SELECT 1 FROM annotated_outputs AS out WHERE out."tx_hash" = txs."tx_hash" AND (out."account_id" = $1 OR out."reference_data"->>'corporate' = $2))
+EXISTS(SELECT 1 FROM annotated_outputs AS out WHERE out."tx_hash" = txs."tx_hash" AND (out."account_id" = $1 OR (out."reference_data"->>'corporate') = $2))
  AND (txs.block_height, txs.tx_pos) > ($3, $4) AND txs.block_height <= $5 ORDER BY txs.block_height ASC, txs.tx_pos ASC LIMIT 100`,
 			wantValues: []interface{}{
 				`acc123`, `corp`, uint64(2), uint32(20), uint64(1),

--- a/core/txfeed/txfeed.go
+++ b/core/txfeed/txfeed.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 
-	"chain/core/query/filter"
+	"chain/core/query"
 	"chain/database/pg"
 	"chain/errors"
 )
@@ -26,7 +26,7 @@ type TxFeed struct {
 
 func (t *Tracker) Create(ctx context.Context, alias, fil, after string, clientToken string) (*TxFeed, error) {
 	// Validate the filter.
-	_, err := filter.Parse(fil)
+	err := query.ValidateTransactionFilter(fil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use the SQL table definitions to typecheck filter predicates more
exhaustively. Also, when possible, infer the type of arbitrary
json values so that we can cast them to the correct PostgreSQL
value.

For example, if you run the filter:
```
asset_definition.priority = 10
```

The type checker will infer that `asset_definition.priority` is an integer
and the resulting SQL will be:
```sql
(tbl."asset_definition"->>"priority")::bigint = 10::bigint
```

This also allows for queries to access boolean values in reference data.
For example, this is now a valid query:
```
asset_definition.is_dollar
```
Booleans that are exposed in the JSON as "yes"/"no" still need to be
compared as strings until we have a backwards compatible way of
supporting both syntaxes for those fields.
