### PR TITLE
dashboard: fix logo link in development

### DIFF
--- a/dashboard/src/utility/environment.js
+++ b/dashboard/src/utility/environment.js
@@ -12,7 +12,7 @@ if (process.env.NODE_ENV === 'production') {
   basename = '/dashboard'
 } else {
   apiHost = process.env.API_URL || 'http://localhost:3000/api'
-  basename = '/'
+  basename = ''
 }
 
 export const chainClient = () => new chainSdk.Client(


### PR DESCRIPTION
The react-router basename cannot end with a slash to correctly route the root path.