### PR TITLE
WIP docker: new docs image

### DIFF
--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,0 +1,10 @@
+FROM codequest/ruby-golang-java-nodejs
+
+RUN apt-get update
+RUN apt-get install -y git
+
+COPY startup.sh /startup.sh
+
+ENV CHAIN /go/src/chain
+ENV DOCS_DEST /generated
+ENTRYPOINT /startup.sh

--- a/docker/docs/README.md
+++ b/docker/docs/README.md
@@ -1,0 +1,14 @@
+This Docker image is used to generate the chain.com/docs website,
+and the documentation for individual SDKs.
+
+Build this WIP image with:
+
+```
+docker build -t docs-wip .
+```
+
+Run the image with an output directory mapped to `/generated` like below:
+
+```
+docker run -v /absolute/path/to/output:/generated docs-wip
+```

--- a/docker/docs/startup.sh
+++ b/docker/docs/startup.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Clone Chain Core
+git clone https://github.com/chain/chain.git $CHAIN
+cd $CHAIN
+
+# Install md2html
+go install chain/cmd/md2html
+
+# Build chain.com/docs
+git checkout cmd.cored-1.1.0
+cd $CHAIN/docs
+md2html $DOCS_DEST/docs
+
+# Build Java docs
+echo
+echo "Building Java SDK documentation..."
+
+cd $CHAIN/sdk/java
+git checkout sdk.java-1.1.0
+mvn javadoc:javadoc
+
+javadoc_dest_path=$DOCS_DEST/java
+mkdir -p $javadoc_dest_path
+cp -R target/site/apidocs/* $javadoc_dest_path
+
+# Build Ruby docs
+echo
+echo "Building Ruby SDK documentation..."
+
+cd $CHAIN/sdk/ruby
+git checkout sdk.ruby-1.1.0
+bundle
+bundle exec yardoc 'lib/**/*.rb'
+
+ruby_dest_path=$DOCS_DEST/ruby
+mkdir -p $ruby_dest_path
+cp -R doc/* $ruby_dest_path
+
+# Build Node docs
+echo
+echo "Building Node.js SDK documentation..."
+
+node_dest_path=$DOCS_DEST/node
+
+cd $CHAIN/sdk/node
+git checkout sdk.node-1.1.0
+npm install
+npm run docs
+mkdir -p $node_dest_path
+cp -R doc/* $node_dest_path


### PR DESCRIPTION
- [ ] Accept a version input (i.e. `1.1`) and pick the latest of each tag that matches
- [ ] Create `bin/` script that builds and runs this Docker image, uploads to S3 (some behavior in existing scripts)
- [ ] Speed up `git clone` - make sparse checkout + shallow clone work with tags
- [ ] Build Ruby, Go, Java, Nodejs from source instead of `codequest/ruby-golang-java-nodejs` image

more tbd