### PR TITLE
core/txfeed: fix not-found status code for Find()

### DIFF
--- a/core/txfeed/txfeed.go
+++ b/core/txfeed/txfeed.go
@@ -130,6 +130,9 @@ func (t *Tracker) Find(ctx context.Context, id, alias string) (*TxFeed, error) {
 	)
 
 	err := t.DB.QueryRow(ctx, q.String(), id).Scan(&feed.ID, &sqlAlias, &feed.Filter, &feed.After)
+	if err == sql.ErrNoRows {
+		return nil, errors.WithDetailf(pg.ErrUserInputNotFound, "alias: %s", alias)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/core/txfeed/txfeed.go
+++ b/core/txfeed/txfeed.go
@@ -131,7 +131,9 @@ func (t *Tracker) Find(ctx context.Context, id, alias string) (*TxFeed, error) {
 
 	err := t.DB.QueryRow(ctx, q.String(), id).Scan(&feed.ID, &sqlAlias, &feed.Filter, &feed.After)
 	if err == sql.ErrNoRows {
-		return nil, errors.WithDetailf(pg.ErrUserInputNotFound, "alias: %s", alias)
+		err = errors.Sub(pg.ErrUserInputNotFound, err)
+		err = errors.WithDetailf(err, "alias: %s", alias)
+		return nil, err
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When retrieving a transaction feed by alias, an empty response
should return a CH002 error, rather than a CH000. This is resolved
by substituting sql.ErrNoRows with pg.ErrUserInputNotFound.