### PR TITLE
protocol: remove Chain.Ready

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -99,7 +99,6 @@ type Chain struct {
 	pendingSnapshots   chan pendingSnapshot
 
 	prevalidated prevalidatedTxsCache
-	ready        chan struct{}
 }
 
 type pendingSnapshot struct {
@@ -116,7 +115,6 @@ func NewChain(ctx context.Context, initialBlockHash bc.Hash, store Store, height
 		prevalidated: prevalidatedTxsCache{
 			lru: lru.New(maxCachedValidatedTxs),
 		},
-		ready: make(chan struct{}),
 	}
 	c.state.cond.L = new(sync.Mutex)
 
@@ -150,13 +148,6 @@ func NewChain(ctx context.Context, initialBlockHash bc.Hash, store Store, height
 	}()
 
 	return c, nil
-}
-
-// Ready returns a channel that is closed when the
-// chain has been recovered. This indicates that it is
-// ready for access.
-func (c *Chain) Ready() <-chan struct{} {
-	return c.ready
 }
 
 // Height returns the current height of the blockchain.

--- a/protocol/recover.go
+++ b/protocol/recover.go
@@ -67,8 +67,5 @@ func (c *Chain) Recover(ctx context.Context) (*bc.Block, *state.Snapshot, error)
 			return nil, nil, errors.Wrap(err, "committing block")
 		}
 	}
-
-	close(c.ready)
-
 	return b, snapshot, nil
 }


### PR DESCRIPTION
With the changes from #497, we can now move the block processor pin
creation into the `leader.Run` closure after the blockchain is
recovered.