### PR TITLE
protocol/tx: assign output id for all types

### DIFF
--- a/protocol/bc/transaction.go
+++ b/protocol/bc/transaction.go
@@ -221,7 +221,7 @@ func (tx *TxData) IssuanceHash(n int) (h Hash, err error) {
 }
 
 func (tx *Tx) OutputID(outputIndex uint32) OutputID {
-	return OutputID{tx.OutputIDs[outputIndex]}
+	return OutputID{tx.ResultHashes[outputIndex]}
 }
 
 func (tx *TxData) MarshalText() ([]byte, error) {

--- a/protocol/bc/txhashes.go
+++ b/protocol/bc/txhashes.go
@@ -3,9 +3,11 @@ package bc
 type (
 	// TxHashes holds data needed for validation and state updates.
 	TxHashes struct {
-		ID        Hash
-		OutputIDs []Hash // each OutputID is also the corresponding UnspentID
-		Issuances []struct {
+		ID Hash
+		// contains OutputIDs and retirment hashes.
+		// each OutputID is also the corresponding UnspentID
+		ResultHashes []Hash
+		Issuances    []struct {
 			ID           Hash
 			ExpirationMS uint64
 		}

--- a/protocol/bc/txhashes.go
+++ b/protocol/bc/txhashes.go
@@ -4,7 +4,7 @@ type (
 	// TxHashes holds data needed for validation and state updates.
 	TxHashes struct {
 		ID Hash
-		// contains OutputIDs and retirment hashes.
+		// contains OutputIDs and retirement hashes.
 		// each OutputID is also the corresponding UnspentID
 		ResultHashes []Hash
 		Issuances    []struct {

--- a/protocol/tx/transaction.go
+++ b/protocol/tx/transaction.go
@@ -29,10 +29,7 @@ func TxHashes(oldTx *bc.TxData) (hashes *bc.TxHashes, err error) {
 	// OutputIDs
 	hashes.OutputIDs = make([]bc.Hash, len(header.body.Results))
 	for i, resultHash := range header.body.Results {
-		result := entries[resultHash]
-		if _, ok := result.(*output); ok {
-			hashes.OutputIDs[i] = bc.Hash(resultHash)
-		}
+		hashes.OutputIDs[i] = bc.Hash(resultHash)
 	}
 
 	var txRefDataHash bc.Hash

--- a/protocol/tx/transaction.go
+++ b/protocol/tx/transaction.go
@@ -26,10 +26,10 @@ func TxHashes(oldTx *bc.TxData) (hashes *bc.TxHashes, err error) {
 	hashes = new(bc.TxHashes)
 	hashes.ID = bc.Hash(txid)
 
-	// OutputIDs
-	hashes.OutputIDs = make([]bc.Hash, len(header.body.Results))
+	// ResultHashes
+	hashes.ResultHashes = make([]bc.Hash, len(header.body.Results))
 	for i, resultHash := range header.body.Results {
-		hashes.OutputIDs[i] = bc.Hash(resultHash)
+		hashes.ResultHashes[i] = bc.Hash(resultHash)
 	}
 
 	var txRefDataHash bc.Hash


### PR DESCRIPTION
All outputs should have an output id assigned, whether they are standard
outputs or retirement outputs. Since the header.body.Results field
contains only outputs, there should be no need for further filtering.