### PR TITLE
errors: immediately return on nil error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -41,6 +41,10 @@ func Root(e error) error {
 // The argument stackSkip is the number of stack frames to ascend when
 // generating stack straces, where 0 is the caller of wrap.
 func wrap(err error, msg string, stackSkip int) error {
+	if err == nil {
+		return nil
+	}
+
 	werr, ok := err.(wrapperError)
 	if !ok {
 		werr.root = err

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -41,10 +41,6 @@ func Root(e error) error {
 // The argument stackSkip is the number of stack frames to ascend when
 // generating stack straces, where 0 is the caller of wrap.
 func wrap(err error, msg string, stackSkip int) error {
-	if err == nil {
-		return nil
-	}
-
 	werr, ok := err.(wrapperError)
 	if !ok {
 		werr.root = err
@@ -64,11 +60,17 @@ func wrap(err error, msg string, stackSkip int) error {
 // Use Stack to recover the stack trace.
 // Wrap returns nil if err is nil.
 func Wrap(err error, a ...interface{}) error {
+	if err == nil {
+		return nil
+	}
 	return wrap(err, fmt.Sprint(a...), 1)
 }
 
 // Wrapf is like Wrap, but arguments are handled as in fmt.Printf.
 func Wrapf(err error, format string, a ...interface{}) error {
+	if err == nil {
+		return nil
+	}
 	return wrap(err, fmt.Sprintf(format, a...), 1)
 }
 
@@ -138,6 +140,9 @@ func withData(err error, v map[string]interface{}) error {
 // Note that if err already has a data item of any other type,
 // it will not be accessible via the returned error value.
 func WithData(err error, keyval ...interface{}) error {
+	if err == nil {
+		return nil
+	}
 	// TODO(kr): add vet check for odd-length keyval and non-string keys
 	newkv := make(map[string]interface{})
 	for k, v := range Data(err) {


### PR DESCRIPTION
Previously, nil errors were detected later in the internal wrap
function. However, most of the callers would also perform unnecessary
work before calling wrap. This changes the callers to return early if
the error is nil.