### PR TITLE
docs/protocol/specifications: Replace draft-irtf-cfrg-eddsa references with RFC 8032

### DIFF
--- a/docs/protocol/specifications/chainkd.md
+++ b/docs/protocol/specifications/chainkd.md
@@ -30,7 +30,7 @@ Features:
 1. Scheme is fully deterministic and allows producing complex hierarchies of keys from a single high-entropy seed.
 2. Derive private keys from extended private keys using “hardened derivation”.
 3. Derive public keys independently from private keys using “non-hardened derivation”.
-4. Hardened and non-hardened public keys and signatures are compatible with [EdDSA](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-08) specification.
+4. Hardened and non-hardened public keys and signatures are compatible with [EdDSA][RFC 8032] specification.
 5. Variable-length string selectors instead of fixed-length integer indexes.
 6. Short 64-byte extended public and private keys without special encoding.
 7. No metadata: an extended key carries only an additional 32-byte salt to avoid having the derivation function depend only on the key itself.
@@ -45,7 +45,7 @@ Features:
 
 **Secret scalar** is 32-byte string representing a 256-bit integer using little-endian convention.
 
-**Public key** is a 32-byte string representing a point on elliptic curve Ed25519 [CFRG].
+**Public key** is a 32-byte string representing a point on elliptic curve Ed25519 [RFC 8032].
 
 **Extended private key** (aka “xprv”) is a 64-byte string representing a key that can be used for deriving *child extended private and public keys*.
 
@@ -208,7 +208,7 @@ Knowledge of a parent extended public key and one of non-hardened derived extend
 **Output:** boolean value indicating if the signature is valid or not.
 
 1. Extract public key `pubkey` as first 32 bytes of `xpub`.
-2. Verify the EdDSA signature `(R,S)` over `message` using `pubkey` per [CFRG](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-08) substituting SHA512 hash function with Hash512 (which equals SHA512 in ChainKD-SHA2 instance thus retaining full compatibility with EdDSA verification procedure).
+2. Verify the EdDSA signature `(R,S)` over `message` using `pubkey` per [RFC 8032] substituting SHA512 hash function with Hash512 (which equals SHA512 in ChainKD-SHA2 instance thus retaining full compatibility with EdDSA verification procedure).
 
 
 ### Generate secret scalar
@@ -322,6 +322,8 @@ All values use hexadecimal encoding.
 
 ## References
 
-1. [CFRG](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-08)
+1. [RFC 8032]
 2. [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
 3. [LEB-128](https://developers.google.com/protocol-buffers/docs/encoding#varints)
+
+[RFC 8032]: https://tools.ietf.org/html/rfc8032

--- a/docs/protocol/specifications/data.md
+++ b/docs/protocol/specifications/data.md
@@ -78,12 +78,12 @@ A varstring31 whose content is the concatenation of other encoded data structure
 ### Public Key
 
 In this document, a *public key* is the 32-byte binary encoding
-of an Ed25519 (EdDSA) public key, as defined in [CFRG1](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-05).
+of an Ed25519 (EdDSA) public key, as defined in [RFC 8032].
 
 ### Signature
 
 In this document, a *signature* is the 64-byte binary encoding
-of an Ed25519 (EdDSA) signature, as defined in [CFRG1](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-05).
+of an Ed25519 (EdDSA) signature, as defined in [RFC 8032].
 
 
 ### SHA3
@@ -91,7 +91,7 @@ of an Ed25519 (EdDSA) signature, as defined in [CFRG1](https://tools.ietf.org/ht
 *SHA3* refers to the SHA3-256 function as defined in [FIPS202](https://dx.doi.org/10.6028/NIST.FIPS.202) with a fixed-length 32-byte output.
 
 This hash function is used throughout all data structures and algorithms in this spec,
-with the exception of SHA-512 (see [FIPS180](http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf)) used internally as function H inside Ed25519 (see [CFRG1](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-05)).
+with the exception of SHA-512 (see [FIPS180](http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf)) used internally as function H inside Ed25519 (see [RFC 8032]).
 
 ### Optional Hash
 
@@ -527,8 +527,8 @@ Note that the resulting merkle patricia tree may not be balanced; however, its s
 * [FIPS180] [“Secure Hash Standard”, United States of America, National Institute of Standards and Technology, Federal Information Processing Standard (FIPS) 180-2](http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf).
 * [FIPS202] [Federal Inf. Process. Stds. (NIST FIPS) - 202 (SHA3)](https://dx.doi.org/10.6028/NIST.FIPS.202)
 * [LEB128] [Little-Endian Base-128 Encoding](https://developers.google.com/protocol-buffers/docs/encoding)
-* [CFRG1] [Edwards-curve Digital Signature Algorithm (EdDSA) draft-irtf-cfrg-eddsa-05](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-05)
-* [RFC 6962](https://tools.ietf.org/html/rfc6962#section-2.1)
+* [RFC 6962]
+* [RFC 8032]
 
-
-
+[RFC 6962]: https://tools.ietf.org/html/rfc6962#section-2.1
+[RFC 8032]: https://tools.ietf.org/html/rfc8032

--- a/docs/protocol/specifications/vm1.md
+++ b/docs/protocol/specifications/vm1.md
@@ -1273,7 +1273,9 @@ The unassigned codes are reserved for future expansion and have no effect on the
 * [FIPS180] ["Secure Hash Standard", United States of America, National Institute of Standards and Technology, Federal Information Processing Standard (FIPS) 180-2](http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf).
 * [FIPS202] [Federal Inf. Process. Stds. (NIST FIPS) - 202 (SHA3)](https://dx.doi.org/10.6028/NIST.FIPS.202)
 * [LEB128] [Little-Endian Base-128 Encoding](https://developers.google.com/protocol-buffers/docs/encoding)
-* [CFRG1] [Edwards-curve Digital Signature Algorithm (EdDSA) draft-irtf-cfrg-eddsa-05](https://tools.ietf.org/html/draft-irtf-cfrg-eddsa-05)
-* [RFC 6962](https://tools.ietf.org/html/rfc6962#section-2.1)
+* [RFC 6962]
+* [RFC 8032] 
 
+[RFC 6962]: https://tools.ietf.org/html/rfc6962#section-2.1
+[RFC 8032]: https://tools.ietf.org/html/rfc8032
 


### PR DESCRIPTION
RFC 8032 has finally been published by the IETF, so we can stop citing the draft.