### PR TITLE
protocol/patricia: remove func Copy

### DIFF
--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -8,7 +8,10 @@
 // within the tree.
 //
 // The nodes in the tree form an immutable persistent data
-// structure, therefore Copy is a O(1) operation.
+// structure. It is okay to copy a Tree struct,
+// which contains the root of the tree, to obtain a new tree
+// with the same contents. The time to make such a copy is
+// independent of the size of the tree.
 package patricia
 
 import (
@@ -27,14 +30,6 @@ var (
 // Tree implements a patricia tree.
 type Tree struct {
 	root *node
-}
-
-// Copy returns a new tree with the same root as this tree. It
-// is an O(1) operation.
-func Copy(t *Tree) *Tree {
-	newT := new(Tree)
-	newT.root = t.root
-	return newT
 }
 
 // WalkFunc is the type of the function called for each leaf

--- a/protocol/state/snapshot.go
+++ b/protocol/state/snapshot.go
@@ -35,9 +35,10 @@ func Copy(original *Snapshot) *Snapshot {
 	// We already handle it that way in many places (with explicit
 	// calls to Copy to get the right behavior).
 	c := &Snapshot{
-		Tree:      patricia.Copy(original.Tree),
+		Tree:      new(patricia.Tree),
 		Issuances: make(PriorIssuances, len(original.Issuances)),
 	}
+	*c.Tree = *original.Tree
 	for k, v := range original.Issuances {
 		c.Issuances[k] = v
 	}


### PR DESCRIPTION
The Copy function merely made a copy of the Tree
structure. Many Go structures, such as http.Request and
bytes.Buffer, are safe to copy, and patricia.Tree is
too. (In fact, one can typically assume that a Go struct
is okay to copy unless its documentation says otherwise.
See sync.Mutex for an example.) We don't need a function
just to perform this basic operation.