### PR TITLE
core/account: stop loading outpoints in reserve

### DIFF
--- a/core/account/reserve.go
+++ b/core/account/reserve.go
@@ -34,8 +34,7 @@ var (
 
 // utxo describes an individual account utxo.
 type utxo struct {
-	bc.Outpoint // TODO(oleg): remove this one
-	OutputID    bc.Hash
+	OutputID bc.Hash
 	bc.AssetAmount
 	ControlProgram []byte
 
@@ -381,18 +380,14 @@ func (sr *sourceReserver) refillCache(ctx context.Context) error {
 
 func findMatchingUTXOs(ctx context.Context, db pg.DB, src source, height uint64) ([]*utxo, error) {
 	const q = `
-		SELECT tx_hash, index, output_id, amount, control_program_index, control_program
+		SELECT output_id, amount, control_program_index, control_program
 		FROM account_utxos
 		WHERE account_id = $1 AND asset_id = $2 AND confirmed_in > $3
 	`
 	var utxos []*utxo
 	err := pg.ForQueryRows(ctx, db, q, src.AccountID, src.AssetID, height,
-		func(txHash bc.Hash, index uint32, oid bc.Hash, amount uint64, cpIndex uint64, controlProg []byte) {
+		func(oid bc.Hash, amount uint64, cpIndex uint64, controlProg []byte) {
 			utxos = append(utxos, &utxo{
-				Outpoint: bc.Outpoint{
-					Hash:  txHash,
-					Index: index,
-				},
 				OutputID: oid,
 				AssetAmount: bc.AssetAmount{
 					Amount:  amount,


### PR DESCRIPTION
Reserving UTXOs used to fetch the outpoint along with the output ID. The
outpoint is no longer used for anything.