### PR TITLE
docs/core/get-started: remove superfluous mention of Sonatype

### DIFF
--- a/docs/core/get-started/sdk.md
+++ b/docs/core/get-started/sdk.md
@@ -10,7 +10,7 @@ To ensure compatibility between your application and Chain Core, choose an SDK v
 
 ## Java
 
-The Java SDK is available via Maven, on Sonatype's [Central Repository](https://search.maven.org/#search%7Cga%7C1%7Cchain-sdk-java). Java 7 or greater is required.
+The Java SDK is available via [Maven](https://search.maven.org/#search%7Cga%7C1%7Cchain-sdk-java). Java 7 or greater is required.
 
 **Maven** users should add the following to `pom.xml`:
 


### PR DESCRIPTION
While Maven Central Repository is technically maintained by Sonatype, this detail is strictly TMI and adds nothing to the SDK download page.