### PR TITLE
	cmd/slashland: generate a "rev id" for each commit on main

### DIFF
--- a/cmd/slashland/revid.go
+++ b/cmd/slashland/revid.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"text/template"
+)
+
+// Paths must begin with generated/; see commitRevIDs.
+var revIDLang = map[string]*template.Template{
+	// tktk are these paths appropriate?
+	"generated/rev/RevId.java": template.Must(template.New("").Parse(revIDJava)),
+	"generated/rev/revid.go":   template.Must(template.New("").Parse(revIDGo)),
+	"generated/rev/revid.js":   template.Must(template.New("").Parse(revIDJavaScript)),
+	"generated/rev/revid.rb":   template.Must(template.New("").Parse(revIDRuby)),
+}
+
+const revIDGo = `
+package rev
+var ID string = "{{.}}"
+`
+
+// tktk do java things need to go in a special place?
+const revIDJava = `
+public final class RevId {
+	public final String Id = "{{.}}";
+}
+`
+
+// tktk [i have no idea what i'm doing dot jpeg]
+const revIDJavaScript = `
+export const RevID = "{{.}}"
+`
+
+// tktk rubby idk; please look
+const revIDRuby = `
+module Chain::Rev
+	ID = "{{.}}".freeze
+end
+`
+
+// revID returns a string to use
+// for the revid of the next commit on main.
+func revID(landdir string) (string, error) {
+	cmd := dirCmd(landdir, "git", "rev-list", "--count", "main")
+	cmd.Stderr = os.Stderr
+	b, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return "rev" + string(bytes.TrimSpace(b)), nil
+}

--- a/cmd/slashland/revid.go
+++ b/cmd/slashland/revid.go
@@ -17,7 +17,7 @@ var revIDLang = map[string]*template.Template{
 
 const revIDGo = `
 package rev
-var ID string = "{{.}}"
+const ID string = "{{.}}"
 `
 
 // tktk do java things need to go in a special place?
@@ -29,7 +29,7 @@ public final class RevId {
 
 // tktk [i have no idea what i'm doing dot jpeg]
 const revIDJavaScript = `
-export const RevID = "{{.}}"
+export const rev_id = "{{.}}"
 `
 
 // tktk rubby idk; please look

--- a/cmd/slashland/revid.go
+++ b/cmd/slashland/revid.go
@@ -16,6 +16,7 @@ var revIDLang = map[string]*template.Template{
 
 const revIDGo = `
 package rev
+
 const ID string = "{{.}}"
 `
 

--- a/cmd/slashland/revid.go
+++ b/cmd/slashland/revid.go
@@ -8,7 +8,6 @@ import (
 
 // Paths must begin with generated/; see commitRevIDs.
 var revIDLang = map[string]*template.Template{
-	// tktk are these paths appropriate?
 	"generated/rev/RevId.java": template.Must(template.New("").Parse(revIDJava)),
 	"generated/rev/revid.go":   template.Must(template.New("").Parse(revIDGo)),
 	"generated/rev/revid.js":   template.Must(template.New("").Parse(revIDJavaScript)),
@@ -20,19 +19,16 @@ package rev
 const ID string = "{{.}}"
 `
 
-// tktk do java things need to go in a special place?
 const revIDJava = `
 public final class RevId {
 	public final String Id = "{{.}}";
 }
 `
 
-// tktk [i have no idea what i'm doing dot jpeg]
 const revIDJavaScript = `
 export const rev_id = "{{.}}"
 `
 
-// tktk rubby idk; please look
 const revIDRuby = `
 module Chain::Rev
 	ID = "{{.}}".freeze

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,0 +1,3 @@
+public final class RevId {
+	public final String Id = "?";
+}

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,2 +1,3 @@
 package rev
+
 const ID string = "?"

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,0 +1,2 @@
+package rev
+const ID string = "?"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,0 +1,1 @@
+export const rev_id = "?"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,0 +1,3 @@
+module Chain::Rev
+	ID = "?".freeze
+end


### PR DESCRIPTION
Right now, when someone clones the repo and builds using 'go install chain/cmd/cored', the resulting binary will have some minimal version information: the latestVersion constant containing the version string of the last release we made. This comes in handy when someone is reporting trouble and we ask them to run `cored -version` to investigate. But this is only a little better than nothing; there are typically hundreds of commits between releases. Adding a unique string to every single revision (on main) will give us a much more precise idea of what code is being run.

We generate source files for our four main languages: Go, Java, JavaScript, and Ruby. It won't be difficult to add others if we need them.

This PR only begins recording the revision ID. We'll incorporate it into the version output in followup work.