### PR TITLE
docs/protocol/specifications: require MPTH input to be prefix-free (redo)

### DIFF
--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -502,7 +502,7 @@ Note that we do not require the length of the input list to be a power of two. T
 
 The protocol uses a binary radix tree with variable-length branches to implement a *merkle patricia tree*. This tree structure is used for efficient concurrent updates of the [assets merkle root](#assets-merkle-root) and compact recency proofs for unspent outputs.
 
-The input to the *merkle patricia tree hash* (MPTH) is a list of data entries; these entries will be hashed to form the leaves of the merkle hash tree. The output is a single 32-byte hash value. The input list must be prefix-free; that is, no element may be a prefix of any other. Given a sorted list of n unique inputs, `D[n] = {d(0), d(1), ..., d(n-1)}`, the MPTH is thus defined as follows:
+The input to the *merkle patricia tree hash* (MPTH) is a list of data entries; these entries will be hashed to form the leaves of the merkle hash tree. The output is a single 32-byte hash value. The input list must be prefix-free; that is, no element can be a prefix of any other. Given a sorted list of n unique inputs, `D[n] = {d(0), d(1), ..., d(n-1)}`, the MPTH is thus defined as follows:
 
 The hash of an empty list is a 32-byte all-zero string:
 

--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -477,7 +477,7 @@ A top hash of a *merkle tree* (binary or patricia). Merkle roots are used within
 
 The protocol uses a binary merkle hash tree for efficient proofs of validity. The construction is from [RFC 6962 Section 2.1](https://tools.ietf.org/html/rfc6962#section-2.1), but using SHA3–256 instead of SHA2–256. It is reproduced here, edited to update the hashing algorithm.
 
-The input to the *merkle binary tree hash* (MBTH) is a list of data entries; these entries will be hashed to form the leaves of the merkle hash tree. The output is a single 32-byte hash value. The input list must be prefix-free; that is, no element may be a prefix of any other. Given an ordered list of n inputs, `D[n] = {d(0), d(1), ..., d(n-1)}`, the MBTH is thus defined as follows:
+The input to the *merkle binary tree hash* (MBTH) is a list of data entries; these entries will be hashed to form the leaves of the merkle hash tree. The output is a single 32-byte hash value. Given an ordered list of n inputs, `D[n] = {d(0), d(1), ..., d(n-1)}`, the MBTH is thus defined as follows:
 
 The hash of an empty list is the hash of an empty string:
 
@@ -502,7 +502,7 @@ Note that we do not require the length of the input list to be a power of two. T
 
 The protocol uses a binary radix tree with variable-length branches to implement a *merkle patricia tree*. This tree structure is used for efficient concurrent updates of the [assets merkle root](#assets-merkle-root) and compact recency proofs for unspent outputs.
 
-The input to the *merkle patricia tree hash* (MPTH) is a list of data entries; these entries will be hashed to form the leaves of the merkle hash tree. The output is a single 32-byte hash value. Given a sorted list of n unique inputs, `D[n] = {d(0), d(1), ..., d(n-1)}`, the MPTH is thus defined as follows:
+The input to the *merkle patricia tree hash* (MPTH) is a list of data entries; these entries will be hashed to form the leaves of the merkle hash tree. The output is a single 32-byte hash value. The input list must be prefix-free; that is, no element may be a prefix of any other. Given a sorted list of n unique inputs, `D[n] = {d(0), d(1), ..., d(n-1)}`, the MPTH is thus defined as follows:
 
 The hash of an empty list is a 32-byte all-zero string:
 


### PR DESCRIPTION
Commit a7bc90d2cb47fdebed2afd734c45d4285e8406bd
mistakenly edited the Merkle Binary Tree section when it
should have edited the Merkle Patricia Tree section. The
prefix-free requirement applies to the patricia tree
construction; the traditional (binary) Merkle tree has
no such requirement.

The description from the previous commit:

The Merkle Patricia Tree is only valid for a prefix-free
set. It is up to the environment applying this function
to ensure that property. The state commitment does so by
making all input elements of equal length (32 bytes).