### PR TITLE
docs/core/examples/node: add gitignore

### DIFF
--- a/docs/core/examples/node/.gitignore
+++ b/docs/core/examples/node/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package.json

--- a/docs/core/examples/node/.gitignore
+++ b/docs/core/examples/node/.gitignore
@@ -1,2 +1,1 @@
 node_modules/
-package.json

--- a/docs/core/examples/node/package.json
+++ b/docs/core/examples/node/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "chain-sdk": "file:../../../../sdk/node"
+  }
+}


### PR DESCRIPTION
To test example files using the Node SDK, it's necessary to supply a
local package.json file. The associated node_modules folder should
be ignored.