### PR TITLE
core: wrap batch panics with stack trace

### DIFF
--- a/core/http.go
+++ b/core/http.go
@@ -58,11 +58,14 @@ func alwaysError(err error) http.Handler {
 
 func batchRecover(ctx context.Context, v *interface{}) {
 	if r := recover(); r != nil {
+		var err error
 		if recoveredErr, ok := r.(error); ok {
-			*v = recoveredErr
+			err = recoveredErr
 		} else {
-			*v = fmt.Errorf("panic with %T", r)
+			err = fmt.Errorf("panic with %T", r)
 		}
+		err = errors.Wrap(err)
+		*v = err
 	}
 
 	if *v == nil {

--- a/errors/stack.go
+++ b/errors/stack.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 )
 
-const stackTraceSize = 5
+const stackTraceSize = 10
 
 // StackFrame represents a single entry in a stack trace.
 type StackFrame struct {


### PR DESCRIPTION
When recovering a panic in a batch endpoint, wrap the panic with the
stack trace. Otherwise, the reported panic doesn't include a stack trace
and can be difficult to debug. Also, bump the number of frames that we
collect.