### PR TITLE
sdk/ruby: add receiver interface

### DIFF
--- a/sdk/ruby/lib/chain/access_token.rb
+++ b/sdk/ruby/lib/chain/access_token.rb
@@ -23,7 +23,7 @@ module Chain
     # @!attribute [r] created_at
     # Timestamp of token creation.
     # @return [Time]
-    attrib(:created_at) { |raw| Time.parse(raw) }
+    attrib :created_at, rfc3339_time: true
 
     class ClientModule < Chain::ClientModule
 

--- a/sdk/ruby/lib/chain/account.rb
+++ b/sdk/ruby/lib/chain/account.rb
@@ -2,6 +2,7 @@ require_relative './client_module'
 require_relative './control_program'
 require_relative './errors'
 require_relative './query'
+require_relative './receiver'
 require_relative './response_object'
 
 module Chain
@@ -48,6 +49,7 @@ module Chain
         client.conn.batch_request('create-account', opts) { |item| Account.new(item) }
       end
 
+      # @deprecated (as of version 1.1) Use {#create_receiver} instead.
       # @param [Hash] opts
       # @return [ControlProgram]
       def create_control_program(opts = {})
@@ -61,6 +63,25 @@ module Chain
           'create-control-program',
           [{type: :account, params: params}]
         ) { |item| ControlProgram.new(item) }
+      end
+
+      # Creates a new receiver under the specified account.
+      #
+      # @param opts [Hash] Options hash
+      # @option opts [String] :account_alias Unique alias for an account. Either account_alias or account_id is required.
+      # @option opts [String] :account_id Unique ID for an account. Either account_alias or account_id is required.
+      # @option opts [String] :expires_at An RFC3339 timestamp indicating when the receiver will expire. Defaults to 30 days in the future.
+      # @return [Receiver]
+      def create_receiver(opts)
+        client.conn.singleton_batch_request('create-account-receiver', [opts]) { |item| Receiver.new(item) }
+      end
+
+      # Creates new receivers under the specified accounts.
+      #
+      # @param opts_list [Array<Hash>] Array of options hashes. See {#create_receiver} for a description of the hash structure.
+      # @return [BatchResponse]
+      def create_receiver_batch(opts_list)
+        client.conn.batch_request('create-account-receiver', opts_list) { |item| Receiver.new(item) }
       end
 
       # @param [Hash] query

--- a/sdk/ruby/lib/chain/config.rb
+++ b/sdk/ruby/lib/chain/config.rb
@@ -33,7 +33,7 @@ module Chain
 
       # @!attribute [r] configured_at
       # @return [Time]
-      attrib(:configured_at) { |raw| Time.parse(raw) }
+      attrib :configured_at, rfc3339_time: true
 
       # @!attribute [r] is_signer
       # @return [Boolean]
@@ -65,7 +65,7 @@ module Chain
 
       # @!attribute [r] generator_block_height_fetched_at
       # @return [Time]
-      attrib(:generator_block_height_fetched_at) { |raw| Time.parse(raw) }
+      attrib :generator_block_height_fetched_at, rfc3339_time: true
 
       # @!attribute [r] is_production
       # @return [Boolean]

--- a/sdk/ruby/lib/chain/receiver.rb
+++ b/sdk/ruby/lib/chain/receiver.rb
@@ -1,0 +1,15 @@
+require_relative './response_object'
+
+module Chain
+  class Receiver < ResponseObject
+    # @!attribute [r] control_program
+    # The underlying control program that will be used in transactions paying to this receiver.
+    # @return [String]
+    attrib :control_program
+
+    # @!attribute [r] expires_at
+    # A timestamp indicating when the receiver will expire.
+    # @return [Time]
+    attrib :expires_at, rfc3339_time: true
+  end
+end

--- a/sdk/ruby/lib/chain/transaction.rb
+++ b/sdk/ruby/lib/chain/transaction.rb
@@ -1,5 +1,4 @@
 require 'securerandom'
-require 'time'
 
 require_relative './client_module'
 require_relative './query'
@@ -16,7 +15,7 @@ module Chain
     # @!attribute [r] timestamp
     # Time of transaction.
     # @return [Time]
-    attrib(:timestamp) { |raw| Time.parse(raw) }
+    attrib :timestamp, rfc3339_time: true
 
     # @!attribute [r] block_id
     # Unique identifier, or block hash, of the block containing a transaction.
@@ -155,6 +154,7 @@ module Chain
       # @return [String]
       attrib :spent_output_id
 
+      # @deprecated (as of version 1.1) Use {#spent_output_id} instead.
       # @!attribute [r] spent_output
       # The output consumed by this input.
       # @return [SpentOutput]
@@ -202,6 +202,7 @@ module Chain
       # @return [Boolean]
       attrib :is_local
 
+      # @deprecated (as of version 1.1)
       class SpentOutput < ResponseObject
         # @!attribute [r] transaction_id
         # Unique transaction identifier.
@@ -405,17 +406,10 @@ module Chain
       # Add a spend action taken on a particular unspent output.
       # @param [Hash] params Action parameters
       # @option params [String] :output_id Output ID specifying the transaction output to spend.
+      # @option params [String] :transaction_id DEPRECATED (as of version 1.1) Transaction ID specifying the transaction to select an output from.
+      # @option params [Integer] :position DEPRECATED (as of version 1.1) Position of the output within the transaction to be spent.
       # @return [Builder]
       def spend_account_unspent_output(params)
-        add_action(params.merge(type: :spend_account_unspent_output))
-      end
-
-      # Add a spend action taken on a particular unspent output.
-      # @param [Hash] params Action parameters
-      # @option params [String] :transaction_id Transaction ID specifying the transaction to select an output from.
-      # @option params [Integer] :position Position of the output within the transaction to be spent.
-      # @return [Builder]
-      def spend_account_unspent_output_deprecated(params)
         add_action(params.merge(type: :spend_account_unspent_output))
       end
 
@@ -435,6 +429,21 @@ module Chain
         add_action(params.merge(type: :control_account))
       end
 
+      # Sends assets to the specified receiver.
+      #
+      # @param [Hash] params Action parameters
+      # @option params [Receiver] :control_program the receiver object.
+      # @option params [String] :asset_id Asset ID specifying the asset to be controlled.
+      #                                   You must specify either an ID or an alias.
+      # @option params [String] :asset_alias Asset alias specifying the asset to be controlled.
+      #                                   You must specify either an ID or an alias.
+      # @option params [Integer] :amount amount of the asset to be controlled.
+      # @return [Builder]
+      def control_with_receiver(params)
+        add_action(params.merge(type: :control_receiver))
+      end
+
+      # @deprecated (as of version 1.1) Use {#control_with_receiver} instead.
       # Add a control action taken on a control program.
       # @param [Hash] params Action parameters
       # @option params [String] :asset_id Asset ID specifying the asset to be controlled.

--- a/sdk/ruby/spec/unit/response_object_spec.rb
+++ b/sdk/ruby/spec/unit/response_object_spec.rb
@@ -1,0 +1,34 @@
+require 'chain'
+
+class Foo < Chain::ResponseObject
+  attrib :time, rfc3339_time: true
+end
+
+class Bar < Chain::ResponseObject
+  attrib :time, rfc3339_time: true
+  attrib(:foos) { |raw| raw.map { |item| Foo.new(item) } }
+end
+
+describe Chain::ResponseObject do
+
+  describe 'translation and detranslation' do
+
+    it 'handles nested time translation' do
+      # DateTime's to_rfc3339 method uses numeric timezones, so this is what
+      # we'll match against here.
+      t1 = '2017-01-01T00:00:00+00:00'
+      t2 = '2018-01-01T00:00:00+00:00'
+      t3 = '2019-01-01T00:00:00+00:00'
+
+      raw = {time: t1, foos: [{time: t2}, {time: t3}]}
+      b = Bar.new(raw)
+
+      expect(b.time).to eql(Time.parse(t1))
+      expect(b.foos[0].time).to eql(Time.parse(t2))
+      expect(b.foos[1].time).to eql(Time.parse(t3))
+      expect(b.to_json).to eql(raw.to_json)
+    end
+
+  end
+
+end


### PR DESCRIPTION
- Refactor ResponseObject attribs to allow for safe translation and
  detranslation between RFC3339 strings and Time.
- Add Receiver class
- Add create_receiver and create_receiver_batch
- Deprecate create_control_program
- Add control_with_receiver action
- Deprecate control_with_program action
- Fix deprecations on spent_output and outpoint params for
  spend_account_unspent_output action