### PR TITLE
core: fix leader forwarding

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -328,7 +328,7 @@ func (h *Handler) forwardToLeader(ctx context.Context, path string, body interfa
 		l.AccessToken = fmt.Sprintf("%s:%s", user, pass)
 	}
 
-	return l.Call(ctx, path, body, &resp)
+	return l.Call(ctx, path, body, resp)
 }
 
 // expvarHandler is copied from the expvar package.

--- a/core/transact.go
+++ b/core/transact.go
@@ -74,7 +74,7 @@ func (h *Handler) build(ctx context.Context, buildReqs []*buildRequest) (interfa
 	// reservations. Forward the build call to the leader process.
 	// TODO(jackson): Distribute reservations across cored processes.
 	if !leader.IsLeading() {
-		var resp map[string]interface{}
+		var resp interface{}
 		err := h.forwardToLeader(ctx, "/build-transaction", buildReqs, &resp)
 		return resp, err
 	}


### PR DESCRIPTION
Fix build-transaction leader-forwarding to use an `interface{}` instead
of a `map[string]interface{}` (fixing #487). Also, remove an unnecessary
extra pointer indirection in `forwardToLeader`.