### PR TITLE
docs/core: introduce receivers

### DIFF
--- a/docs/core/build-applications/accounts.md
+++ b/docs/core/build-applications/accounts.md
@@ -72,7 +72,9 @@ $code submit-transfer ../examples/java/Accounts.java ../examples/ruby/accounts.r
 
 ## Receive asset units from an external party
 
-Account IDs and aliases are local Chain Core data. They do not exist in the blockchain. When an external party wishes to transfer assets to your account, you must first create a receiver for the account. We will create a receiver for Bob’s account, which we can then send to the external party (see following example).
+When an external party wishes to transfer assets to your account, you must first create a **receiver** for the account. A receiver is a one-time-use payment object similar to an invoice, and it contains a new control program derived from the account's root keys, as well as supplementary payment information.
+
+We will create a receiver for Bob’s account, which we can then serialize and send to an external party (see following example).
 
 $code create-receiver ../examples/java/Accounts.java ../examples/ruby/accounts.rb ../examples/node/accounts.js
 

--- a/docs/core/build-applications/accounts.md
+++ b/docs/core/build-applications/accounts.md
@@ -72,7 +72,7 @@ $code submit-transfer ../examples/java/Accounts.java ../examples/ruby/accounts.r
 
 ## Receive asset units from an external party
 
-When an external party wishes to transfer assets to your account, you must first create a **receiver** for the account. A receiver is a one-time-use payment object similar to an invoice, and it contains a new control program derived from the account's root keys, as well as supplementary payment information.
+When an external party wishes to transfer assets to your account, you must first create a **receiver** for the account. A receiver is a one-time-use payment object similar to an invoice. It contains a new control program derived from the account's root keys, as well as supplementary payment information such as an expiration date.
 
 We will create a receiver for Bob’s account, which we can then serialize and send to an external party (see following example).
 

--- a/docs/core/build-applications/accounts.md
+++ b/docs/core/build-applications/accounts.md
@@ -72,15 +72,15 @@ $code submit-transfer ../examples/java/Accounts.java ../examples/ruby/accounts.r
 
 ## Receive asset units from an external party
 
-Account IDs and aliases are local Chain Core data. They do not exist in the blockchain. When an external party wishes to transfer assets to your account, you must first create a control program for the account. We will create a control program for Bob’s account, which we can then send to the external party (see following example).
+Account IDs and aliases are local Chain Core data. They do not exist in the blockchain. When an external party wishes to transfer assets to your account, you must first create a receiver for the account. We will create a receiver for Bob’s account, which we can then send to the external party (see following example).
 
-$code create-control-program ../examples/java/Accounts.java ../examples/ruby/accounts.rb ../examples/node/accounts.js
+$code create-receiver ../examples/java/Accounts.java ../examples/ruby/accounts.rb ../examples/node/accounts.js
 
 ## Transfer asset units to an external party
 
-If you wish to transfer asset units to an external party, you must first request a control program from them. You can then build, sign, and submit a transaction sending asset units to their control program. We will use the control program we created in Bob’s account to demonstrate this external facing functionality.
+If you wish to transfer asset units to an external party, you must first request a receiver from them. You can then build, sign, and submit a transaction sending asset units to their control program. We will use the receiver we created in Bob’s account to demonstrate this external facing functionality.
 
-$code transfer-to-control-program ../examples/java/Accounts.java ../examples/ruby/accounts.rb ../examples/node/accounts.js
+$code transfer-to-receiver ../examples/java/Accounts.java ../examples/ruby/accounts.rb ../examples/node/accounts.js
 
 ## List account transactions
 

--- a/docs/core/build-applications/assets.md
+++ b/docs/core/build-applications/assets.md
@@ -79,7 +79,7 @@ $code submit-issue ../examples/java/Assets.java ../examples/ruby/assets.rb ../ex
 
 ## Issue asset units to an external party
 
-If you wish to issue asset units to an external party, you must first request a control program from them. You can then build, sign, and submit a transaction issuing asset units to their control program.
+If you wish to issue asset units to an external party, you must first request a receiver from them. You can then build, sign, and submit a transaction issuing asset units to their receiver.
 
 We will issue 2000 units of Acme Common stock to an external party.
 
@@ -125,7 +125,7 @@ $code list-retirements ../examples/java/Assets.java ../examples/ruby/assets.rb .
 
 ## Get asset circulation
 
-The circulation of an asset is the sum of all non-retired units of that asset existing in unspent transaction outputs in the blockchain, regardless of control program.
+The circulation of an asset is the sum of all non-retired units of that asset existing in unspent transaction outputs in the blockchain.
 
 To list the circulation of Acme Common stock, we build a balance query, filtering on the Acme Common stock `asset_alias`.
 
@@ -135,6 +135,6 @@ To list the circulation of all classes of Acme stock, we build a balance query, 
 
 $code list-acme-balance ../examples/java/Assets.java ../examples/ruby/assets.rb ../examples/node/assets.js
 
-To list all the control programs that hold a portion of the circulation of Acme Common stock, we build an unspent outputs query, filtering on the Acme Common stock `asset_alias`.
+To list all the unspent outputs that hold a portion of the circulation of Acme Common stock, we build an unspent outputs query, filtering on the Acme Common stock `asset_alias`.
 
 $code list-acme-common-unspents ../examples/java/Assets.java ../examples/ruby/assets.rb ../examples/node/assets.js

--- a/docs/core/build-applications/balances.md
+++ b/docs/core/build-applications/balances.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Any balance on the blockchain is simply a summation of unspent outputs. For example, the balance of Alice’s account is a summation of all the unspent outputs whose control program was created from the keys in Alice’s account.
+Any balance on the blockchain is simply a summation of unspent outputs. For example, the balance of Alice’s account is a summation of all the unspent outputs whose control programs were created from the keys in Alice’s account.
 
 Unlike other queries in Chain Core, balance queries do not return Chain Core objects, only simple sums over the `amount` fields in a specified list of unspent output objects.
 

--- a/docs/core/build-applications/batch-operations.md
+++ b/docs/core/build-applications/batch-operations.md
@@ -23,7 +23,7 @@ All code samples in this guide can be viewed in a single, runnable script. Avail
 
 ## Example: Creating assets in a batch
 
-All batch operations share a common workflow. To illustrate this, we’ll walk through an example program that creates several assets as a batch.
+All batch operations share a common workflow. To illustrate this, we’ll walk through an example application that creates several assets as a batch.
 
 #### Preparing the request
 

--- a/docs/core/build-applications/batch-operations.md
+++ b/docs/core/build-applications/batch-operations.md
@@ -8,7 +8,7 @@ Operations that support batching include:
 
 * Creating assets
 * Creating accounts
-* Creating control programs
+* Creating receivers
 * Building transactions
 * Signing transactions
 * Submitting transactions

--- a/docs/core/build-applications/control-programs.md
+++ b/docs/core/build-applications/control-programs.md
@@ -28,13 +28,17 @@ The most basic type of control program is an account control program, which defi
 
 Although all control programs in one account are controlled by keys derived from the same root keys, it is impossible for other participants on the blockchain to recognize any relationship between them. This technique (known as hierarchical deterministic key derivation) ensures that only the participant on the blockchain with whom you transact will know that a specific control program is yours. To everyone else, the creator of the control program will be unknown. For more information about key derivation, see the [Chain key derivation specification](../../protocol/specifications/chainkd.md).
 
+### Receivers
+
+Since version 1.1., the Chain API does not expose account control programs directly. Instead, you can generate **receiver** objects that wrap account control programs with additional payment information, such as expiration dates. If control programs are like payment addresses, then receivers are like invoices, which contain additional information in addition to mere addresses.
+
 ### Example
 
-If Alice wishes to be paid gold by an external party (Bob), she first creates a new control program in her account:
+If Alice wishes to be paid gold by an external party (Bob), she first creates a new receiver in her account:
 
-$code create-control-program ../examples/java/ControlPrograms.java ../examples/ruby/control_programs.rb ../examples/node/controlPrograms.js
+$code create-receiver ../examples/java/ControlPrograms.java ../examples/ruby/control_programs.rb ../examples/node/controlPrograms.js
 
-She then delivers the control program to Bob, who provides it to the transaction builder:
+The new receiver contains a control program for the specified account. Alice then serializes the receiver and delivers it to Bob, who deserializes it and sends it to the transaction builder:
 
 $code build-transaction ../examples/java/ControlPrograms.java ../examples/ruby/control_programs.rb ../examples/node/controlPrograms.js
 

--- a/docs/core/build-applications/control-programs.md
+++ b/docs/core/build-applications/control-programs.md
@@ -30,7 +30,7 @@ Although all control programs in one account are controlled by keys derived from
 
 ### Receivers
 
-Since version 1.1., the Chain API does not expose account control programs directly. Instead, you can generate **receiver** objects that wrap account control programs with additional payment information, such as expiration dates. If control programs are like payment addresses, then receivers are like invoices, which contain additional information in addition to mere addresses.
+Since version 1.1, the Chain Core accounts API does not expose account control programs directly. Instead, you can generate **receiver** objects, which wrap account control programs with additional payment information, such as expiration dates. If control programs are like payment addresses, then receivers are like invoices, which contain additional information on top of the addresses themselves.
 
 ### Example
 

--- a/docs/core/build-applications/queries.md
+++ b/docs/core/build-applications/queries.md
@@ -77,7 +77,7 @@ Balance and unspent output queries accept a timestamp parameter to report owners
 
 ### Special Case: Balance queries
 
-Any balance on the blockchain is simply a summation of unspent outputs. For example, the balance of Alice’s account is a summation of all the unspent outputs whose control program was created from the keys in Alice’s account.
+Any balance on the blockchain is simply a summation of unspent outputs. For example, the balance of Alice’s account is a summation of all the unspent outputs whose control programs were created from the keys in Alice’s account.
 
 Unlike other queries in Chain Core, balance queries do not return Chain Core objects, only simple sums over the `amount` fields in a specified list of unspent output objects.
 

--- a/docs/core/build-applications/real-time-transaction-processing.md
+++ b/docs/core/build-applications/real-time-transaction-processing.md
@@ -14,7 +14,7 @@ All code samples in this guide can be viewed in a single, runnable script. Avail
 
 ## Example
 
-To illustrate how to use transaction feeds, we'll create a program that prints information about new [local](../learn-more/global-vs-local-data.md) transactions as they arrive.
+To illustrate how to use transaction feeds, we'll create an application that prints information about new [local](../learn-more/global-vs-local-data.md) transactions as they arrive.
 
 #### Creating and retrieving a transaction feed
 
@@ -40,7 +40,7 @@ Next, we'll set up an infinite loop that reads from the transaction feed, and se
 
 $code processing-loop ../examples/java/RealTimeTransactionProcessing.java ../examples/ruby/real_time_transaction_processing.rb ../examples/node/realTimeTransactionProcessing.js
 
-Note that the processing loop **acknowledges** consumption of the current item. (In most platforms, this is a call to an `ack` method; in Node, this is achieved by passing `true` to the `next` callback). This updates the transaction feed via an API call so that if your program terminates for any reason, it can pick back up from the point that `ack` was last called. It's safest, but not necessary, to acknowledge on every cycle of the processing loop.
+Note that the processing loop **acknowledges** consumption of the current item. (In most platforms, this is a call to an `ack` method; in Node, this is achieved by passing `true` to the `next` callback). This updates the transaction feed via an API call so that if your application terminates for any reason, it can pick back up from the point that `ack` was last called. It's safest, but not necessary, to acknowledge on every cycle of the processing loop.
 
 The body of the processing loop will run once for every new transaction that arrives on the blockchain. If you've already processed all available transactions, then the call to `next` will **block the active thread** until a transaction matching the filter arrives. Because of this blocking behavior, we'll run the processing loop in its own thread:
 
@@ -110,7 +110,7 @@ Under the hood, the SDK reads data from a transaction feed using a long-polling 
 
 #### When to acknowledge in the processing loop
 
-Acknowledging each item as you consume it in your processing loop is the safest strategy, but it's not the only strategy. If you'd prefer to cut down on API calls to the Chain Core, you can acknowledge less frequently. The less frequently you acknowledge, the more risk you'll have of repeating some processing if your program terminates unexpectedly.
+Acknowledging each item as you consume it in your processing loop is the safest strategy, but it's not the only strategy. If you'd prefer to cut down on API calls to the Chain Core, you can acknowledge less frequently. The less frequently you acknowledge, the more risk you'll have of repeating some processing if your application terminates unexpectedly.
 
 Transaction feeds provide *at-least-once* delivery of transactions; occasionally, a transaction may be delivered multiple times. Regardless of how frequently you acknowledge, it's a good idea to design your transaction processing to be **idempotent**, so that your application can process a given transaction twice or more without adverse effects.
 

--- a/docs/core/build-applications/transaction-basics.md
+++ b/docs/core/build-applications/transaction-basics.md
@@ -65,7 +65,7 @@ Issue                                   | Issues new units of a specified asset.
 Spend from account                      | Spends units of a specified asset from a specified account. Automatically handles locating outputs with enough units, and the creation of change outputs.
 Spend an unspent output from an account | Spends an entire, specific unspent output in an account. Change must be handled manually, using other actions.
 Control with account                    | Receives units of a specified asset into a specified account.
-Control with receiver                   | Receives units of an asset into a receiver, which contains a control program and associated payment information. Used when making a payment to an external party/account in another Chain Core.
+Control with receiver                   | Receives units of an asset into a receiver, which contains a control program and supplementary payment information, such as an expiration date. Used when making a payment to an external party/account in another Chain Core.
 Retire                                  | Retires units of a specified asset.
 Set transaction reference data          | Sets arbitrary reference data on the transaction.
 

--- a/docs/core/build-applications/transaction-basics.md
+++ b/docs/core/build-applications/transaction-basics.md
@@ -65,7 +65,7 @@ Issue                                   | Issues new units of a specified asset.
 Spend from account                      | Spends units of a specified asset from a specified account. Automatically handles locating outputs with enough units, and the creation of change outputs.
 Spend an unspent output from an account | Spends an entire, specific unspent output in an account. Change must be handled manually, using other actions.
 Control with account                    | Receives units of a specified asset into a specified account.
-Control with program                    | Receives units of an asset into a specificed control program. Used when making a payment to an external party/account in another Chain Core.
+Control with receiver                   | Receives units of an asset into a receiver, which contains a control program and associated payment information. Used when making a payment to an external party/account in another Chain Core.
 Retire                                  | Retires units of a specified asset.
 Set transaction reference data          | Sets arbitrary reference data on the transaction.
 
@@ -87,7 +87,7 @@ The Chain Core SDK assumes that private keys are held within an HSM controlled b
 
 Once a transaction is balanced and all inputs are signed, it is considered valid and can be submitted to the blockchain. The local core will forward the transaction to the generator, which adds it to the blockchain and propagates it to other cores on the network.
 
-The Chain Core API does not return a response until either the transaction has been added to the blockchain and indexed by the local core, or there was an error. This allows you to write your programs in a linear fashion. In general, if a submission responds with success, the rest of your program may proceed with the guarantee that the transaction has been committed to the blockchain.
+The Chain Core API does not return a response until either the transaction has been added to the blockchain and indexed by the local core, or there was an error. This allows you to write your applications in a linear fashion. In general, if a submission responds with success, the rest of your application may proceed with the guarantee that the transaction has been committed to the blockchain.
 
 ## Examples
 
@@ -101,13 +101,13 @@ $code issue-within-core ../examples/java/TransactionBasics.java ../examples/ruby
 
 #### Between two Chain Cores
 
-First, Bob creates a control program in his account, which he can send to the issuer of gold.
+First, Bob creates a receiver in his account, which he can serialize and send to the issuer of gold.
 
-$code create-bob-issue-program ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
+$code create-bob-issue-receiver ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
 
-The issuer then builds, signs, and submits a transaction, sending gold to Bob's control program.
+The issuer then builds, signs, and submits a transaction, sending gold to Bob's receiver.
 
-$code issue-to-bob-program ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
+$code issue-to-bob-receiver ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
 
 ### Simple payment
 
@@ -119,11 +119,11 @@ $code pay-within-core ../examples/java/TransactionBasics.java ../examples/ruby/t
 
 #### Between two Chain Cores
 
-First, Bob creates a control program in his account, which he can send to Alice.
+First, Bob creates a receiver in his account, which he can serialize and send to Alice.
 
-$code create-bob-payment-program ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
+$code create-bob-payment-receiver ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
 
-Alice then builds, signs, and submits a transaction, sending gold to Bob's control program.
+Alice then builds, signs, and submits a transaction, sending gold to Bob's receiver.
 
 $code pay-between-cores ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
 
@@ -137,11 +137,11 @@ $code multiasset-within-core ../examples/java/TransactionBasics.java ../examples
 
 #### Between two Chain Cores
 
-First Bob creates a control program in his account, which he can send to Alice.
+Currently, the transaction builder API assigns each receiver to its own output, which means that a single receiver can only be used to receive single asset type. It's important for Bob not to re-use receivers, so he creates one for each asset payment he will receive. He serializes both and sends them to Alice.
 
-$code create-bob-multiasset-program ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
+$code create-bob-multiasset-receiver ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
 
-Alice then builds, signs, and submits a transaction, sending gold and silver to Bob's control program.
+Alice then builds, signs, and submits a transaction, sending gold and silver to Bob's receivers.
 
 $code multiasset-between-cores ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
 

--- a/docs/core/build-applications/transaction-basics.md
+++ b/docs/core/build-applications/transaction-basics.md
@@ -137,7 +137,7 @@ $code multiasset-within-core ../examples/java/TransactionBasics.java ../examples
 
 #### Between two Chain Cores
 
-Currently, the transaction builder API assigns each receiver to its own output, which means that a single receiver can only be used to receive single asset type. It's important for Bob not to re-use receivers, so he creates one for each asset payment he will receive. He serializes both and sends them to Alice.
+Currently, the transaction builder API assigns each receiver to its own output, which means that a single receiver can only be used to receive a single asset type. It's important for Bob not to re-use receivers, so he creates one for each asset payment he will receive. He serializes both and sends them to Alice.
 
 $code create-bob-multiasset-receiver ../examples/java/TransactionBasics.java ../examples/ruby/transaction_basics.rb ../examples/node/transactionBasics.js
 

--- a/docs/core/examples/java/Accounts.java
+++ b/docs/core/examples/java/Accounts.java
@@ -110,20 +110,21 @@ class Accounts {
     Transaction.submit(client, signedSpendingTransaction);
     // endsnippet
 
-    // snippet create-control-program
-    ControlProgram bobProgram = new ControlProgram.Builder()
-      .controlWithAccountByAlias("bob")
+    // snippet create-receiver
+    Receiver bobReceiver = new Account.ReceiverBuilder()
+      .setAccountAlias("bob")
       .create(client);
+    String bobReceiverSerialized = bobReceiver.toJson();
     // endsnippet
 
-    // snippet transfer-to-control-program
+    // snippet transfer-to-receiver
     Transaction.Template spendingTransaction2 = new Transaction.Builder()
       .addAction(new Transaction.Action.SpendFromAccount()
         .setAccountAlias("alice")
         .setAssetAlias("gold")
         .setAmount(10)
-      ).addAction(new Transaction.Action.ControlWithProgram()
-        .setControlProgram(bobProgram)
+      ).addAction(new Transaction.Action.ControlWithReceiver()
+        .setReceiver(Receiver.fromJson(bobReceiverSerialized))
         .setAssetAlias("gold")
         .setAmount(10)
       ).build(client);

--- a/docs/core/examples/java/Assets.java
+++ b/docs/core/examples/java/Assets.java
@@ -92,8 +92,8 @@ class Assets {
     Transaction.submit(client, signedIssuanceTransaction);
     // endsnippet
 
-    ControlProgram externalProgram = new ControlProgram.Builder()
-      .controlWithAccountByAlias("acme_treasury")
+    Receiver externalReceiver = new Account.ReceiverBuilder()
+      .setAccountAlias("acme_treasury")
       .create(client);
 
     // snippet external-issue
@@ -101,8 +101,8 @@ class Assets {
       .addAction(new Transaction.Action.Issue()
         .setAssetAlias("acme_preferred")
         .setAmount(2000)
-      ).addAction(new Transaction.Action.ControlWithProgram()
-        .setControlProgram(externalProgram)
+      ).addAction(new Transaction.Action.ControlWithReceiver()
+        .setReceiver(externalReceiver)
         .setAssetAlias("acme_preferred")
         .setAmount(2000)
       ).build(client);

--- a/docs/core/examples/java/ControlPrograms.java
+++ b/docs/core/examples/java/ControlPrograms.java
@@ -9,25 +9,26 @@ class ControlPrograms {
     Client client = new Client();
     setup(client);
 
-    // snippet create-control-program
-    ControlProgram aliceProgram = new ControlProgram.Builder()
-      .controlWithAccountByAlias("alice")
+    // snippet create-receiver
+    Receiver aliceReceiver = new Account.ReceiverBuilder()
+      .setAccountAlias("alice")
       .create(client);
+    String aliceReceiverSerialized = aliceReceiver.toJson();
     // endsnippet
 
     // snippet build-transaction
-    Transaction.Template paymentToProgram = new Transaction.Builder()
+    Transaction.Template paymentToReceiver = new Transaction.Builder()
       .addAction(new Transaction.Action.SpendFromAccount()
         .setAccountAlias("bob")
         .setAssetAlias("gold")
         .setAmount(10)
-      ).addAction(new Transaction.Action.ControlWithProgram()
-        .setControlProgram(aliceProgram.controlProgram)
+      ).addAction(new Transaction.Action.ControlWithReceiver()
+        .setReceiver(Receiver.fromJson(aliceReceiverSerialized))
         .setAssetAlias("gold")
         .setAmount(10)
       ).build(client);
 
-    Transaction.submit(client, HsmSigner.sign(paymentToProgram));
+    Transaction.submit(client, HsmSigner.sign(paymentToReceiver));
     // endsnippet
 
     // snippet retire

--- a/docs/core/examples/java/TransactionBasics.java
+++ b/docs/core/examples/java/TransactionBasics.java
@@ -26,26 +26,27 @@ class TransactionBasics {
     Transaction.submit(client, signedIssuance);
     // endsnippet
 
-    // snippet create-bob-issue-program
-    ControlProgram bobProgram = new ControlProgram.Builder()
-      .controlWithAccountByAlias("bob")
+    // snippet create-bob-issue-receiver
+    Receiver bobIssuanceReceiver = new Account.ReceiverBuilder()
+      .setAccountAlias("bob")
       .create(otherCoreClient);
+    String bobIssuanceReceiverSerialized = bobIssuanceReceiver.toJson();
     // endsnippet
 
-    // snippet issue-to-bob-program
-    Transaction.Template issuanceToProgram = new Transaction.Builder()
+    // snippet issue-to-bob-receiver
+    Transaction.Template issuanceToReceiver = new Transaction.Builder()
       .addAction(new Transaction.Action.Issue()
         .setAssetAlias("gold")
         .setAmount(10)
-      ).addAction(new Transaction.Action.ControlWithProgram()
-        .setControlProgram(bobProgram.controlProgram)
+      ).addAction(new Transaction.Action.ControlWithReceiver()
+        .setReceiver(Receiver.fromJson(bobIssuanceReceiverSerialized))
         .setAssetAlias("gold")
         .setAmount(10)
       ).build(client);
 
-    Transaction.Template signedIssuanceToProgram = HsmSigner.sign(issuanceToProgram);
+    Transaction.Template signedIssuanceToReceiver = HsmSigner.sign(issuanceToReceiver);
 
-    Transaction.submit(client, signedIssuanceToProgram);
+    Transaction.submit(client, signedIssuanceToReceiver);
     // endsnippet
 
     // snippet pay-within-core
@@ -65,27 +66,28 @@ class TransactionBasics {
     Transaction.submit(client, signedPayment);
     // endsnippet
 
-    // snippet create-bob-payment-program
-    bobProgram = new ControlProgram.Builder()
-      .controlWithAccountByAlias("bob")
+    // snippet create-bob-payment-receiver
+    Receiver bobPaymentReceiver = new Account.ReceiverBuilder()
+      .setAccountAlias("bob")
       .create(otherCoreClient);
+    String bobPaymentReceiverSerialized = bobPaymentReceiver.toJson();
     // endsnippet
 
     // snippet pay-between-cores
-    Transaction.Template paymentToProgram = new Transaction.Builder()
+    Transaction.Template paymentToReceiver = new Transaction.Builder()
       .addAction(new Transaction.Action.SpendFromAccount()
         .setAccountAlias("alice")
         .setAssetAlias("gold")
         .setAmount(10)
-      ).addAction(new Transaction.Action.ControlWithProgram()
-        .setControlProgram(bobProgram.controlProgram)
+      ).addAction(new Transaction.Action.ControlWithReceiver()
+        .setReceiver(Receiver.fromJson(bobPaymentReceiverSerialized))
         .setAssetAlias("gold")
         .setAmount(10)
       ).build(client);
 
-    Transaction.Template signedPaymentToProgram = HsmSigner.sign(paymentToProgram);
+    Transaction.Template signedPaymentToReceiver = HsmSigner.sign(paymentToReceiver);
 
-    Transaction.submit(client, signedPaymentToProgram);
+    Transaction.submit(client, signedPaymentToReceiver);
     // endsnippet
 
     if (client.equals(otherCoreClient)) {
@@ -115,14 +117,20 @@ class TransactionBasics {
       // endsnippet
     }
 
-    // snippet create-bob-multiasset-program
-    bobProgram = new ControlProgram.Builder()
-      .controlWithAccountByAlias("bob")
+    // snippet create-bob-multiasset-receiver
+    Receiver bobGoldReceiver = new Account.ReceiverBuilder()
+      .setAccountAlias("bob")
       .create(otherCoreClient);
+    String bobGoldReceiverSerialized = bobGoldReceiver.toJson();
+
+    Receiver bobSilverReceiver = new Account.ReceiverBuilder()
+      .setAccountAlias("bob")
+      .create(otherCoreClient);
+    String bobSilverReceiverSerialized = bobSilverReceiver.toJson();
     // endsnippet
 
     // snippet multiasset-between-cores
-    Transaction.Template multiAssetToProgram = new Transaction.Builder()
+    Transaction.Template multiAssetToReceiver = new Transaction.Builder()
       .addAction(new Transaction.Action.SpendFromAccount()
         .setAccountAlias("alice")
         .setAssetAlias("gold")
@@ -131,19 +139,19 @@ class TransactionBasics {
         .setAccountAlias("alice")
         .setAssetAlias("silver")
         .setAmount(20)
-      ).addAction(new Transaction.Action.ControlWithProgram()
-        .setControlProgram(bobProgram.controlProgram)
+      ).addAction(new Transaction.Action.ControlWithReceiver()
+        .setReceiver(Receiver.fromJson(bobGoldReceiverSerialized))
         .setAssetAlias("gold")
         .setAmount(10)
-      ).addAction(new Transaction.Action.ControlWithProgram()
-        .setControlProgram(bobProgram.controlProgram)
+      ).addAction(new Transaction.Action.ControlWithReceiver()
+        .setReceiver(Receiver.fromJson(bobSilverReceiverSerialized))
         .setAssetAlias("silver")
         .setAmount(20)
       ).build(client);
 
-    Transaction.Template signedMultiAssetToProgram = HsmSigner.sign(multiAssetToProgram);
+    Transaction.Template signedMultiAssetToReceiver = HsmSigner.sign(multiAssetToReceiver);
 
-    Transaction.submit(client, signedMultiAssetToProgram);
+    Transaction.submit(client, signedMultiAssetToReceiver);
     // endsnippet
 
     // snippet retire

--- a/docs/core/examples/node/accounts.js
+++ b/docs/core/examples/node/accounts.js
@@ -108,22 +108,24 @@ Promise.all([
     // endsnippet
   )
 }).then(() => {
-  // snippet create-control-program
-  const bobProgramPromise = client.accounts.createControlProgram({
-    alias: 'bob',
+  // snippet create-receiver
+  const bobReceiverSerializedPromise = client.accounts.createReceiver({
+    accountAlias: 'bob',
+  }).then(bobReceiver => {
+    return JSON.stringify(bobReceiver)
   })
   // endsnippet
 
-  return bobProgramPromise.then(bobProgram =>
-    // snippet transfer-to-control-program
+  return bobReceiverSerializedPromise.then(bobReceiverSerialized =>
+    // snippet transfer-to-receiver
     client.transactions.build(builder => {
       builder.spendFromAccount({
         accountAlias: 'alice',
         assetAlias: 'gold',
         amount: 10
       })
-      builder.controlWithProgram({
-        controlProgram: bobProgram.controlProgram,
+      builder.controlWithReceiver({
+        receiver: JSON.parse(bobReceiverSerialized),
         assetAlias: 'gold',
         amount: 10
       })

--- a/docs/core/examples/node/assets.js
+++ b/docs/core/examples/node/assets.js
@@ -100,19 +100,19 @@ Promise.all([
     // endsnippet
   )
 }).then(() => {
-  const externalProgramPromise = client.accounts.createControlProgram({
-    alias: 'acme_treasury',
+  const externalReceiverPromise = client.accounts.createReceiver({
+    accountAlias: 'acme_treasury',
   })
 
-  return externalProgramPromise.then(externalProgram =>
+  return externalReceiverPromise.then(externalReceiver =>
     // snippet external-issue
     client.transactions.build(builder => {
       builder.issue({
         assetAlias: 'acme_preferred',
         amount: 2000
       })
-      builder.controlWithProgram({
-        controlProgram: externalProgram.controlProgram,
+      builder.controlWithReceiver({
+        receiver: externalReceiver,
         assetAlias: 'acme_preferred',
         amount: 2000
       })

--- a/docs/core/examples/node/controlPrograms.js
+++ b/docs/core/examples/node/controlPrograms.js
@@ -41,14 +41,16 @@ client.mockHsm.keys.create().then(key => {
 ).then(
   signed => client.transactions.submit(signed)
 ).then(() => {
-  // snippet create-control-program
-  const aliceProgramPromise = client.accounts.createControlProgram({
-    alias: 'alice',
+  // snippet create-receiver
+  const aliceReceiverSerializedPromise = client.accounts.createReceiver({
+    accountAlias: 'alice',
+  }).then(aliceReceiver => {
+    return JSON.stringify(aliceReceiver)
   })
   // endsnippet
 
-  return aliceProgramPromise
-}).then(aliceProgram => {
+  return aliceReceiverSerializedPromise
+}).then(aliceReceiverSerialized => {
   // snippet build-transaction
   return client.transactions.build(builder => {
     builder.spendFromAccount({
@@ -56,8 +58,8 @@ client.mockHsm.keys.create().then(key => {
       assetAlias: 'gold',
       amount: 10
     })
-    builder.controlWithProgram({
-      controlProgram: aliceProgram.controlProgram,
+    builder.controlWithReceiver({
+      receiver: JSON.parse(aliceReceiverSerialized),
       assetAlias: 'gold',
       amount: 10
     })

--- a/docs/core/examples/ruby/accounts.rb
+++ b/docs/core/examples/ruby/accounts.rb
@@ -90,16 +90,21 @@ signed_spending_tx = signer.sign(spending_tx)
 chain.transactions.submit(signed_spending_tx)
 # endsnippet
 
-# snippet create-control-program
-bob_program = chain.accounts.create_control_program(
-  alias: 'bob'
-).control_program
+# snippet create-receiver
+bob_receiver = chain.accounts.create_receiver(
+  account_alias: 'bob'
+)
+bob_receiver_serialized = bob_receiver.to_json
 # endsnippet
 
-# snippet transfer-to-control-program
+# snippet transfer-to-receiver
 spending_tx2 = chain.transactions.build do |b|
   b.spend_from_account account_alias: 'alice', asset_alias: 'gold', amount: 10
-  b.control_with_program control_program: bob_program, asset_alias: 'gold', amount: 10
+  b.control_with_receiver(
+    receiver: JSON.parse(bob_receiver_serialized),
+    asset_alias: 'gold',
+    amount: 10
+  )
 end
 
 chain.transactions.submit(signer.sign(spending_tx2))

--- a/docs/core/examples/ruby/assets.rb
+++ b/docs/core/examples/ruby/assets.rb
@@ -82,14 +82,14 @@ signed_issuance_tx = signer.sign(issuance_tx)
 chain.transactions.submit(signed_issuance_tx)
 # endsnippet
 
-external_program = chain.accounts.create_control_program(
-  alias: 'acme_treasury'
-).control_program
+external_receiver = chain.accounts.create_receiver(
+  account_alias: 'acme_treasury'
+)
 
 # snippet external-issue
 external_issuance = chain.transactions.build do |b|
   b.issue asset_alias: 'acme_preferred', amount: 2000
-  b.control_with_program control_program: external_program, asset_alias: 'acme_preferred', amount: 2000
+  b.control_with_receiver receiver: external_receiver, asset_alias: 'acme_preferred', amount: 2000
 end
 
 chain.transactions.submit(signer.sign(external_issuance))

--- a/docs/core/examples/ruby/control_programs.rb
+++ b/docs/core/examples/ruby/control_programs.rb
@@ -39,7 +39,7 @@ alice_receiver_serialized = alice_receiver.to_json
 # endsnippet
 
 # snippet build-transaction
-payment_to_program = chain.transactions.build do |b|
+payment_to_receiver = chain.transactions.build do |b|
   b.spend_from_account account_alias: 'bob', asset_alias: 'gold', amount: 10
   b.control_with_receiver(
     receiver: JSON.parse(alice_receiver_serialized),
@@ -48,7 +48,7 @@ payment_to_program = chain.transactions.build do |b|
   )
 end
 
-chain.transactions.submit(signer.sign(payment_to_program))
+chain.transactions.submit(signer.sign(payment_to_receiver))
 # endsnippet
 
 # snippet retire

--- a/docs/core/examples/ruby/control_programs.rb
+++ b/docs/core/examples/ruby/control_programs.rb
@@ -31,16 +31,21 @@ end
 
 chain.transactions.submit(signer.sign(tx))
 
-# snippet create-control-program
-alice_program = chain.accounts.create_control_program(
-  alias: 'alice'
-).control_program
+# snippet create-receiver
+alice_receiver = chain.accounts.create_receiver(
+  account_alias: 'alice'
+)
+alice_receiver_serialized = alice_receiver.to_json
 # endsnippet
 
 # snippet build-transaction
 payment_to_program = chain.transactions.build do |b|
   b.spend_from_account account_alias: 'bob', asset_alias: 'gold', amount: 10
-  b.control_with_program control_program: alice_program, asset_alias: 'gold', amount: 10
+  b.control_with_receiver(
+    receiver: JSON.parse(alice_receiver_serialized),
+    asset_alias: 'gold',
+    amount: 10
+  )
 end
 
 chain.transactions.submit(signer.sign(payment_to_program))

--- a/docs/core/examples/ruby/transaction_basics.rb
+++ b/docs/core/examples/ruby/transaction_basics.rb
@@ -76,7 +76,7 @@ bob_payment_receiver_serialized = bob_payment_receiver.to_json
 # endsnippet
 
 # snippet pay-between-cores
-payment_to_program = chain.transactions.build do |b|
+payment_to_receiver = chain.transactions.build do |b|
   b.spend_from_account account_alias: 'alice', asset_alias: 'gold', amount: 10
   b.control_with_receiver(
     receiver: JSON.parse(bob_payment_receiver_serialized),
@@ -85,9 +85,9 @@ payment_to_program = chain.transactions.build do |b|
   )
 end
 
-signed_payment_to_program = signer.sign(payment_to_program)
+signed_payment_to_receiver = signer.sign(payment_to_receiver)
 
-chain.transactions.submit(signed_payment_to_program)
+chain.transactions.submit(signed_payment_to_receiver)
 # endsnippet
 
 if (chain.opts[:url] == other_core.opts[:url])
@@ -118,7 +118,7 @@ bob_silver_receiver_serialized = bob_silver_receiver.to_json
 # endsnippet
 
 # snippet multiasset-between-cores
-multi_asset_to_program = chain.transactions.build do |b|
+multi_asset_to_receiver = chain.transactions.build do |b|
   b.spend_from_account account_alias: 'alice', asset_alias: 'gold', amount: 10
   b.spend_from_account account_alias: 'alice', asset_alias: 'silver', amount: 20
   b.control_with_receiver(
@@ -133,9 +133,9 @@ multi_asset_to_program = chain.transactions.build do |b|
   )
 end
 
-signed_multi_asset_to_program = signer.sign(multi_asset_to_program)
+signed_multi_asset_to_receiver = signer.sign(multi_asset_to_receiver)
 
-chain.transactions.submit(signed_multi_asset_to_program)
+chain.transactions.submit(signed_multi_asset_to_receiver)
 # endsnippet
 
 # snippet retire

--- a/docs/core/examples/ruby/transaction_basics.rb
+++ b/docs/core/examples/ruby/transaction_basics.rb
@@ -33,21 +33,26 @@ signed_issuance = signer.sign(issuance)
 chain.transactions.submit(signed_issuance)
 # endsnippet
 
-# snippet create-bob-issue-program
-bob_program = other_core.accounts.create_control_program(
-  alias: 'bob'
-).control_program
+# snippet create-bob-issue-receiver
+bob_issuance_receiver = other_core.accounts.create_receiver(
+  account_alias: 'bob'
+)
+bob_issuance_receiver_serialized = bob_issuance_receiver.to_json
 # endsnippet
 
-# snippet issue-to-bob-program
-issuance_to_program = chain.transactions.build do |b|
+# snippet issue-to-bob-receiver
+issuance_to_receiver = chain.transactions.build do |b|
   b.issue asset_alias: 'gold', amount: 10
-  b.control_with_program control_program: bob_program, asset_alias: 'gold', amount: 10
+  b.control_with_receiver(
+    receiver: JSON.parse(bob_issuance_receiver_serialized),
+    asset_alias: 'gold',
+    amount: 10
+  )
 end
 
-signed_issuance_to_program = signer.sign(issuance_to_program)
+signed_issuance_to_receiver = signer.sign(issuance_to_receiver)
 
-chain.transactions.submit(signed_issuance_to_program)
+chain.transactions.submit(signed_issuance_to_receiver)
 # endsnippet
 
 if (chain.opts[:url] == other_core.opts[:url])
@@ -63,16 +68,21 @@ if (chain.opts[:url] == other_core.opts[:url])
   # endsnippet
 end
 
-# snippet create-bob-payment-program
-bob_program = other_core.accounts.create_control_program(
-  alias: 'bob'
-).control_program
+# snippet create-bob-payment-receiver
+bob_payment_receiver = other_core.accounts.create_receiver(
+  account_alias: 'bob'
+)
+bob_payment_receiver_serialized = bob_payment_receiver.to_json
 # endsnippet
 
 # snippet pay-between-cores
 payment_to_program = chain.transactions.build do |b|
   b.spend_from_account account_alias: 'alice', asset_alias: 'gold', amount: 10
-  b.control_with_program control_program: bob_program, asset_alias: 'gold', amount: 10
+  b.control_with_receiver(
+    receiver: JSON.parse(bob_payment_receiver_serialized),
+    asset_alias: 'gold',
+    amount: 10
+  )
 end
 
 signed_payment_to_program = signer.sign(payment_to_program)
@@ -95,18 +105,32 @@ if (chain.opts[:url] == other_core.opts[:url])
   # endsnippet
 end
 
-# snippet create-bob-multiasset-program
-bob_program = other_core.accounts.create_control_program(
-  alias: 'bob'
-).control_program
+# snippet create-bob-multiasset-receiver
+bob_gold_receiver = other_core.accounts.create_receiver(
+  account_alias: 'bob'
+)
+bob_gold_receiver_serialized = bob_gold_receiver.to_json
+
+bob_silver_receiver = other_core.accounts.create_receiver(
+  account_alias: 'bob'
+)
+bob_silver_receiver_serialized = bob_silver_receiver.to_json
 # endsnippet
 
 # snippet multiasset-between-cores
 multi_asset_to_program = chain.transactions.build do |b|
   b.spend_from_account account_alias: 'alice', asset_alias: 'gold', amount: 10
   b.spend_from_account account_alias: 'alice', asset_alias: 'silver', amount: 20
-  b.control_with_program control_program: bob_program, asset_alias: 'gold', amount: 10
-  b.control_with_program control_program: bob_program, asset_alias: 'silver', amount: 20
+  b.control_with_receiver(
+    receiver: JSON.parse(bob_gold_receiver_serialized),
+    asset_alias: 'gold',
+    amount: 10
+  )
+  b.control_with_receiver(
+    receiver: JSON.parse(bob_silver_receiver_serialized),
+    asset_alias: 'silver',
+    amount: 20
+  )
 end
 
 signed_multi_asset_to_program = signer.sign(multi_asset_to_program)


### PR DESCRIPTION
This commit updates the documentation so it uses receivers the first-class cross-core payment object; control programs are thusly deprecated. Both prose and code samples have been updated to educate users about receivers.