### PR TITLE
cmd/corectl: disable key generation in prod

### DIFF
--- a/cmd/corectl/dev.go
+++ b/cmd/corectl/dev.go
@@ -4,8 +4,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"chain/core/coreunsafe"
+	"chain/core/mockhsm"
 	"chain/database/sql"
 )
 
@@ -19,4 +21,19 @@ func reset(db *sql.DB, args []string) {
 	if err != nil {
 		fatalln("error:", err)
 	}
+}
+
+func createBlockKeyPair(db *sql.DB, args []string) {
+	if len(args) != 0 {
+		fatalln("error: create-block-keypair takes no args")
+	}
+
+	hsm := mockhsm.New(db)
+	ctx := context.Background()
+	pub, err := hsm.Create(ctx, "block_key")
+	if err != nil {
+		fatalln("error:", err)
+	}
+
+	fmt.Printf("%x\n", pub.Pub)
 }

--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -14,7 +14,6 @@ import (
 	"chain/core/accesstoken"
 	"chain/core/config"
 	"chain/core/migrate"
-	"chain/core/mockhsm"
 	"chain/crypto/ed25519"
 	"chain/database/sql"
 	chainjson "chain/encoding/json"
@@ -149,21 +148,6 @@ func configGenerator(db *sql.DB, args []string) {
 	}
 
 	fmt.Println("blockchain id", conf.BlockchainID)
-}
-
-func createBlockKeyPair(db *sql.DB, args []string) {
-	if len(args) != 0 {
-		fatalln("error: create-block-keypair takes no args")
-	}
-
-	hsm := mockhsm.New(db)
-	ctx := context.Background()
-	pub, err := hsm.Create(ctx, "block_key")
-	if err != nil {
-		fatalln("error:", err)
-	}
-
-	fmt.Printf("%x\n", pub.Pub)
 }
 
 func createToken(db *sql.DB, args []string) {

--- a/cmd/corectl/prod.go
+++ b/cmd/corectl/prod.go
@@ -7,3 +7,7 @@ import "chain/database/sql"
 func reset(db *sql.DB, args []string) {
 	fatalln("error: reset disabled in prod build")
 }
+
+func createBlockKeyPair(db *sql.DB, args []string) {
+	fatalln("error: create-block-keypair disabled in prod build")
+}


### PR DESCRIPTION
This disables the create-block-keypair command when the prod build tag
is used. Additionally, mockhsm is not compiled into the binary when the
prod build tag is used.