### PR TITLE
docs/internal: use hyphens for all tags/branches

### DIFF
--- a/docs/internal/package-tags-branches.md
+++ b/docs/internal/package-tags-branches.md
@@ -8,21 +8,21 @@
 - `chain-core-docker`: Docker image. Previously known as `docker.de`.
 - `chain-core-mac`: Mac app. Previously known as `installer.mac`.
 - `chain-core-windows`: Windows installer. Previously known as `installer.windows`.
-- `sdk.java`
-- `sdk.node`
-- `sdk.ruby`
+- `sdk-java`
+- `sdk-node`
+- `sdk-ruby`
 
 ## Basic scheme
 
 Every release has a **tag** that specifies the major, minor, and build versions, e.g.:
 
 - `chain-core-server-1.1.0`
-- `sdk.ruby-1.0.2`
+- `sdk-ruby-1.0.2`
 
 If a point release is necessary for a package, we should create a new major-minor version **branch** e.g.:
 
 - `chain-core-server-1.1.x`
-- `sdk.ruby-1.0.x`
+- `sdk-ruby-1.0.x`
 
 Note that there's a `.x` suffix to distinguish the branch name from the corresponding `.0` release.
 
@@ -31,4 +31,4 @@ Updates to these branches should be as conservative as possible.  Our [versionin
 Naturally, release tags should live on their relevant branches, e.g.:
 
 - `chain-core-server-1.1.0` is on the `chain-core-server-1.1.x` branch
-- `sdk.ruby-1.0.2` is on the `sdk.ruby-1.0.x` branch
+- `sdk-ruby-1.0.2` is on the `sdk-ruby-1.0.x` branch


### PR DESCRIPTION
For the future, it's easiest to use hyphens for word separators
in tag names, as opposed to a mix of hyphens and periods.