### PR TITLE
protocol/patricia: adopt set semantics (not dict)

### DIFF
--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -49,7 +49,7 @@ func TestCancelReservation(t *testing.T) {
 
 	// Fake the output in the state tree.
 	_, s := c.State()
-	err = s.Tree.Insert(outputID.Hash[:], outputID.Hash[:])
+	err = s.Tree.Insert(outputID.Hash[:])
 	if err != nil {
 		t.Error(err)
 	}

--- a/core/txdb/snapshot.go
+++ b/core/txdb/snapshot.go
@@ -25,7 +25,7 @@ func DecodeSnapshot(data []byte) (*state.Snapshot, error) {
 
 	tree := new(patricia.Tree)
 	for _, node := range storedSnapshot.Nodes {
-		err = tree.Insert(node.Key, node.Key)
+		err = tree.Insert(node.Key)
 		if err != nil {
 			return nil, errors.Wrap(err, "reconstructing state tree")
 		}

--- a/core/txdb/snapshot_test.go
+++ b/core/txdb/snapshot_test.go
@@ -59,7 +59,7 @@ func TestReadWriteStateSnapshot(t *testing.T) {
 		t.Logf("Applying changeset %d\n", i)
 
 		for _, insert := range changeset.inserts {
-			err := snapshot.Tree.Insert(insert[:], insert[:])
+			err := snapshot.Tree.Insert(insert[:])
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -126,7 +126,7 @@ func benchmarkStoreSnapshot(nodes, issuances int, b *testing.B) {
 			b.Fatal(err)
 		}
 
-		err = snapshot.Tree.Insert(h[:], h[:])
+		err = snapshot.Tree.Insert(h[:])
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -1,11 +1,16 @@
-// Package patricia implements a patricia tree, or a radix
-// tree with a radix of 2 -- creating an uneven binary tree.
+// Package patricia computes the Merkle Patricia Tree Hash of a
+// set of bit strings, as described in the Chain Protocol spec.
+// See https://chain.com/docs/protocol/specifications/data#merkle-patricia-tree.
+// Because a patricia tree (a radix tree with a radix of 2)
+// provides efficient incremental updates, so does the Merkle
+// Patricia Tree Hash computation, making this structure suitable
+// for the blockchain full-state commitment.
 //
-// Each entry is a key value pair. The key determines
-// where the value is placed in the tree, with each bit
-// of the key indicating a path. Values are arbitrary byte
-// slices but only the SHA3-256 hash of the value is stored
-// within the tree.
+// Type Tree represents a set, where the elements are bit strings.
+// The set must be prefix-free -- no item can be a prefix of
+// any other -- enforced by Insert.
+// The length of each bit string must also be a multiple of eight,
+// simply because the interface uses []byte to represent an item.
 //
 // The nodes in the tree form an immutable persistent data
 // structure. It is okay to copy a Tree struct,
@@ -32,12 +37,12 @@ type Tree struct {
 	root *node
 }
 
-// WalkFunc is the type of the function called for each leaf
+// WalkFunc is the type of the function called for each item
 // visited by Walk. If an error is returned, processing stops.
-type WalkFunc func(k []byte) error
+type WalkFunc func(item []byte) error
 
-// Walk walks the patricia tree calling walkFn for each leaf in
-// the tree. If an error is returned by walkFn at any point,
+// Walk walks t calling walkFn for each item.
+// If an error is returned by walkFn at any point,
 // processing is stopped and the error is returned.
 func Walk(t *Tree, walkFn WalkFunc) error {
 	if t.root == nil {
@@ -60,8 +65,7 @@ func walk(n *node, walkFn WalkFunc) error {
 	return err
 }
 
-// Contains returns whether the tree contains (item, item)
-// as a (key, value) pair.
+// Contains returns whether t contains item.
 func (t *Tree) Contains(item []byte) bool {
 	if t.root == nil {
 		return false
@@ -94,17 +98,20 @@ func lookup(n *node, key []uint8) *node {
 	return lookup(n.children[bit], key)
 }
 
-// Insert enters data into the tree.
-// If the key is not already present in the tree,
-// a new node will be created and inserted,
-// rearranging the tree to the optimal structure.
-// If the key is present, the existing node is found
-// and its value is updated, leaving the structure of
-// the tree alone.
-// It is an error for bkey to be a prefix
-// of a key already in t or to contain a key already
-// in t as a prefix.
-func (t *Tree) Insert(bkey, val []byte) error {
+// Insert inserts item into t.
+//
+// It is an error for item to be a prefix of an element
+// already in t or to contain an element already in t
+// as a prefix.
+// If item itself is already in t, Insert does nothing
+// (and this is not an error).
+func (t *Tree) Insert(item []byte) error {
+	return t.insert(item, item)
+}
+
+// TODO(kr): rewrite tests to always use Insert
+// and remove the extra func
+func (t *Tree) insert(bkey, val []byte) error {
 	key := bitKey(bkey)
 
 	var hash bc.Hash
@@ -169,11 +176,9 @@ func insert(n *node, key []uint8, hash *bc.Hash) (*node, error) {
 	return newNode, nil
 }
 
-// Delete removes up to one value with a matching key.
-// After removing the node, it will rearrange the tree
-// to the optimal structure.
-func (t *Tree) Delete(bkey []byte) {
-	key := bitKey(bkey)
+// Delete removes item from t, if present.
+func (t *Tree) Delete(item []byte) {
+	key := bitKey(item)
 
 	if t.root != nil {
 		t.root = delete(t.root, key)
@@ -208,7 +213,7 @@ func delete(n *node, key []uint8) *node {
 	return newNode
 }
 
-// RootHash returns the merkle root of the tree.
+// RootHash returns the Merkle root of the tree.
 func (t *Tree) RootHash() bc.Hash {
 	root := t.root
 	if root == nil {

--- a/protocol/patricia/patricia.go
+++ b/protocol/patricia/patricia.go
@@ -10,7 +10,7 @@
 // The set must be prefix-free -- no item can be a prefix of
 // any other -- enforced by Insert.
 // The length of each bit string must also be a multiple of eight,
-// simply because the interface uses []byte to represent an item.
+// because the interface uses []byte to represent an item.
 //
 // The nodes in the tree form an immutable persistent data
 // structure. It is okay to copy a Tree struct,
@@ -101,8 +101,7 @@ func lookup(n *node, key []uint8) *node {
 // Insert inserts item into t.
 //
 // It is an error for item to be a prefix of an element
-// already in t or to contain an element already in t
-// as a prefix.
+// in t or to contain an element in t as a prefix.
 // If item itself is already in t, Insert does nothing
 // (and this is not an error).
 func (t *Tree) Insert(item []byte) error {

--- a/protocol/patricia/patricia_test.go
+++ b/protocol/patricia/patricia_test.go
@@ -27,7 +27,7 @@ func BenchmarkInserts(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			err = tr.Insert(h[:], h[:])
+			err = tr.Insert(h[:])
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -47,7 +47,7 @@ func BenchmarkInsertsRootHash(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			err = tr.Insert(h[:], h[:])
+			err = tr.Insert(h[:])
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -59,16 +59,16 @@ func BenchmarkInsertsRootHash(b *testing.B) {
 func TestRootHashBug(t *testing.T) {
 	tr := new(Tree)
 
-	err := tr.Insert([]byte{0x94}, []byte{0x01})
+	err := tr.insert([]byte{0x94}, []byte{0x01})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tr.Insert([]byte{0x36}, []byte{0x02})
+	err = tr.insert([]byte{0x36}, []byte{0x02})
 	if err != nil {
 		t.Fatal(err)
 	}
 	before := tr.RootHash()
-	err = tr.Insert([]byte{0xba}, []byte{0x03})
+	err = tr.insert([]byte{0xba}, []byte{0x03})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,30 +80,30 @@ func TestRootHashBug(t *testing.T) {
 func TestLeafVsInternalNodes(t *testing.T) {
 	tr0 := new(Tree)
 
-	err := tr0.Insert([]byte{0x01}, []byte{0x01})
+	err := tr0.Insert([]byte{0x01})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tr0.Insert([]byte{0x02}, []byte{0x02})
+	err = tr0.Insert([]byte{0x02})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tr0.Insert([]byte{0x03}, []byte{0x03})
+	err = tr0.Insert([]byte{0x03})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tr0.Insert([]byte{0x04}, []byte{0x04})
+	err = tr0.Insert([]byte{0x04})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Create a second tree using an internal node from tr1.
 	tr1 := new(Tree)
-	err = tr1.Insert([]byte{0x02}, mustDecodeHash("82b08f644c16985d2d9961b4104cc4bf4ba2be6bb5c3d0df2ecb94149f212fc9")) // this is an internal node of tr0
+	err = tr1.insert([]byte{0x02}, mustDecodeHash("82b08f644c16985d2d9961b4104cc4bf4ba2be6bb5c3d0df2ecb94149f212fc9")) // this is an internal node of tr0
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = tr1.Insert([]byte{0x04}, []byte{0x04})
+	err = tr1.Insert([]byte{0x04})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestRootHashInsertQuickCheck(t *testing.T) {
 	f := func(b [32]byte) bool {
 		before := tr.RootHash()
 		h := sha3.Sum256(b[:])
-		err := tr.Insert(b[:], h[:])
+		err := tr.insert(b[:], h[:])
 		keys = append(keys, b[:])
 		if err != nil {
 			return false
@@ -193,8 +193,8 @@ func TestLookup(t *testing.T) {
 
 func TestContains(t *testing.T) {
 	tr := new(Tree)
-	tr.Insert(bits("00000011"), bits("00000011"))
-	tr.Insert(bits("00000010"), bits("00000000")) // note different val
+	tr.Insert(bits("00000011"))
+	tr.insert(bits("00000010"), bits("00000000")) // note different val
 
 	if v := bits("00000011"); !tr.Contains(v) {
 		t.Errorf("expected tree to contain %x, but did not", v)
@@ -212,7 +212,7 @@ func TestInsert(t *testing.T) {
 	tr := new(Tree)
 	vals, hashes := makeVals(6)
 
-	tr.Insert(bits("11111111"), vals[0])
+	tr.insert(bits("11111111"), vals[0])
 	tr.RootHash()
 	want := &Tree{
 		root: &node{key: bools("11111111"), hash: &hashes[0], isLeaf: true},
@@ -223,7 +223,7 @@ func TestInsert(t *testing.T) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
-	tr.Insert(bits("11111111"), vals[1])
+	tr.insert(bits("11111111"), vals[1])
 	tr.RootHash()
 	want = &Tree{
 		root: &node{key: bools("11111111"), hash: &hashes[1], isLeaf: true},
@@ -233,7 +233,7 @@ func TestInsert(t *testing.T) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
-	tr.Insert(bits("11110000"), vals[2])
+	tr.insert(bits("11110000"), vals[2])
 	tr.RootHash()
 	want = &Tree{
 		root: &node{
@@ -250,7 +250,7 @@ func TestInsert(t *testing.T) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
-	tr.Insert(bits("11111100"), vals[3])
+	tr.insert(bits("11111100"), vals[3])
 	tr.RootHash()
 	want = &Tree{
 		root: &node{
@@ -273,7 +273,7 @@ func TestInsert(t *testing.T) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
-	tr.Insert(bits("11111110"), vals[4])
+	tr.insert(bits("11111110"), vals[4])
 	tr.RootHash()
 	want = &Tree{
 		root: &node{
@@ -304,7 +304,7 @@ func TestInsert(t *testing.T) {
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}
 
-	tr.Insert(bits("11111011"), vals[5])
+	tr.insert(bits("11111011"), vals[5])
 	tr.RootHash()
 	want = &Tree{
 		root: &node{

--- a/protocol/validation/tx.go
+++ b/protocol/validation/tx.go
@@ -281,7 +281,7 @@ func ApplyTx(snapshot *state.Snapshot, tx *bc.Tx) error {
 		}
 		// Insert new outputs into the state tree.
 		outputID := tx.OutputID(uint32(i))
-		err := snapshot.Tree.Insert(outputID.Hash[:], outputID.Hash[:])
+		err := snapshot.Tree.Insert(outputID.Hash[:])
 		if err != nil {
 			return err
 		}

--- a/protocol/validation/tx_test.go
+++ b/protocol/validation/tx_test.go
@@ -966,7 +966,7 @@ func TestConfirmTx(t *testing.T) {
 	outid1 := tx.OutputID(0)
 
 	snapshot := state.Empty()
-	err := snapshot.Tree.Insert(outid1.Hash[:], outid1.Hash[:])
+	err := snapshot.Tree.Insert(outid1.Hash[:])
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
With this change, Insert takes a single argument, the
data item to insert into the set; it no longer takes a
separate key and value. This brings the interface and
behavior up to date with the specification. We update
the package documentation and various parameter names
accordingly.