### PR TITLE
all: update to Go 1.8

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
   "ImportPath": "chain",
-  "GoVersion": "go1.7",
+  "GoVersion": "go1.8",
   "Packages": [
     "./..."
   ],

--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ If you are interested in contributing to this code base, please read our [issue]
 
 ## Building from source
 
-* [Go](https://golang.org/doc/install) version 1.7, with $GOPATH set to your
+* [Go](https://golang.org/doc/install) version 1.8, with $GOPATH set to your
   preferred directory
 * Postgres (we suggest [Postgres.app](http://postgresapp.com/)),
   along with the [command line tools](http://postgresapp.com/documentation/cli-tools.html)

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.4-alpine
+FROM golang:1.8-alpine
 
 RUN apk --no-cache add bash clang git g++ make nodejs openjdk8 python perl \
     ruby ruby-bigdecimal ruby-bundler ruby-io-console ruby-irb ruby-json openssl ca-certificates \

--- a/docker/testbot/Dockerfile
+++ b/docker/testbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.4-alpine
+FROM golang:1.7.1-alpine
 ENV CHAIN /go/src/chain
 ENV DATABASE_URL postgres://testbot:@localhost/core?sslmode=disable
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk

--- a/docker/testbot/Dockerfile
+++ b/docker/testbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.1-alpine
+FROM golang:1.8-alpine
 ENV CHAIN /go/src/chain
 ENV DATABASE_URL postgres://testbot:@localhost/core?sslmode=disable
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk

--- a/docker/testbot/Dockerfile
+++ b/docker/testbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine
+FROM golang:1.7.4-alpine
 ENV CHAIN /go/src/chain
 ENV DATABASE_URL postgres://testbot:@localhost/core?sslmode=disable
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20170118
+box: chaindev/ci:20170301
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 


### PR DESCRIPTION
We can begin taking advantage of Go 1.8 features and bug-fixes in follow-up commits. See the PR discussion for some examples.