### PR TITLE
core/txbuilder: check txsighash for issuance-only txs, too

### DIFF
--- a/core/txbuilder/finalize.go
+++ b/core/txbuilder/finalize.go
@@ -69,7 +69,6 @@ var (
 )
 
 func checkTxSighashCommitment(tx *bc.Tx) error {
-	allIssuances := true
 	var lastError error
 
 	for i, inp := range tx.Inputs {
@@ -77,7 +76,6 @@ func checkTxSighashCommitment(tx *bc.Tx) error {
 		switch t := inp.TypedInput.(type) {
 		case *bc.SpendInput:
 			args = t.Arguments
-			allIssuances = false
 		case *bc.IssuanceInput:
 			args = t.Arguments
 		}
@@ -114,11 +112,7 @@ func checkTxSighashCommitment(tx *bc.Tx) error {
 		return nil
 	}
 
-	if !allIssuances {
-		return lastError
-	}
-
-	return nil
+	return lastError
 }
 
 // RemoteGenerator implements the Submitter interface and submits the

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -267,7 +267,7 @@ func TestTxSighashCommitment(t *testing.T) {
 	issuanceProg := []byte{byte(vm.OP_TRUE)}
 	assetID := bc.ComputeAssetID(issuanceProg, initialBlockHash, 1, bc.EmptyStringHash)
 
-	// Tx with only issuance inputs is OK
+	// all-issuance input tx should fail if none of the inputs commit to the tx signature
 	tx := bc.NewTx(bc.TxData{
 		Version: 1,
 		Inputs: []*bc.TxInput{
@@ -313,8 +313,8 @@ func TestTxSighashCommitment(t *testing.T) {
 		MaxTime: bc.Millis(time.Now().Add(time.Hour)),
 	})
 	err := checkTxSighashCommitment(tx)
-	if err != nil {
-		t.Errorf("issuances-only: got error %s, want no error", err)
+	if err != ErrNoTxSighashAttempt {
+		t.Errorf("no issuance inputs committing to txsighash: got error %s, want ErrNoTxSighashAttempt", err)
 	}
 
 	// Tx with any spend inputs, none committing to the txsighash, is not OK


### PR DESCRIPTION
Should resolve #169 for real this time. 