### PR TITLE
protocol/validation: pass only the pieces of state needed to ConfirmTx, not a whole block

### DIFF
--- a/protocol/block.go
+++ b/protocol/block.go
@@ -80,7 +80,7 @@ func (c *Chain) GenerateBlock(ctx context.Context, prev *bc.Block, snapshot *sta
 			continue
 		}
 
-		if validation.ConfirmTx(result, c.InitialBlockHash, b, tx) == nil {
+		if validation.ConfirmTx(result, c.InitialBlockHash, bc.NewBlockVersion, timestampMS, tx) == nil {
 			err = validation.ApplyTx(result, tx)
 			if err != nil {
 				return nil, nil, err

--- a/protocol/validation/block.go
+++ b/protocol/validation/block.go
@@ -74,7 +74,7 @@ func ValidateBlock(ctx context.Context, snapshot *state.Snapshot, initialBlockHa
 		// TODO(erykwalder): consider writing to a copy of the state tree
 		// of the one provided and make the caller call ApplyBlock as well
 		for _, tx := range block.Transactions {
-			err = ConfirmTx(snapshot, initialBlockHash, block, tx)
+			err = ConfirmTx(snapshot, initialBlockHash, block.Version, block.TimestampMS, tx)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This keeps us from having to pass an incompletely constructed block to ConfirmTx from Chain.GenerateBlock.