### PR TITLE
bin/jrun: display deprecation errors

### DIFF
--- a/bin/jrun
+++ b/bin/jrun
@@ -23,5 +23,5 @@ trap "rm -rf $COMPILE_PATH" EXIT
 JARFILE=`echo $CHAIN/sdk/java/target/chain-sdk-java*[[:digit:]].jar`
 export CLASSPATH=.:$JARFILE:$COMPILE_PATH
 
-javac -d $COMPILE_PATH $SRC
+javac -d $COMPILE_PATH -Xlint:deprecation $SRC
 java $CLASS


### PR DESCRIPTION
This commit adds a compile flag so use of deprecated APIs
will trigger console warnings. Since jrun is used primarily to test
documentation examples, this is a really good thing!