### PR TITLE
core/query: make annotated output's txid truly omittable

### DIFF
--- a/core/query/annotated.go
+++ b/core/query/annotated.go
@@ -47,7 +47,7 @@ type AnnotatedOutput struct {
 	Type            string             `json:"type"`
 	Purpose         string             `json:"purpose,omitempty"`
 	OutputID        bc.OutputID        `json:"id"`
-	TransactionID   bc.Hash            `json:"transaction_id,omitempty"`
+	TransactionID   *bc.Hash           `json:"transaction_id,omitempty"`
 	Position        uint32             `json:"position"`
 	AssetID         bc.AssetID         `json:"asset_id"`
 	AssetAlias      string             `json:"asset_alias,omitempty"`

--- a/core/query/outputs.go
+++ b/core/query/outputs.go
@@ -10,6 +10,7 @@ import (
 
 	"chain/core/query/filter"
 	"chain/errors"
+	"chain/protocol/bc"
 )
 
 var defaultOutputsAfter = OutputsAfter{
@@ -75,6 +76,7 @@ func (ind *Indexer) Outputs(ctx context.Context, filt string, vals []interface{}
 		var (
 			blockHeight  uint64
 			txPos        uint32
+			txID         = new(bc.Hash)
 			accountID    *string
 			accountAlias *string
 			out          = new(AnnotatedOutput)
@@ -83,7 +85,7 @@ func (ind *Indexer) Outputs(ctx context.Context, filt string, vals []interface{}
 			&blockHeight,
 			&txPos,
 			&out.Position,
-			&out.TransactionID,
+			txID,
 			&out.OutputID,
 			&out.Type,
 			&out.Purpose,
@@ -103,6 +105,8 @@ func (ind *Indexer) Outputs(ctx context.Context, filt string, vals []interface{}
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "scanning annotated output")
 		}
+
+		out.TransactionID = txID
 
 		// Set nullable fields.
 		if accountID != nil {


### PR DESCRIPTION
AnnotatedOutput'd TransactionID field is a bc.Hash, which does not have
a zero-value that will trigger the omitempty directive when serialized
to JSON. We use pointers instead to get the desired behavior.

This commit is a stopgap measure to prevent some weird behavior in the
Node SDK; namely, transaction output objects are currently returned as
strings of zeros. In the future, we can re-evaluate the API spec and decide
whether we should allow the transaction ID field to be empty in any context.

