### PR TITLE
core/txbuilder: add `control_receiver` action

### DIFF
--- a/core/account/receivers.go
+++ b/core/account/receivers.go
@@ -4,24 +4,17 @@ import (
 	"context"
 	"time"
 
-	chainjson "chain/encoding/json"
+	"chain/core/txbuilder"
 	"chain/errors"
 )
 
 const defaultReceiverExpiry = 30 * 24 * time.Hour // 30 days
 
-// Receiver encapsulates information about where to send assets to
-// be received by an account.
-type Receiver struct {
-	ControlProgram chainjson.HexBytes `json:"control_program"`
-	ExpiresAt      time.Time          `json:"expires_at"`
-}
-
 // CreateReceiver creates a new account receiver for an account
 // with the provided expiry. If a zero time is provided for the
 // expiry, a default expiry of 30 days from the current time is
 // used.
-func (m *Manager) CreateReceiver(ctx context.Context, accID, accAlias string, expiresAt time.Time) (*Receiver, error) {
+func (m *Manager) CreateReceiver(ctx context.Context, accID, accAlias string, expiresAt time.Time) (*txbuilder.Receiver, error) {
 	if expiresAt.IsZero() {
 		expiresAt = time.Now().Add(defaultReceiverExpiry)
 	}
@@ -38,7 +31,7 @@ func (m *Manager) CreateReceiver(ctx context.Context, accID, accAlias string, ex
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
-	return &Receiver{
+	return &txbuilder.Receiver{
 		ControlProgram: cp,
 		ExpiresAt:      expiresAt,
 	}, nil

--- a/core/api.go
+++ b/core/api.go
@@ -99,6 +99,7 @@ func (h *Handler) init() {
 	h.actionDecoders = map[string]func(data []byte) (txbuilder.Action, error){
 		"control_account":                h.Accounts.DecodeControlAction,
 		"control_program":                txbuilder.DecodeControlProgramAction,
+		"control_with_receiver":          txbuilder.DecodeControlWithReceiverAction,
 		"issue":                          h.Assets.DecodeIssueAction,
 		"retire":                         txbuilder.DecodeRetireAction,
 		"spend_account":                  h.Accounts.DecodeSpendAction,

--- a/core/api.go
+++ b/core/api.go
@@ -99,7 +99,7 @@ func (h *Handler) init() {
 	h.actionDecoders = map[string]func(data []byte) (txbuilder.Action, error){
 		"control_account":                h.Accounts.DecodeControlAction,
 		"control_program":                txbuilder.DecodeControlProgramAction,
-		"control_with_receiver":          txbuilder.DecodeControlWithReceiverAction,
+		"control_receiver":               txbuilder.DecodeControlReceiverAction,
 		"issue":                          h.Assets.DecodeIssueAction,
 		"retire":                         txbuilder.DecodeRetireAction,
 		"spend_account":                  h.Accounts.DecodeSpendAction,

--- a/core/txbuilder/actions.go
+++ b/core/txbuilder/actions.go
@@ -12,19 +12,19 @@ import (
 
 var retirementProgram = vmutil.NewBuilder().AddOp(vm.OP_FAIL).Program
 
-func DecodeControlWithReceiverAction(data []byte) (Action, error) {
-	a := new(controlWithReceiverAction)
+func DecodeControlReceiverAction(data []byte) (Action, error) {
+	a := new(controlReceiverAction)
 	err := stdjson.Unmarshal(data, a)
 	return a, err
 }
 
-type controlWithReceiverAction struct {
+type controlReceiverAction struct {
 	bc.AssetAmount
 	Receiver      *Receiver `json:"receiver"`
 	ReferenceData json.Map  `json:"reference_data"`
 }
 
-func (a *controlWithReceiverAction) Build(ctx context.Context, b *TemplateBuilder) error {
+func (a *controlReceiverAction) Build(ctx context.Context, b *TemplateBuilder) error {
 	var missing []string
 	if a.Receiver == nil {
 		missing = append(missing, "receiver")

--- a/core/txbuilder/actions.go
+++ b/core/txbuilder/actions.go
@@ -12,6 +12,42 @@ import (
 
 var retirementProgram = vmutil.NewBuilder().AddOp(vm.OP_FAIL).Program
 
+func DecodeControlWithReceiverAction(data []byte) (Action, error) {
+	a := new(controlWithReceiverAction)
+	err := stdjson.Unmarshal(data, a)
+	return a, err
+}
+
+type controlWithReceiverAction struct {
+	bc.AssetAmount
+	Receiver      *Receiver `json:"receiver"`
+	ReferenceData json.Map  `json:"reference_data"`
+}
+
+func (a *controlWithReceiverAction) Build(ctx context.Context, b *TemplateBuilder) error {
+	var missing []string
+	if a.Receiver == nil {
+		missing = append(missing, "receiver")
+	} else {
+		if len(a.Receiver.ControlProgram) == 0 {
+			missing = append(missing, "receiver.control_program")
+		}
+		if a.Receiver.ExpiresAt.IsZero() {
+			missing = append(missing, "receiver.expires_at")
+		}
+	}
+	if a.AssetID == (bc.AssetID{}) {
+		missing = append(missing, "asset_id")
+	}
+	if len(missing) > 0 {
+		return MissingFieldsError(missing...)
+	}
+
+	b.RestrictMaxTime(a.Receiver.ExpiresAt)
+	out := bc.NewTxOutput(a.AssetID, a.Amount, a.Receiver.ControlProgram, a.ReferenceData)
+	return b.AddOutput(out)
+}
+
 func DecodeControlProgramAction(data []byte) (Action, error) {
 	a := new(controlProgramAction)
 	err := stdjson.Unmarshal(data, a)

--- a/core/txbuilder/builder.go
+++ b/core/txbuilder/builder.go
@@ -48,6 +48,12 @@ func (b *TemplateBuilder) RestrictMinTime(t time.Time) {
 	}
 }
 
+func (b *TemplateBuilder) RestrictMaxTime(t time.Time) {
+	if t.Before(b.maxTime) {
+		b.maxTime = t
+	}
+}
+
 func (b *TemplateBuilder) MaxTime() time.Time {
 	return b.maxTime
 }

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -3,7 +3,9 @@ package txbuilder
 import (
 	"context"
 	"encoding/json"
+	"time"
 
+	chainjson "chain/encoding/json"
 	"chain/errors"
 	"chain/protocol/bc"
 )
@@ -66,4 +68,10 @@ func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 
 type Action interface {
 	Build(context.Context, *TemplateBuilder) error
+}
+
+// Reciever encapsulates information about where to send assets.
+type Receiver struct {
+	ControlProgram chainjson.HexBytes `json:"control_program"`
+	ExpiresAt      time.Time          `json:"expires_at"`
 }


### PR DESCRIPTION
Add a transaction-building action to control assets with a Receiver.