### PR TITLE
docs/core/get-started: rename Mac app installer

### DIFF
--- a/docs/core/get-started/install.partial.html
+++ b/docs/core/get-started/install.partial.html
@@ -34,7 +34,7 @@
           <p>Download and run the <strong>Chain Core app</strong>.</p>
 
           <p>
-            <a href="https://download.chain.com/mac/Chain_Core.zip" onclick="track('download-app','mac')" class="downloadBtn btn success">
+            <a href="https://download.chain.com/mac/Chain_Core_Latest.zip" onclick="track('download-app','mac')" class="downloadBtn btn success">
               Download App
               <img src="/docs/images/download-icon.png" class="btn-icon icon-download">
             </a>


### PR DESCRIPTION
We'd like to use the "_Latest" suffix convention for our installer
downloads.