### PR TITLE
protocol/tx: add benchmarks for entryID

### DIFF
--- a/protocol/tx/entry_test.go
+++ b/protocol/tx/entry_test.go
@@ -2,67 +2,40 @@ package tx
 
 import (
 	"chain/protocol/bc"
+	"reflect"
 	"testing"
 	"time"
 )
 
-func BenchmarkEntryIDIssuance(b *testing.B) {
-	entry := newIssuance(bc.Hash{}, bc.AssetAmount{}, bc.Hash{}, 0)
-	for i := 0; i < b.N; i++ {
-		_ = entryID(entry)
+func BenchmarkEntryID(b *testing.B) {
+	entries := []entry{
+		newIssuance(bc.Hash{}, bc.AssetAmount{}, bc.Hash{}, 0),
+		newHeader(1, []bc.Hash{{}}, bc.Hash{}, uint64(time.Now().Unix()), uint64(time.Now().Unix())),
+		newMux([]valueSource{{
+			Ref:      bc.Hash{},
+			Value:    bc.AssetAmount{},
+			Position: 1,
+		}}, program{Code: []byte{1}, VMVersion: 1}),
+		newNonce(program{Code: []byte{1}, VMVersion: 1}, bc.Hash{}),
+		newOutput(valueSource{
+			Ref:      bc.Hash{},
+			Value:    bc.AssetAmount{},
+			Position: 1,
+		}, program{Code: []byte{1}, VMVersion: 1}, bc.Hash{}, 0),
+		newRetirement(valueSource{
+			Ref:      bc.Hash{},
+			Value:    bc.AssetAmount{},
+			Position: 1,
+		}, bc.Hash{}, 1),
+		newSpend(bc.Hash{}, bc.Hash{}, 0),
 	}
-}
 
-func BenchmarkEntryIDHeader(b *testing.B) {
-	entry := newHeader(1, []bc.Hash{{}}, bc.Hash{}, uint64(time.Now().Unix()), uint64(time.Now().Unix()))
-	for i := 0; i < b.N; i++ {
-		_ = entryID(entry)
-	}
-}
-
-func BenchmarkEntryIDMux(b *testing.B) {
-	entry := newMux([]valueSource{{
-		Ref:      bc.Hash{},
-		Value:    bc.AssetAmount{},
-		Position: 1,
-	}}, program{Code: []byte{1}, VMVersion: 1})
-	for i := 0; i < b.N; i++ {
-		_ = entryID(entry)
-	}
-}
-
-func BenchmarkEntryIDNonce(b *testing.B) {
-	entry := newNonce(program{Code: []byte{1}, VMVersion: 1}, bc.Hash{})
-	for i := 0; i < b.N; i++ {
-		_ = entryID(entry)
-	}
-}
-
-func BenchmarkEntryIDOutput(b *testing.B) {
-	entry := newOutput(valueSource{
-		Ref:      bc.Hash{},
-		Value:    bc.AssetAmount{},
-		Position: 1,
-	}, program{Code: []byte{1}, VMVersion: 1}, bc.Hash{}, 0)
-	for i := 0; i < b.N; i++ {
-		_ = entryID(entry)
-	}
-}
-
-func BenchmarkEntryIDRetirement(b *testing.B) {
-	entry := newRetirement(valueSource{
-		Ref:      bc.Hash{},
-		Value:    bc.AssetAmount{},
-		Position: 1,
-	}, bc.Hash{}, 1)
-	for i := 0; i < b.N; i++ {
-		_ = entryID(entry)
-	}
-}
-
-func BenchmarkEntryIDSpend(b *testing.B) {
-	entry := newSpend(bc.Hash{}, bc.Hash{}, 0)
-	for i := 0; i < b.N; i++ {
-		_ = entryID(entry)
+	for _, e := range entries {
+		name := reflect.TypeOf(e).Elem().Name()
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				entryID(e)
+			}
+		})
 	}
 }

--- a/protocol/tx/entry_test.go
+++ b/protocol/tx/entry_test.go
@@ -1,0 +1,68 @@
+package tx
+
+import (
+	"chain/protocol/bc"
+	"testing"
+	"time"
+)
+
+func BenchmarkEntryIDIssuance(b *testing.B) {
+	entry := newIssuance(bc.Hash{}, bc.AssetAmount{}, bc.Hash{}, 0)
+	for i := 0; i < b.N; i++ {
+		_ = entryID(entry)
+	}
+}
+
+func BenchmarkEntryIDHeader(b *testing.B) {
+	entry := newHeader(1, []bc.Hash{{}}, bc.Hash{}, uint64(time.Now().Unix()), uint64(time.Now().Unix()))
+	for i := 0; i < b.N; i++ {
+		_ = entryID(entry)
+	}
+}
+
+func BenchmarkEntryIDMux(b *testing.B) {
+	entry := newMux([]valueSource{{
+		Ref:      bc.Hash{},
+		Value:    bc.AssetAmount{},
+		Position: 1,
+	}}, program{Code: []byte{1}, VMVersion: 1})
+	for i := 0; i < b.N; i++ {
+		_ = entryID(entry)
+	}
+}
+
+func BenchmarkEntryIDNonce(b *testing.B) {
+	entry := newNonce(program{Code: []byte{1}, VMVersion: 1}, bc.Hash{})
+	for i := 0; i < b.N; i++ {
+		_ = entryID(entry)
+	}
+}
+
+func BenchmarkEntryIDOutput(b *testing.B) {
+	entry := newOutput(valueSource{
+		Ref:      bc.Hash{},
+		Value:    bc.AssetAmount{},
+		Position: 1,
+	}, program{Code: []byte{1}, VMVersion: 1}, bc.Hash{}, 0)
+	for i := 0; i < b.N; i++ {
+		_ = entryID(entry)
+	}
+}
+
+func BenchmarkEntryIDRetirement(b *testing.B) {
+	entry := newRetirement(valueSource{
+		Ref:      bc.Hash{},
+		Value:    bc.AssetAmount{},
+		Position: 1,
+	}, bc.Hash{}, 1)
+	for i := 0; i < b.N; i++ {
+		_ = entryID(entry)
+	}
+}
+
+func BenchmarkEntryIDSpend(b *testing.B) {
+	entry := newSpend(bc.Hash{}, bc.Hash{}, 0)
+	for i := 0; i < b.N; i++ {
+		_ = entryID(entry)
+	}
+}


### PR DESCRIPTION
Adds benchmarks for entryID across several types of entries.