### PR TITLE
core/query: add spent_output, spent_output_id

### DIFF
--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -29,4 +29,9 @@ var migrations = []migration{
 		ALTER TABLE annotated_assets ALTER COLUMN alias SET NOT NULL;
 		ALTER TABLE annotated_accounts ALTER COLUMN alias SET NOT NULL;
 	`},
+	{Name: `2017-02-16.0.query.spent-output.sql`, SQL: `
+		ALTER TABLE annotated_inputs
+			ADD COLUMN spent_output_id bytea NOT NULL,
+			ADD COLUMN spent_output jsonb;
+	`},
 }

--- a/core/query/sql.go
+++ b/core/query/sql.go
@@ -68,6 +68,8 @@ var (
 			"issuance_program": {Name: "issuance_program", Type: filter.String, SQLType: filter.SQLBytea},
 			"reference_data":   {Name: "reference_data", Type: filter.Object, SQLType: filter.SQLJSONB},
 			"is_local":         {Name: "local", Type: filter.Bool, SQLType: filter.SQLBool},
+			"spent_output_id":  {Name: "spent_output_id", Type: filter.String, SQLType: filter.SQLBytea},
+			"spent_output":     {Name: "spent_output", Type: filter.Object, SQLType: filter.SQLJSONB},
 		},
 	}
 	transactionsTable = &filter.SQLTable{

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -260,7 +260,9 @@ CREATE TABLE annotated_inputs (
     account_tags jsonb,
     issuance_program bytea NOT NULL,
     reference_data jsonb NOT NULL,
-    local boolean NOT NULL
+    local boolean NOT NULL,
+    spent_output_id bytea NOT NULL,
+    spent_output jsonb
 );
 
 
@@ -894,3 +896,4 @@ CREATE INDEX signers_type_id_idx ON signers USING btree (type, id);
 
 insert into migrations (filename, hash) values ('2017-02-03.0.core.schema-snapshot.sql', '1d55668affe0be9f3c19ead9d67bc75cfd37ec430651434d0f2af2706d9f08cd');
 insert into migrations (filename, hash) values ('2017-02-07.0.query.non-null-alias.sql', '17028a0bdbc95911e299dc65fe641184e54c87a0d07b3c576d62d023b9a8defc');
+insert into migrations (filename, hash) values ('2017-02-16.0.query.spent-output.sql', '7cd52095b6f202d7a25ffe666b7b7d60e7700d314a7559b911e236b72661a738');


### PR DESCRIPTION
These columns were forgotten in the query rewrite.

Fix #523