### PR TITLE
protocol/tx: allow entryID to panic rather than return an error

### DIFF
--- a/protocol/bc/block.go
+++ b/protocol/bc/block.go
@@ -169,11 +169,7 @@ func (bh *BlockHeader) Value() (driver.Value, error) {
 
 // Hash returns complete hash of the block header.
 func (bh *BlockHeader) Hash() Hash {
-	h, err := BlockHeaderHashFunc(bh)
-	if err != nil {
-		panic(err)
-	}
-	return h
+	return BlockHeaderHashFunc(bh)
 }
 
 // MarshalText fulfills the json.Marshaler interface.

--- a/protocol/bc/txhashes.go
+++ b/protocol/bc/txhashes.go
@@ -39,4 +39,4 @@ func (t TxHashes) SigHash(n uint32) Hash {
 // BlockHeaderHashFunc is initialized to a function in protocol/tx
 // that can compute the hash of a blockheader. It is a variable here
 // to avoid a circular dependency between the bc and tx packages.
-var BlockHeaderHashFunc func(*BlockHeader) (Hash, error)
+var BlockHeaderHashFunc func(*BlockHeader) Hash

--- a/protocol/tx/entry.go
+++ b/protocol/tx/entry.go
@@ -25,7 +25,7 @@ type entry interface {
 
 var errInvalidValue = errors.New("invalid value")
 
-func entryID(e entry) (bc.Hash, error) {
+func entryID(e entry) bc.Hash {
 	h := sha3pool.Get256()
 	defer sha3pool.Put256(h)
 
@@ -37,7 +37,7 @@ func entryID(e entry) (bc.Hash, error) {
 	defer sha3pool.Put256(bh)
 	err := writeForHash(bh, e.Body())
 	if err != nil {
-		return bc.Hash{}, err
+		panic(err)
 	}
 	var innerHash bc.Hash
 	bh.Read(innerHash[:])
@@ -46,7 +46,7 @@ func entryID(e entry) (bc.Hash, error) {
 	var hash bc.Hash
 	h.Read(hash[:])
 
-	return hash, nil
+	return hash
 }
 
 func writeForHash(w io.Writer, c interface{}) error {

--- a/protocol/tx/transaction.go
+++ b/protocol/tx/transaction.go
@@ -10,9 +10,9 @@ import (
 
 func init() {
 	bc.TxHashesFunc = TxHashes
-	bc.BlockHeaderHashFunc = func(old *bc.BlockHeader) (bc.Hash, error) {
-		hash, _, err := mapBlockHeader(old)
-		return bc.Hash(hash), err
+	bc.BlockHeaderHashFunc = func(old *bc.BlockHeader) bc.Hash {
+		hash, _ := mapBlockHeader(old)
+		return hash
 	}
 }
 


### PR DESCRIPTION
Also, recover from the panic inside `mapTx` and turn it back into an error.