### PR TITLE
cmd/cored: use latestVersion constant only for dev builds

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -86,13 +86,10 @@ var (
 
 func init() {
 	var version string
-	if strings.HasPrefix(buildTag, "cmd.cored-") {
-		// build tag with cmd.cored- prefix indicates official release
-		version = latestVersion
-	} else if buildTag != "?" {
-		version = latestVersion + "-" + buildTag
+	if buildTag != "?" {
+		version = strings.TrimPrefix(buildTag, "cmd.cored-")
 	} else {
-		// -dev suffix indicates intermediate, non-release build
+		// +changes suffix indicates non-release build
 		version = latestVersion + "+changes"
 	}
 


### PR DESCRIPTION
This slightly simplifies the logic for initializing the
version string on startup. (It shouldn't be complicated!)
Notably, this means that the release version string is
derived entirely from the build tag, and it doesn't use
the latestVersion constant at all -- this way, release
version strings are consistently derived from a single
source of truth, the git tag.