### PR TITLE
sdk/ruby: fix path joining

### DIFF
--- a/sdk/ruby/chain-sdk.gemspec
+++ b/sdk/ruby/chain-sdk.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'bundler', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.5.0', '>= 3.5.0'
+  s.add_development_dependency 'webmock', '~> 2.3.2'
   s.add_development_dependency 'yard', '~> 0.9.5', '>= 0.9.5'
 end

--- a/sdk/ruby/lib/chain/connection.rb
+++ b/sdk/ruby/lib/chain/connection.rb
@@ -111,7 +111,10 @@ module Chain
           http.send "#{k}=", @opts[k]
         end
 
-        req = Net::HTTP::Post.new(@url.request_uri + path)
+        full_path = @url.request_uri.chomp('/')
+        full_path += (path[0] == '/') ? path : '/' + path
+
+        req = Net::HTTP::Post.new(full_path)
         req['Accept'] = 'application/json'
         req['Content-Type'] = 'application/json'
         req['User-Agent'] = 'chain-sdk-ruby/' + Chain::VERSION

--- a/sdk/ruby/spec/unit/connection_spec.rb
+++ b/sdk/ruby/spec/unit/connection_spec.rb
@@ -1,0 +1,21 @@
+require 'chain'
+require 'webmock'
+
+include WebMock::API
+WebMock.enable!
+
+describe Chain::Connection do
+
+  example 'works with mixtures of relative and absolute paths' do
+    stub_request(:any, 'foo.test/bar').to_return(body: '{}', headers: {'Chain-Request-ID' => 'test'})
+    stub_request(:any, 'foo.test/bar/baz').to_return(body: '{}', headers: {'Chain-Request-ID' => 'test'})
+
+    expect {
+      Chain::Connection.new(url: 'http://foo.test').request('bar')
+      Chain::Connection.new(url: 'http://foo.test').request('/bar')
+      Chain::Connection.new(url: 'http://foo.test/bar').request('baz')
+      Chain::Connection.new(url: 'http://foo.test/bar').request('/baz')
+    }.not_to raise_exception
+  end
+
+end


### PR DESCRIPTION
The Connection class does not appropriately join URL path components
when both trailing and leading slashes occur in adjacent components.
This can occur when connecting to a real HSM server and attempting to
sign.

I chose a more brute-force approach for this fix, despite the existence
of something like URI::join. The latter has issues when adjacent paths
are both relative. The fix in this commit deals with this case
correctly.