### PR TITLE
docker/ci: Add Rust tools to Dockerfile

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -20,6 +20,10 @@ RUN apk --no-cache add bash clang git g++ make nodejs openjdk8 python perl \
     && cd $(go env GOPATH)/src/github.com/GoASTScanner/gas \
     && git reset --hard d30c5cde3613e9ba0129febda849e4d4df1d57cd \
     && go install github.com/GoASTScanner/gas
+    && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2017-02-25
+    && ~/.cargo/bin/cargo install rustfmt
+    && ~/.cargo/bin/cargo install clippy
+    && ~/.cargo/bin/cargo install cargo-audit
 
 ADD bin /usr/bin
 ENV CHAIN ${GOPATH:-$HOME/go}/src/chain


### PR DESCRIPTION
Installs Rust nightly (locked to 2017-02-25 snapshot) via Rustup:

https://www.rustup.rs/

Also installs the following development tools:

- rustfmt: Lint syntax to ensure it follows standard style (ala gofmt)
- clippy: Lint for non-idiomatic Rust or other minor mistakes
- cargo-audit: Audit Cargo.lock for crates containing security vulnerabilities