### PR TITLE
protocol/patricia: un-export ErrPrefix

### DIFF
--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -116,7 +116,8 @@ func lookup(n *node, key []uint8) *node {
 // and its value is updated, leaving the structure of
 // the tree alone.
 // It is an error for bkey to be a prefix
-// of a key already in t.
+// of a key already in t or to contain a key already
+// in t as a prefix.
 func (t *Tree) Insert(bkey, val []byte) error {
 	key := bitKey(bkey)
 

--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -19,10 +19,6 @@ import (
 	"chain/protocol/bc"
 )
 
-// ErrPrefix is returned from Insert if
-// the key provided is a prefix to existing nodes.
-var ErrPrefix = errors.New("key provided is a prefix to other keys")
-
 var (
 	leafPrefix     = []byte{0x00}
 	interiorPrefix = []byte{0x01}
@@ -119,6 +115,8 @@ func lookup(n *node, key []uint8) *node {
 // If the key is present, the existing node is found
 // and its value is updated, leaving the structure of
 // the tree alone.
+// It is an error for bkey to be a prefix
+// of an existing key in t.
 func (t *Tree) Insert(bkey, val []byte) error {
 	key := bitKey(bkey)
 
@@ -142,7 +140,7 @@ func (t *Tree) Insert(bkey, val []byte) error {
 func insert(n *node, key []uint8, hash *bc.Hash) (*node, error) {
 	if bytes.Equal(n.key, key) {
 		if !n.isLeaf {
-			return n, errors.Wrap(ErrPrefix)
+			return n, errors.Wrap(errors.New("key provided is a prefix to other keys"))
 		}
 
 		n = &node{
@@ -155,7 +153,7 @@ func insert(n *node, key []uint8, hash *bc.Hash) (*node, error) {
 
 	if bytes.HasPrefix(key, n.key) {
 		if n.isLeaf {
-			return n, errors.Wrap(ErrPrefix)
+			return n, errors.Wrap(errors.New("key provided is a prefix to other keys"))
 		}
 		bit := key[len(n.key)]
 

--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -116,7 +116,7 @@ func lookup(n *node, key []uint8) *node {
 // and its value is updated, leaving the structure of
 // the tree alone.
 // It is an error for bkey to be a prefix
-// of an existing key in t.
+// of a key already in t.
 func (t *Tree) Insert(bkey, val []byte) error {
 	key := bitKey(bkey)
 


### PR DESCRIPTION
No other package uses the value of ErrPrefix, so we can
reduce the surface area of this package by not exporting it.