### PR TITLE
core: initialize handler before first request

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -177,11 +177,11 @@ func runServer() {
 		h = launchConfiguredCore(ctx, db, conf, processID)
 	} else {
 		chainlog.Messagef(ctx, "Launching as unconfigured Core.")
-		h = &core.API{
+		h = core.Handler(&core.API{
 			DB:           db,
 			AltAuth:      authLoopbackInDev,
 			AccessTokens: &accesstoken.CredentialStore{DB: db},
-		}
+		})
 	}
 
 	secureheader.DefaultConfig.PermitClearLoopback = true
@@ -402,9 +402,11 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 		}
 	})
 
+	handler := core.Handler(h)
+
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set(rpc.HeaderBlockchainID, conf.BlockchainID.String())
-		h.ServeHTTP(w, req)
+		handler.ServeHTTP(w, req)
 	})
 }
 

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -37,6 +37,7 @@ import (
 	"chain/core/txdb"
 	"chain/core/txfeed"
 	"chain/crypto/ed25519"
+	"chain/database/pg"
 	"chain/database/sql"
 	"chain/encoding/json"
 	"chain/env"
@@ -176,12 +177,7 @@ func runServer() {
 	if conf != nil {
 		h = launchConfiguredCore(ctx, db, conf, processID)
 	} else {
-		chainlog.Messagef(ctx, "Launching as unconfigured Core.")
-		h = core.Handler(&core.API{
-			DB:           db,
-			AltAuth:      authLoopbackInDev,
-			AccessTokens: &accesstoken.CredentialStore{DB: db},
-		})
+		h = launchUnconfiguredCore(ctx, db)
 	}
 
 	secureheader.DefaultConfig.PermitClearLoopback = true
@@ -407,6 +403,15 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set(rpc.HeaderBlockchainID, conf.BlockchainID.String())
 		handler.ServeHTTP(w, req)
+	})
+}
+
+func launchUnconfiguredCore(ctx context.Context, db pg.DB) http.Handler {
+	chainlog.Messagef(ctx, "Launching as unconfigured Core.")
+	return core.Handler(&core.API{
+		DB:           db,
+		AltAuth:      authLoopbackInDev,
+		AccessTokens: &accesstoken.CredentialStore{DB: db},
 	})
 }
 

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -194,7 +194,7 @@ func TestMux(t *testing.T) {
 			t.Fatal("unexpected panic:", err)
 		}
 	}()
-	(&API{Config: &config.Config{}}).init()
+	Handler(&API{Config: &config.Config{}})
 }
 
 func TestTransfer(t *testing.T) {


### PR DESCRIPTION
Rather than initializing the http handler on the first request, this
makes the creation of the handler an explicit step.