### PR TITLE
protocol/state: replace state.Output with bc.OutputID

### DIFF
--- a/core/account/builder_test.go
+++ b/core/account/builder_test.go
@@ -33,7 +33,7 @@ func TestAccountSourceReserve(t *testing.T) {
 
 		accID           = coretest.CreateAccount(ctx, t, accounts, "", nil)
 		asset           = coretest.CreateAsset(ctx, t, assets, nil, "", nil)
-		txOut, stateOut = coretest.IssueAssets(ctx, t, c, g, assets, accounts, asset, 2, accID)
+		txOut, outputID = coretest.IssueAssets(ctx, t, c, g, assets, accounts, asset, 2, accID)
 	)
 
 	coretest.CreatePins(ctx, t, pinStore)
@@ -60,7 +60,7 @@ func TestAccountSourceReserve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantTxIns := []*bc.TxInput{bc.NewSpendInput(stateOut.OutputID, nil, txOut.AssetID, txOut.Amount, txOut.ControlProgram, nil)}
+	wantTxIns := []*bc.TxInput{bc.NewSpendInput(outputID, nil, txOut.AssetID, txOut.Amount, txOut.ControlProgram, nil)}
 	if !testutil.DeepEqual(tx.Inputs, wantTxIns) {
 		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tx.Inputs, wantTxIns)
 	}
@@ -88,7 +88,7 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 
 		accID           = coretest.CreateAccount(ctx, t, accounts, "", nil)
 		asset           = coretest.CreateAsset(ctx, t, assets, nil, "", nil)
-		txOut, stateOut = coretest.IssueAssets(ctx, t, c, g, assets, accounts, asset, 2, accID)
+		txOut, outputID = coretest.IssueAssets(ctx, t, c, g, assets, accounts, asset, 2, accID)
 	)
 
 	coretest.CreatePins(ctx, t, pinStore)
@@ -99,7 +99,7 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 	prottest.MakeBlock(t, c, g.PendingTxs())
 	<-pinStore.PinWaiter(account.PinName, c.Height())
 
-	source := accounts.NewSpendUTXOAction(stateOut.OutputID)
+	source := accounts.NewSpendUTXOAction(outputID)
 
 	builder := txbuilder.NewBuilder(time.Now().Add(5 * time.Minute))
 	err := source.Build(ctx, builder)
@@ -111,7 +111,7 @@ func TestAccountSourceUTXOReserve(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantTxIns := []*bc.TxInput{bc.NewSpendInput(stateOut.OutputID, nil, txOut.AssetID, txOut.Amount, txOut.ControlProgram, nil)}
+	wantTxIns := []*bc.TxInput{bc.NewSpendInput(outputID, nil, txOut.AssetID, txOut.Amount, txOut.ControlProgram, nil)}
 
 	if !testutil.DeepEqual(tx.Inputs, wantTxIns) {
 		t.Errorf("build txins\ngot:\n\t%+v\nwant:\n\t%+v", tx.Inputs, wantTxIns)

--- a/core/account/indexer.go
+++ b/core/account/indexer.go
@@ -12,7 +12,6 @@ import (
 	chainjson "chain/encoding/json"
 	"chain/errors"
 	"chain/protocol/bc"
-	"chain/protocol/state"
 )
 
 // PinName is used to identify the pin associated with
@@ -73,7 +72,7 @@ func (m *Manager) indexAnnotatedAccount(ctx context.Context, a *Account) error {
 }
 
 type rawOutput struct {
-	state.Output
+	bc.OutputID
 	bc.AssetAmount
 	ControlProgram []byte
 	txHash         bc.Hash
@@ -113,9 +112,7 @@ func (m *Manager) indexAccountUTXOs(ctx context.Context, b *bc.Block) error {
 		blockPositions[tx.ID] = uint32(i)
 		for j, out := range tx.Outputs {
 			out := &rawOutput{
-				Output: state.Output{
-					OutputID: tx.OutputID(uint32(j)),
-				},
+				OutputID:       tx.OutputID(uint32(j)),
 				AssetAmount:    out.AssetAmount,
 				ControlProgram: out.ControlProgram,
 				txHash:         tx.ID,
@@ -157,7 +154,7 @@ func prevoutDBKeys(txs ...*bc.Tx) (outputIDs pq.ByteaArray) {
 	return
 }
 
-// loadAccountInfo turns a set of state.Outputs into a set of
+// loadAccountInfo turns a set of output IDs into a set of
 // outputs by adding account annotations.  Outputs that can't be
 // annotated are excluded from the result.
 func (m *Manager) loadAccountInfo(ctx context.Context, outs []*rawOutput) ([]*accountOutput, error) {

--- a/core/account/indexer.go
+++ b/core/account/indexer.go
@@ -74,8 +74,10 @@ func (m *Manager) indexAnnotatedAccount(ctx context.Context, a *Account) error {
 
 type rawOutput struct {
 	state.Output
-	txHash      bc.Hash
-	outputIndex uint32
+	bc.AssetAmount
+	ControlProgram []byte
+	txHash         bc.Hash
+	outputIndex    uint32
 }
 
 type accountOutput struct {
@@ -112,11 +114,12 @@ func (m *Manager) indexAccountUTXOs(ctx context.Context, b *bc.Block) error {
 		for j, out := range tx.Outputs {
 			out := &rawOutput{
 				Output: state.Output{
-					TxOutput: *out,
 					OutputID: tx.OutputID(uint32(j)),
 				},
-				txHash:      tx.ID,
-				outputIndex: uint32(j),
+				AssetAmount:    out.AssetAmount,
+				ControlProgram: out.ControlProgram,
+				txHash:         tx.ID,
+				outputIndex:    uint32(j),
 			}
 			outs = append(outs, out)
 		}

--- a/core/account/indexer_test.go
+++ b/core/account/indexer_test.go
@@ -7,7 +7,6 @@ import (
 	"chain/database/pg/pgtest"
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
-	"chain/protocol/state"
 	"chain/testutil"
 )
 
@@ -23,13 +22,11 @@ func TestLoadAccountInfo(t *testing.T) {
 	to2 := bc.NewTxOutput(bc.AssetID{}, 0, []byte("notfound"), nil)
 
 	outs := []*rawOutput{{
-		Output: state.Output{
-			TxOutput: *to1,
-		},
+		AssetAmount:    to1.AssetAmount,
+		ControlProgram: to1.ControlProgram,
 	}, {
-		Output: state.Output{
-			TxOutput: *to2,
-		},
+		AssetAmount:    to2.AssetAmount,
+		ControlProgram: to2.ControlProgram,
 	}}
 
 	got, err := m.loadAccountInfo(ctx, outs)

--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -14,7 +14,6 @@ import (
 	"chain/crypto/ed25519/chainkd"
 	"chain/protocol"
 	"chain/protocol/bc"
-	"chain/protocol/state"
 	"chain/testutil"
 )
 
@@ -46,7 +45,7 @@ func CreateAsset(ctx context.Context, t testing.TB, assets *asset.Registry, def 
 	return asset.AssetID
 }
 
-func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuilder.Submitter, assets *asset.Registry, accounts *account.Manager, assetID bc.AssetID, amount uint64, accountID string) (*bc.TxOutput, state.Output) {
+func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuilder.Submitter, assets *asset.Registry, accounts *account.Manager, assetID bc.AssetID, amount uint64, accountID string) (*bc.TxOutput, bc.OutputID) {
 	assetAmount := bc.AssetAmount{AssetID: assetID, Amount: amount}
 
 	tpl, err := txbuilder.Build(ctx, nil, []txbuilder.Action{
@@ -64,9 +63,7 @@ func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuild
 		testutil.FatalErr(t, err)
 	}
 
-	return tpl.Transaction.Outputs[0], state.Output{
-		OutputID: tpl.Transaction.OutputID(0),
-	}
+	return tpl.Transaction.Outputs[0], tpl.Transaction.OutputID(0)
 }
 
 func Transfer(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuilder.Submitter, actions []txbuilder.Action) *bc.Tx {

--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -66,7 +66,6 @@ func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuild
 
 	return state.Output{
 		OutputID: tpl.Transaction.OutputID(0),
-		TxOutput: *tpl.Transaction.Outputs[0],
 	}
 }
 

--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -46,7 +46,7 @@ func CreateAsset(ctx context.Context, t testing.TB, assets *asset.Registry, def 
 	return asset.AssetID
 }
 
-func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuilder.Submitter, assets *asset.Registry, accounts *account.Manager, assetID bc.AssetID, amount uint64, accountID string) state.Output {
+func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuilder.Submitter, assets *asset.Registry, accounts *account.Manager, assetID bc.AssetID, amount uint64, accountID string) (*bc.TxOutput, state.Output) {
 	assetAmount := bc.AssetAmount{AssetID: assetID, Amount: amount}
 
 	tpl, err := txbuilder.Build(ctx, nil, []txbuilder.Action{
@@ -64,7 +64,7 @@ func IssueAssets(ctx context.Context, t testing.TB, c *protocol.Chain, s txbuild
 		testutil.FatalErr(t, err)
 	}
 
-	return state.Output{
+	return tpl.Transaction.Outputs[0], state.Output{
 		OutputID: tpl.Transaction.OutputID(0),
 	}
 }

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -59,8 +59,8 @@ func TestRecovery(t *testing.T) {
 		bob     = coretest.CreateAccount(ctx, t, accounts, "bob", nil)
 	)
 	// Issue some apples to Alice and a dollar to Bob.
-	_ = coretest.IssueAssets(ctx, t, c, g, assets, accounts, apple, 10, alice)
-	_ = coretest.IssueAssets(ctx, t, c, g, assets, accounts, usd, 1, bob)
+	coretest.IssueAssets(ctx, t, c, g, assets, accounts, apple, 10, alice)
+	coretest.IssueAssets(ctx, t, c, g, assets, accounts, usd, 1, bob)
 	prottest.MakeBlock(t, c, g.PendingTxs())
 	<-pinStore.PinWaiter(account.PinName, c.Height())
 

--- a/protocol/state/outputs.go
+++ b/protocol/state/outputs.go
@@ -1,37 +1,13 @@
 package state
 
-import (
-	"chain/protocol/bc"
-)
-
-// Output represents a spent or unspent output
-// for the validation process.
-type Output struct {
-	bc.OutputID
-}
-
-// NewOutput creates a new Output.
-func NewOutput(outid bc.OutputID) *Output {
-	return &Output{
-		OutputID: outid,
-	}
-}
-
-// Prevout returns the Output consumed by the provided tx input. It
-// only includes the output data that is embedded within inputs (ex,
-// excludes reference data).
-func Prevout(in *bc.TxInput) *Output {
-	return &Output{
-		OutputID: in.SpentOutputID(),
-	}
-}
+import "chain/protocol/bc"
 
 // OutputTreeItem returns the key of an output in the state tree,
 // as well as the output commitment (a second []byte) for Inserts
 // into the state tree.
-func OutputTreeItem(o *Output) (bkey, commitment []byte) {
+func OutputTreeItem(outputID bc.OutputID) (bkey, commitment []byte) {
 	// We implement the set of unspent IDs via Patricia Trie
 	// by having the leaf data being equal to keys.
-	key := o.OutputID.Bytes()
+	key := outputID.Bytes()
 	return key, key
 }

--- a/protocol/state/outputs.go
+++ b/protocol/state/outputs.go
@@ -8,13 +8,11 @@ import (
 // for the validation process.
 type Output struct {
 	bc.OutputID
-	bc.TxOutput
 }
 
 // NewOutput creates a new Output.
-func NewOutput(o bc.TxOutput, outid bc.OutputID) *Output {
+func NewOutput(outid bc.OutputID) *Output {
 	return &Output{
-		TxOutput: o,
 		OutputID: outid,
 	}
 }
@@ -23,13 +21,8 @@ func NewOutput(o bc.TxOutput, outid bc.OutputID) *Output {
 // only includes the output data that is embedded within inputs (ex,
 // excludes reference data).
 func Prevout(in *bc.TxInput) *Output {
-	assetAmount := in.AssetAmount()
-	// TODO(oleg): for new outputid we need to have correct output commitment, not reconstruct this here
-	// Also we do not care about all these, but only about UnspentID
-	t := bc.NewTxOutput(assetAmount.AssetID, assetAmount.Amount, in.ControlProgram(), nil)
 	return &Output{
 		OutputID: in.SpentOutputID(),
-		TxOutput: *t,
 	}
 }
 

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -284,7 +284,7 @@ func ApplyTx(snapshot *state.Snapshot, tx *bc.Tx) error {
 			continue
 		}
 		// Insert new outputs into the state tree.
-		o := state.NewOutput(*out, tx.OutputID(uint32(i)))
+		o := state.NewOutput(tx.OutputID(uint32(i)))
 
 		err := snapshot.Tree.Insert(state.OutputTreeItem(o))
 		if err != nil {

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -104,7 +104,7 @@ func ConfirmTx(snapshot *state.Snapshot, initialBlockHash bc.Hash, block *bc.Blo
 		// txin is a spend
 
 		// Lookup the prevout in the blockchain state tree.
-		k, val := state.OutputTreeItem(state.Prevout(txin))
+		k, val := state.OutputTreeItem(txin.SpentOutputID())
 		if !snapshot.Tree.Contains(k, val) {
 			return badTxErrf(errInvalidOutput, "output %s for input %d is invalid", txin.SpentOutputID().String(), i)
 		}
@@ -284,9 +284,7 @@ func ApplyTx(snapshot *state.Snapshot, tx *bc.Tx) error {
 			continue
 		}
 		// Insert new outputs into the state tree.
-		o := state.NewOutput(tx.OutputID(uint32(i)))
-
-		err := snapshot.Tree.Insert(state.OutputTreeItem(o))
+		err := snapshot.Tree.Insert(state.OutputTreeItem(tx.OutputID(uint32(i))))
 		if err != nil {
 			return err
 		}

--- a/protocol/validation/tx_test.go
+++ b/protocol/validation/tx_test.go
@@ -964,7 +964,7 @@ func TestConfirmTx(t *testing.T) {
 	})
 
 	outid1 := tx.OutputID(0)
-	stateout := state.NewOutput(txout, outid1)
+	stateout := state.NewOutput(outid1)
 
 	snapshot := state.Empty()
 	err := snapshot.Tree.Insert(state.OutputTreeItem(stateout))

--- a/protocol/validation/tx_test.go
+++ b/protocol/validation/tx_test.go
@@ -964,10 +964,9 @@ func TestConfirmTx(t *testing.T) {
 	})
 
 	outid1 := tx.OutputID(0)
-	stateout := state.NewOutput(outid1)
 
 	snapshot := state.Empty()
-	err := snapshot.Tree.Insert(state.OutputTreeItem(stateout))
+	err := snapshot.Tree.Insert(state.OutputTreeItem(outid1))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Turns out we no longer need to carry around the `TxOutput`.

The indexer was using the `TxOutput` in a `state.Output`, but it can get that same info elsewhere, and now does.