### PR TITLE
protocol/patricia: remove error case in Delete

### DIFF
--- a/core/txdb/snapshot_test.go
+++ b/core/txdb/snapshot_test.go
@@ -65,10 +65,7 @@ func TestReadWriteStateSnapshot(t *testing.T) {
 			}
 		}
 		for _, key := range changeset.deletes {
-			err := snapshot.Tree.Delete(key[:])
-			if err != nil {
-				t.Fatal(err)
-			}
+			snapshot.Tree.Delete(key[:])
 		}
 
 		err := storeStateSnapshot(ctx, dbtx, snapshot, uint64(i))

--- a/protocol/patricia/patricia_test.go
+++ b/protocol/patricia/patricia_test.go
@@ -444,6 +444,24 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestDeletePrefix(t *testing.T) {
+	_, hashes := makeVals(4)
+	root := &node{
+		key:  bools("111111"),
+		hash: hashPtr(hashForNonLeaf(hashes[2], hashes[3])),
+		children: [2]*node{
+			{key: bools("11111110"), hash: &hashes[2], isLeaf: true},
+			{key: bools("11111111"), hash: &hashes[3], isLeaf: true},
+		},
+	}
+
+	got := delete(root, bools("111111"))
+	got.calcHash()
+	if !testutil.DeepEqual(got, root) {
+		t.Fatalf("got:\n%swant:\n%s", prettyNode(got, 0), prettyNode(root, 0))
+	}
+}
+
 func TestBoolKey(t *testing.T) {
 	cases := []struct {
 		b []byte

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -273,10 +273,7 @@ func ApplyTx(snapshot *state.Snapshot, tx *bc.Tx) error {
 
 		// Remove the consumed output from the state tree.
 		uid := si.SpentOutputID
-		err := snapshot.Tree.Delete(uid.Bytes())
-		if err != nil {
-			return err
-		}
+		snapshot.Tree.Delete(uid.Bytes())
 	}
 
 	for i, out := range tx.Outputs {


### PR DESCRIPTION
Delete used to return ErrPrefix in one case: when the
requested key exactly matches an interior node. There
were three problems with this:

First, it didn't cover all cases where the requested key
is a prefix of an existing item. Consider the following
tree of three items (001, 010, and 011):

    0             (interior node)
    +-- 001       (leaf node)
    +-- 01        (interior node)
        +--  010  (leaf node)
        +--  011  (leaf node)

Attempting to delete 01 produced ErrPrefix, but
attempting to delete 00 was a no-op, returning a nil
error. Both of those keys are prefixes of other keys in
the set.

Second, there was a bug in the recursive call. It
returned a nil node on error. This returned all the way
up the stack and caused the root node to be replaced
with nil. Thus, attempting to delete a nonexistent key
corresponding to an interior node would actually delete
the entire tree.

Third, and most broadly, attempting to delete a prefix
of an existing key (whether or not it matches an
interior node) shouldn't be an error. It should be a
no-op, just like trying to delete any other key that's
not in the set.

This patch addresses these issues by removing the error
condition and treating that case as a no-op.

There's no significant difference in performance in the
existing benchmarks.

benchmark                      old ns/op     new ns/op     delta
BenchmarkInserts-4             27923330      27744174      -0.64%
BenchmarkInsertsRootHash-4     37095589      37046587      -0.13%

benchmark                      old allocs     new allocs     delta
BenchmarkInserts-4             161756         161755         -0.00%
BenchmarkInsertsRootHash-4     171776         171776         +0.00%

benchmark                      old bytes     new bytes     delta
BenchmarkInserts-4             11642978      11642854      -0.00%
BenchmarkInsertsRootHash-4     11970751      11970739      -0.00%