### PR TITLE
errors: add new function Sub

### DIFF
--- a/core/blocksigner/blocksigner.go
+++ b/core/blocksigner/blocksigner.go
@@ -53,7 +53,7 @@ func New(pub ed25519.PublicKey, hsm Signer, db pg.DB, c *protocol.Chain) *BlockS
 func (s *BlockSigner) SignBlock(ctx context.Context, b *bc.Block) ([]byte, error) {
 	sig, err := s.hsm.Sign(ctx, s.Pub, &b.BlockHeader)
 	if err != nil {
-		return nil, errors.Wrapf(ErrInvalidKey, "err=%s", err.Error())
+		return nil, errors.Sub(ErrInvalidKey, err)
 	}
 	return sig, nil
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -163,10 +163,10 @@ func Configure(ctx context.Context, db pg.DB, c *Config) error {
 		for _, signer := range c.Signers {
 			_, err = url.Parse(signer.URL)
 			if err != nil {
-				return errors.Wrap(ErrBadSignerURL, err.Error())
+				return errors.Sub(ErrBadSignerURL, err)
 			}
 			if len(signer.Pubkey) != ed25519.PublicKeySize {
-				return errors.Wrap(ErrBadSignerPubkey, err.Error())
+				return errors.Sub(ErrBadSignerPubkey, err)
 			}
 			signingKeys = append(signingKeys, ed25519.PublicKey(signer.Pubkey))
 		}
@@ -248,7 +248,7 @@ func tryGenerator(ctx context.Context, url, accessToken, blockchainID string) er
 	}
 	err := client.Call(ctx, "/rpc/block-height", nil, &x)
 	if err != nil {
-		return errors.Wrap(ErrBadGenerator, err.Error())
+		return errors.Sub(ErrBadGenerator, err)
 	}
 
 	if x.BlockHeight < 1 {

--- a/core/query/outputs.go
+++ b/core/query/outputs.go
@@ -32,7 +32,7 @@ func DecodeOutputsAfter(str string) (c *OutputsAfter, err error) {
 	var lastBlockHeight, lastTxPos, lastIndex uint64
 	_, err = fmt.Sscanf(str, "%d:%d:%d", &lastBlockHeight, &lastTxPos, &lastIndex)
 	if err != nil {
-		return c, errors.Wrap(ErrBadAfter, err.Error())
+		return c, errors.Sub(ErrBadAfter, err)
 	}
 	if lastBlockHeight > math.MaxInt64 ||
 		lastTxPos > math.MaxUint32 ||

--- a/core/query/transactions.go
+++ b/core/query/transactions.go
@@ -40,7 +40,7 @@ func DecodeTxAfter(str string) (c TxAfter, err error) {
 	var from, pos, stop uint64
 	_, err = fmt.Sscanf(str, "%d:%d-%d", &from, &pos, &stop)
 	if err != nil {
-		return c, errors.Wrap(ErrBadAfter, err.Error())
+		return c, errors.Sub(ErrBadAfter, err)
 	}
 	if from > math.MaxInt64 ||
 		pos > math.MaxUint32 ||

--- a/core/txbuilder/finalize.go
+++ b/core/txbuilder/finalize.go
@@ -42,9 +42,7 @@ func FinalizeTx(ctx context.Context, c *protocol.Chain, s Submitter, tx *bc.Tx) 
 	// If this transaction is valid, ValidateTxCached will store it in the cache.
 	err = c.ValidateTxCached(tx)
 	if errors.Root(err) == validation.ErrBadTx {
-		detail := errors.Detail(err)
-		err = errors.Wrap(ErrRejected, err)
-		return errors.WithDetail(err, detail)
+		return errors.Sub(ErrRejected, err)
 	} else if err != nil {
 		return errors.Wrap(err, "tx rejected")
 	}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -154,3 +154,19 @@ func Data(err error) map[string]interface{} {
 	wrapper, _ := err.(wrapperError)
 	return wrapper.data
 }
+
+// Sub returns an error with all the associated data from old,
+// including stack trace, detail, message, and data, but using
+// new as the root error. It also wraps the newly-created error
+// with the formatted error string from old.
+//
+// Use this when you need to substitute a new root error in place
+// of an existing error that may already have an associated stack trace
+// or other metadata.
+func Sub(new, old error) error {
+	if wrapper, ok := old.(wrapperError); ok && new != nil {
+		wrapper.root = Root(new)
+		new = wrapper
+	}
+	return Wrap(new, old.Error())
+}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -163,7 +163,7 @@ func Data(err error) map[string]interface{} {
 // Sub returns nil when either new or old is nil.
 //
 // Use this when you need to substitute a new root error in place
-// of an existing error that may already have an associated stack trace
+// of an existing error that may already hold a stack trace
 // or other metadata.
 func Sub(new, old error) error {
 	if wrapper, ok := old.(wrapperError); ok && new != nil {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -160,6 +160,8 @@ func Data(err error) map[string]interface{} {
 // new as the root error. It also wraps the newly-created error
 // with the formatted error string from old.
 //
+// Sub returns nil when either new or old is nil.
+//
 // Use this when you need to substitute a new root error in place
 // of an existing error that may already have an associated stack trace
 // or other metadata.
@@ -167,6 +169,9 @@ func Sub(new, old error) error {
 	if wrapper, ok := old.(wrapperError); ok && new != nil {
 		wrapper.root = Root(new)
 		new = wrapper
+	}
+	if old == nil {
+		return nil
 	}
 	return Wrap(new, old.Error())
 }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -168,6 +168,7 @@ func Data(err error) map[string]interface{} {
 func Sub(new, old error) error {
 	if wrapper, ok := old.(wrapperError); ok && new != nil {
 		wrapper.root = Root(new)
+		wrapper.msg = new.Error()
 		new = wrapper
 	}
 	if old == nil {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -117,3 +117,26 @@ func TestData(t *testing.T) {
 		}
 	}
 }
+
+func TestSub(t *testing.T) {
+	x := errors.New("x")
+	y := errors.New("y")
+	cases := []struct{ new, old, want error }{
+		{nil, nil, nil},
+		{x, nil, nil},
+		{nil, Wrap(y), nil},
+		{Wrap(x), nil, nil},
+		{nil, y, nil},
+		{x, y, errors.New("y: x")},
+		{Wrap(x), y, errors.New("y: x")},
+		{x, Wrap(y), errors.New("y: x")},
+		{Wrap(x, "z"), Wrap(y), errors.New("y: z: x")},
+	}
+
+	for _, test := range cases {
+		got := Sub(test.new, test.old)
+		if !(got == nil && test.want == nil || got.Error() == test.want.Error()) {
+			t.Errorf("Sub(%#v, %#v) = %v, want %v", test.new, test.old, got, test.want)
+		}
+	}
+}

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -1,0 +1,25 @@
+package errors_test
+
+import (
+	"fmt"
+
+	"chain/errors"
+)
+
+var ErrInvalidKey = errors.New("invalid key")
+
+func ExampleSub() error {
+	sig, err := sign()
+	if err != nil {
+		return errors.Sub(ErrInvalidKey, err)
+	}
+	fmt.Println(sig)
+	return nil
+}
+
+func ExampleSub_return() ([]byte, error) {
+	sig, err := sign()
+	return sig, errors.Sub(ErrInvalidKey, err)
+}
+
+func sign() ([]byte, error) { return nil, nil }

--- a/errors/example_test.go
+++ b/errors/example_test.go
@@ -1,25 +1,21 @@
 package errors_test
 
-import (
-	"fmt"
-
-	"chain/errors"
-)
+import "chain/errors"
 
 var ErrInvalidKey = errors.New("invalid key")
 
-func ExampleSub() error {
-	sig, err := sign()
+func ExampleSub() {
+	err := sign()
 	if err != nil {
-		return errors.Sub(ErrInvalidKey, err)
+		err = errors.Sub(ErrInvalidKey, err)
+		return
 	}
-	fmt.Println(sig)
-	return nil
 }
 
-func ExampleSub_return() ([]byte, error) {
-	sig, err := sign()
-	return sig, errors.Sub(ErrInvalidKey, err)
+func ExampleSub_return() {
+	err := sign()
+	err = errors.Sub(ErrInvalidKey, err)
+	return
 }
 
-func sign() ([]byte, error) { return nil, nil }
+func sign() error { return nil }

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -103,7 +103,7 @@ func (c *Chain) ValidateBlock(ctx context.Context, prevState *state.Snapshot, pr
 	newState := state.Copy(prevState)
 	err := validation.ValidateBlockForAccept(ctx, newState, c.InitialBlockHash, prev, block, c.ValidateTxCached)
 	if err != nil {
-		return nil, errors.Wrapf(ErrBadBlock, "validate block: %v", err)
+		return nil, errors.Sub(ErrBadBlock, err)
 	}
 	// TODO(kr): consider calling CommitBlock here and
 	// renaming this function to AcceptBlock.

--- a/protocol/validation/block.go
+++ b/protocol/validation/block.go
@@ -42,7 +42,7 @@ func ValidateBlockForAccept(ctx context.Context, snapshot *state.Snapshot, initi
 				witnessStrs = append(witnessStrs, hex.EncodeToString(w))
 			}
 			witnessStr := strings.Join(witnessStrs, "; ")
-			return errors.Wrapf(ErrBadSig, "validation failed in script execution in block (program [%s] witness [%s]): %s", pkScriptStr, witnessStr, err)
+			return errors.Sub(ErrBadSig, errors.Wrapf(err, "program [%s] witness [%s]", pkScriptStr, witnessStr))
 		}
 	}
 

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -41,16 +41,16 @@ var (
 	errUnbalancedV1           = errors.New("amounts for asset are not balanced on v1 inputs and outputs")
 )
 
-func badTxErr(suberr error) error {
-	err := errors.WithData(ErrBadTx, "badtx", suberr)
-	err = errors.WithDetail(err, suberr.Error())
-	return err
+func badTxErr(err error) error {
+	err = errors.WithData(err, "badtx", err)
+	err = errors.WithDetail(err, err.Error())
+	return errors.Sub(ErrBadTx, err)
 }
 
-func badTxErrf(suberr error, f string, args ...interface{}) error {
-	err := errors.WithData(ErrBadTx, "badtx", suberr)
+func badTxErrf(err error, f string, args ...interface{}) error {
+	err = errors.WithData(err, "badtx", err)
 	err = errors.WithDetailf(err, f, args...)
-	return err
+	return errors.Sub(ErrBadTx, err)
 }
 
 // ConfirmTx validates the given transaction against the given state tree


### PR DESCRIPTION
Sub takes an existing error, which might have an associated stack trace or other metadata, and substitutes a new root error, which is sometimes necessary to return a certain error code to the client.

This change also updates all call sites I could find to use the new function.