### PR TITLE
protocol/tx: add cross-entry pointers in parallel with their hashes

### DIFF
--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -255,21 +255,23 @@ func benchGenBlock(b *testing.B) {
 		"00" + // common witness extensible string length
 		"01" + // inputs count
 		"01" + // input 0, asset version
-		"4b" + // input 0, input commitment length prefix
-		"01" + // input 0, input commitment, "spend" type
-		"110bd1b4e5efc2994c9abc77f223a52c834d8f26b907c6c19d90b9e77a8e2fed" + // input 0, spend input commitment, output ID
-		"29" + // input 0, spend input commitment, output commitment length prefix
-		"0000000000000000000000000000000000000000000000000000000000000000" + // input 0, spend input commitment, output commitment, asset id
-		"80a094a58d1d" + // input 0, spend input commitment, output commitment, amount
-		"01" + // input 0, spend input commitment, output commitment, vm version
-		"0101" + // input 0, spend input commitment, output commitment, control program
+		"6c" + // input 0, input commitment length prefix
+		"01" + // input 0, input commitment, "spend" type+
+		"6a" + // input 0, spend input commitment, spend commitment length prefix
+		"dd385f6fe25d91d8c1bd0fa58951ad56b0c5229dcc01f61d9f9e8b9eb92d3292" + // input 0, spend input commitment, spend commitment, source ID
+		"0000000000000000000000000000000000000000000000000000000000000000" + // input 0, spend input commitment, spend commitment, asset id
+		"80a094a58d1d" + // input 0, spend input commitment, spend commitment, amount
+		"01" + // input 0, spend input commitment, spend commitment, source position
+		"01" + // input 0, spend input commitment, spend commitment, vm version
+		"0101" + // input 0, spend input commitment, spend commitment, control program
+		"0000000000000000000000000000000000000000000000000000000000000000" + // input 0, spend input commitment, spend commitment, reference data hash
 		"05696e707574" + // input 0, reference data
 		"01" + // input 0, input witness length prefix
 		"00" + // input 0, input witness, number of args
 		"02" + // outputs count
 		"01" + // output 0, asset version
 		"29" + // output 0, output commitment length
-		"9ed3e85a8c2d3717b5c94bd2db2ab9cab56955b2c4fb4696f345ca97aaab82d6" + // output 0, output commitment, asset id
+		"a9b2b6c5394888ab5396f583ae484b8459486b14268e2bef1b637440335eb6c1" + // output 0, output commitment, asset id
 		"80e0a596bb11" + // output 0, output commitment, amount
 		"01" + // output 0, output commitment, vm version
 		"0101" + // output 0, output commitment, control program
@@ -277,7 +279,7 @@ func benchGenBlock(b *testing.B) {
 		"00" + // output 0, output witness
 		"01" + // output 1, asset version
 		"29" + // output 1, output commitment length
-		"9ed3e85a8c2d3717b5c94bd2db2ab9cab56955b2c4fb4696f345ca97aaab82d6" + // output 1, output commitment, asset id
+		"a9b2b6c5394888ab5396f583ae484b8459486b14268e2bef1b637440335eb6c1" + // output 1, output commitment, asset id
 		"80c0ee8ed20b" + // output 1, output commitment, amount
 		"01" + // output 1, vm version
 		"0102" + // output 1, output commitment, control program

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -241,6 +241,7 @@ func dumpBlocks(ctx context.Context, t *testing.T, db pg.DB) {
 }
 
 func BenchmarkGenerateBlock(b *testing.B) {
+	b.Skip() // b.N reaches 50000 which can eventually kill the process on macosx
 	for i := 0; i < b.N; i++ {
 		benchGenBlock(b)
 	}

--- a/protocol/tx/entry.go
+++ b/protocol/tx/entry.go
@@ -25,13 +25,17 @@ type entry interface {
 
 var errInvalidValue = errors.New("invalid value")
 
-func entryID(e entry) bc.Hash {
-	h := sha3pool.Get256()
-	defer sha3pool.Put256(h)
+func entryID(e entry) (hash bc.Hash) {
+	if e == nil {
+		return hash
+	}
 
-	h.Write([]byte("entryid:"))
-	h.Write([]byte(e.Type()))
-	h.Write([]byte{':'})
+	hasher := sha3pool.Get256()
+	defer sha3pool.Put256(hasher)
+
+	hasher.Write([]byte("entryid:"))
+	hasher.Write([]byte(e.Type()))
+	hasher.Write([]byte{':'})
 
 	bh := sha3pool.Get256()
 	defer sha3pool.Put256(bh)
@@ -41,11 +45,9 @@ func entryID(e entry) bc.Hash {
 	}
 	var innerHash bc.Hash
 	bh.Read(innerHash[:])
-	h.Write(innerHash[:])
+	hasher.Write(innerHash[:])
 
-	var hash bc.Hash
-	h.Read(hash[:])
-
+	hasher.Read(hash[:])
 	return hash
 }
 

--- a/protocol/tx/entry_test.go
+++ b/protocol/tx/entry_test.go
@@ -8,26 +8,17 @@ import (
 )
 
 func BenchmarkEntryID(b *testing.B) {
+	m := newMux(program{Code: []byte{1}, VMVersion: 1})
+	m.addSourceID(bc.Hash{}, bc.AssetAmount{}, 1)
+
 	entries := []entry{
-		newIssuance(bc.Hash{}, bc.AssetAmount{}, bc.Hash{}, 0),
-		newHeader(1, []bc.Hash{{}}, bc.Hash{}, uint64(time.Now().Unix()), uint64(time.Now().Unix())),
-		newMux([]valueSource{{
-			Ref:      bc.Hash{},
-			Value:    bc.AssetAmount{},
-			Position: 1,
-		}}, program{Code: []byte{1}, VMVersion: 1}),
-		newNonce(program{Code: []byte{1}, VMVersion: 1}, bc.Hash{}),
-		newOutput(valueSource{
-			Ref:      bc.Hash{},
-			Value:    bc.AssetAmount{},
-			Position: 1,
-		}, program{Code: []byte{1}, VMVersion: 1}, bc.Hash{}, 0),
-		newRetirement(valueSource{
-			Ref:      bc.Hash{},
-			Value:    bc.AssetAmount{},
-			Position: 1,
-		}, bc.Hash{}, 1),
-		newSpend(bc.Hash{}, bc.Hash{}, 0),
+		newIssuance(nil, bc.AssetAmount{}, bc.Hash{}, 0),
+		newHeader(1, nil, bc.Hash{}, uint64(time.Now().Unix()), uint64(time.Now().Unix())),
+		m,
+		newNonce(program{Code: []byte{1}, VMVersion: 1}, nil),
+		newOutput(program{Code: []byte{1}, VMVersion: 1}, bc.Hash{}, 0),
+		newRetirement(bc.Hash{}, 1),
+		newSpend(newOutput(program{Code: []byte{1}, VMVersion: 1}, bc.Hash{}, 0), bc.Hash{}, 0),
 	}
 
 	for _, e := range entries {

--- a/protocol/tx/header.go
+++ b/protocol/tx/header.go
@@ -13,7 +13,7 @@ type header struct {
 
 	// Results contains (pointers to) the manifested entries for the
 	// items in body.Results.
-	Results []entry
+	Results []entry // each entry is *output or *retirement
 }
 
 func (header) Type() string         { return "txheader" }

--- a/protocol/tx/header.go
+++ b/protocol/tx/header.go
@@ -10,6 +10,10 @@ type header struct {
 		MinTimeMS, MaxTimeMS uint64
 		ExtHash              bc.Hash
 	}
+
+	// Results contains (pointers to) the manifested entries for the
+	// items in body.Results.
+	Results []entry
 }
 
 func (header) Type() string         { return "txheader" }
@@ -17,12 +21,20 @@ func (h *header) Body() interface{} { return h.body }
 
 func (header) Ordinal() int { return -1 }
 
-func newHeader(version uint64, results []bc.Hash, data bc.Hash, minTimeMS, maxTimeMS uint64) *header {
+func newHeader(version uint64, results []entry, data bc.Hash, minTimeMS, maxTimeMS uint64) *header {
 	h := new(header)
 	h.body.Version = version
-	h.body.Results = results
 	h.body.Data = data
 	h.body.MinTimeMS = minTimeMS
 	h.body.MaxTimeMS = maxTimeMS
+
+	if len(results) > 0 {
+		h.Results = results
+		h.body.Results = make([]bc.Hash, 0, len(results))
+		for _, r := range results {
+			h.body.Results = append(h.body.Results, entryID(r))
+		}
+	}
+
 	return h
 }

--- a/protocol/tx/header.go
+++ b/protocol/tx/header.go
@@ -28,12 +28,9 @@ func newHeader(version uint64, results []entry, data bc.Hash, minTimeMS, maxTime
 	h.body.MinTimeMS = minTimeMS
 	h.body.MaxTimeMS = maxTimeMS
 
-	if len(results) > 0 {
-		h.Results = results
-		h.body.Results = make([]bc.Hash, 0, len(results))
-		for _, r := range results {
-			h.body.Results = append(h.body.Results, entryID(r))
-		}
+	h.Results = results
+	for _, r := range results {
+		h.body.Results = append(h.body.Results, entryID(r))
 	}
 
 	return h

--- a/protocol/tx/issuance.go
+++ b/protocol/tx/issuance.go
@@ -10,6 +10,10 @@ type issuance struct {
 		ExtHash bc.Hash
 	}
 	ordinal int
+
+	// Anchor is a pointer to the manifested entry corresponding to
+	// body.Anchor.
+	Anchor entry
 }
 
 func (issuance) Type() string           { return "issuance1" }
@@ -17,9 +21,12 @@ func (iss *issuance) Body() interface{} { return iss.body }
 
 func (iss issuance) Ordinal() int { return iss.ordinal }
 
-func newIssuance(anchor bc.Hash, value bc.AssetAmount, data bc.Hash, ordinal int) *issuance {
+func newIssuance(anchor entry, value bc.AssetAmount, data bc.Hash, ordinal int) *issuance {
 	iss := new(issuance)
-	iss.body.Anchor = anchor
+	if anchor != nil {
+		iss.body.Anchor = entryID(anchor)
+		iss.Anchor = anchor
+	}
 	iss.body.Value = value
 	iss.body.Data = data
 	iss.ordinal = ordinal

--- a/protocol/tx/issuance.go
+++ b/protocol/tx/issuance.go
@@ -23,10 +23,8 @@ func (iss issuance) Ordinal() int { return iss.ordinal }
 
 func newIssuance(anchor entry, value bc.AssetAmount, data bc.Hash, ordinal int) *issuance {
 	iss := new(issuance)
-	if anchor != nil {
-		iss.body.Anchor = entryID(anchor)
-		iss.Anchor = anchor
-	}
+	iss.body.Anchor = entryID(anchor)
+	iss.Anchor = anchor
 	iss.body.Value = value
 	iss.body.Data = data
 	iss.ordinal = ordinal

--- a/protocol/tx/issuance.go
+++ b/protocol/tx/issuance.go
@@ -13,7 +13,7 @@ type issuance struct {
 
 	// Anchor is a pointer to the manifested entry corresponding to
 	// body.Anchor.
-	Anchor entry
+	Anchor entry // *nonce or *spend
 }
 
 func (issuance) Type() string           { return "issuance1" }

--- a/protocol/tx/map.go
+++ b/protocol/tx/map.go
@@ -33,8 +33,10 @@ func mapTx(tx *bc.TxData) (headerID bc.Hash, hdr *header, entryMap map[bc.Hash]e
 
 	for i, inp := range tx.Inputs {
 		if oldSp, ok := inp.TypedInput.(*bc.SpendInput); ok {
-			sp := newSpend(hashData(inp.ReferenceData), i)
-			sp.setSpentInfo(oldSp.SpentOutputID, oldSp.AssetAmount, program{VMVersion: oldSp.VMVersion, Code: oldSp.ControlProgram})
+			prog := program{VMVersion: oldSp.VMVersion, Code: oldSp.ControlProgram}
+			out := newOutput(prog, oldSp.RefDataHash, 0) // ordinal doesn't matter for prevouts, only for result outputs
+			out.setSourceID(oldSp.SourceID, oldSp.AssetAmount, oldSp.SourcePosition)
+			sp := newSpend(out, hashData(inp.ReferenceData), i)
 			var id bc.Hash
 			id, err = addEntry(sp)
 			if err != nil {

--- a/protocol/tx/map.go
+++ b/protocol/tx/map.go
@@ -13,7 +13,7 @@ import (
 func mapTx(tx *bc.TxData) (headerID bc.Hash, hdr *header, entryMap map[bc.Hash]entry, err error) {
 	entryMap = make(map[bc.Hash]entry)
 
-	addEntry := func(e entry) (id bc.Hash, entry entry, err error) {
+	addEntry := func(e entry) (id bc.Hash, err error) {
 		defer func() {
 			if pErr, ok := recover().(error); ok {
 				err = pErr
@@ -21,35 +21,32 @@ func mapTx(tx *bc.TxData) (headerID bc.Hash, hdr *header, entryMap map[bc.Hash]e
 		}()
 		id = entryID(e)
 		entryMap[id] = e
-		return id, e, err
+		return id, err
 	}
 
 	// Loop twice over tx.Inputs, once for spends and once for
 	// issuances.  Do spends first so the entry ID of the first spend is
 	// available in case an issuance needs it for its anchor.
 
-	var firstSpendID *bc.Hash
+	var firstSpend *spend
 	muxSources := make([]valueSource, len(tx.Inputs))
 
 	for i, inp := range tx.Inputs {
 		if oldSp, ok := inp.TypedInput.(*bc.SpendInput); ok {
-			var spentOutputID bc.Hash
-			spentOutputID, err = ComputeOutputID(&oldSp.SpendCommitment)
-			if err != nil {
-				return
-			}
-			var spID bc.Hash
-			spID, _, err = addEntry(newSpend(spentOutputID, hashData(inp.ReferenceData), i))
+			sp := newSpend(hashData(inp.ReferenceData), i)
+			sp.setSpentInfo(oldSp.AssetAmount, program{VMVersion: oldSp.VMVersion, Code: oldSp.ControlProgram})
+			var id bc.Hash
+			id, err = addEntry(sp)
 			if err != nil {
 				err = errors.Wrapf(err, "adding spend entry for input %d", i)
 				return
 			}
 			muxSources[i] = valueSource{
-				Ref:   spID,
+				Ref:   id,
 				Value: oldSp.AssetAmount,
 			}
-			if firstSpendID == nil {
-				firstSpendID = &spID
+			if firstSpend == nil {
+				firstSpend = sp
 			}
 		}
 	}
@@ -60,17 +57,17 @@ func mapTx(tx *bc.TxData) (headerID bc.Hash, hdr *header, entryMap map[bc.Hash]e
 			// programs are omitted here because they do not contribute to
 			// the body hash of an issuance.
 
-			var nonceHash bc.Hash
+			var nonce entry
 
 			if len(oldIss.Nonce) == 0 {
-				if firstSpendID == nil {
+				if firstSpend == nil {
 					err = fmt.Errorf("nonce-less issuance in transaction with no spends")
 					return
 				}
-				nonceHash = *firstSpendID
+				nonce = firstSpend
 			} else {
-				var trID bc.Hash
-				trID, _, err = addEntry(newTimeRange(tx.MinTime, tx.MaxTime))
+				tr := newTimeRange(tx.MinTime, tx.MaxTime)
+				_, err = addEntry(tr)
 				if err != nil {
 					err = errors.Wrapf(err, "adding timerange entry for input %d", i)
 					return
@@ -80,7 +77,8 @@ func mapTx(tx *bc.TxData) (headerID bc.Hash, hdr *header, entryMap map[bc.Hash]e
 				b := vmutil.NewBuilder()
 				b = b.AddData(oldIss.Nonce).AddOp(vm.OP_DROP).AddOp(vm.OP_ASSET).AddData(assetID[:]).AddOp(vm.OP_EQUAL)
 
-				nonceHash, _, err = addEntry(newNonce(program{1, b.Program}, trID))
+				nonce = newNonce(program{1, b.Program}, tr)
+				_, err = addEntry(nonce)
 				if err != nil {
 					err = errors.Wrapf(err, "adding nonce entry for input %d", i)
 					return
@@ -89,8 +87,9 @@ func mapTx(tx *bc.TxData) (headerID bc.Hash, hdr *header, entryMap map[bc.Hash]e
 
 			val := inp.AssetAmount()
 
+			iss := newIssuance(nonce, val, hashData(inp.ReferenceData), i)
 			var issID bc.Hash
-			issID, _, err = addEntry(newIssuance(nonceHash, val, hashData(inp.ReferenceData), i))
+			issID, err = addEntry(iss)
 			if err != nil {
 				err = errors.Wrapf(err, "adding issuance entry for input %d", i)
 				return
@@ -103,50 +102,52 @@ func mapTx(tx *bc.TxData) (headerID bc.Hash, hdr *header, entryMap map[bc.Hash]e
 		}
 	}
 
-	muxID, _, err := addEntry(newMux(muxSources, program{VMVersion: 1, Code: []byte{byte(vm.OP_TRUE)}}))
+	mux := newMux(program{VMVersion: 1, Code: []byte{byte(vm.OP_TRUE)}})
+	for _, src := range muxSources {
+		// xxx addSource will recompute the hash of entryMap[src.Ref], which is available as src.Ref - fix this
+		mux.addSource(entryMap[src.Ref], src.Value, src.Position)
+	}
+	_, err = addEntry(mux)
 	if err != nil {
 		err = errors.Wrap(err, "adding mux entry")
 		return
 	}
 
-	var results []bc.Hash
+	var results []entry
 
 	for i, out := range tx.Outputs {
-		s := valueSource{
-			Ref:      muxID,
-			Position: uint64(i),
-			Value:    out.AssetAmount,
-		}
-
-		var resultID bc.Hash
 		if vmutil.IsUnspendable(out.ControlProgram) {
 			// retirement
-			resultID, _, err = addEntry(newRetirement(s, hashData(out.ReferenceData), i))
+			r := newRetirement(hashData(out.ReferenceData), i)
+			r.setSource(mux, out.AssetAmount, uint64(i))
+			_, err = addEntry(r)
 			if err != nil {
 				err = errors.Wrapf(err, "adding retirement entry for output %d", i)
 				return
 			}
+			results = append(results, r)
 		} else {
 			// non-retirement
 			prog := program{out.VMVersion, out.ControlProgram}
-			resultID, _, err = addEntry(newOutput(s, prog, hashData(out.ReferenceData), i))
+			o := newOutput(prog, hashData(out.ReferenceData), i)
+			o.setSource(mux, out.AssetAmount, uint64(i))
+			_, err = addEntry(o)
 			if err != nil {
 				err = errors.Wrapf(err, "adding output entry for output %d", i)
 				return
 			}
+			results = append(results, o)
 		}
-
-		results = append(results, resultID)
 	}
 
-	var h entry
-	headerID, h, err = addEntry(newHeader(tx.Version, results, hashData(tx.ReferenceData), tx.MinTime, tx.MaxTime))
+	h := newHeader(tx.Version, results, hashData(tx.ReferenceData), tx.MinTime, tx.MaxTime)
+	headerID, err = addEntry(h)
 	if err != nil {
 		err = errors.Wrap(err, "adding header entry")
 		return
 	}
 
-	return headerID, h.(*header), entryMap, nil
+	return headerID, h, entryMap, nil
 }
 
 func mapBlockHeader(old *bc.BlockHeader) (bhID bc.Hash, bh *blockHeader) {

--- a/protocol/tx/map.go
+++ b/protocol/tx/map.go
@@ -34,7 +34,7 @@ func mapTx(tx *bc.TxData) (headerID bc.Hash, hdr *header, entryMap map[bc.Hash]e
 	for i, inp := range tx.Inputs {
 		if oldSp, ok := inp.TypedInput.(*bc.SpendInput); ok {
 			sp := newSpend(hashData(inp.ReferenceData), i)
-			sp.setSpentInfo(oldSp.AssetAmount, program{VMVersion: oldSp.VMVersion, Code: oldSp.ControlProgram})
+			sp.setSpentInfo(oldSp.SpentOutputID, oldSp.AssetAmount, program{VMVersion: oldSp.VMVersion, Code: oldSp.ControlProgram})
 			var id bc.Hash
 			id, err = addEntry(sp)
 			if err != nil {
@@ -104,7 +104,9 @@ func mapTx(tx *bc.TxData) (headerID bc.Hash, hdr *header, entryMap map[bc.Hash]e
 
 	mux := newMux(program{VMVersion: 1, Code: []byte{byte(vm.OP_TRUE)}})
 	for _, src := range muxSources {
-		// xxx addSource will recompute the hash of entryMap[src.Ref], which is available as src.Ref - fix this
+		// TODO(bobg): addSource will recompute the hash of
+		// entryMap[src.Ref], which is already available as src.Ref - fix
+		// this (and a number of other such places)
 		mux.addSource(entryMap[src.Ref], src.Value, src.Position)
 	}
 	_, err = addEntry(mux)

--- a/protocol/tx/mux.go
+++ b/protocol/tx/mux.go
@@ -11,7 +11,7 @@ type mux struct {
 
 	// Sources contains (pointers to) the manifested entries for each
 	// body.Sources[i].Ref.
-	Sources []entry
+	Sources []entry // each entry is *issuance, *spend, or *mux
 }
 
 func (mux) Type() string         { return "mux1" }

--- a/protocol/tx/mux.go
+++ b/protocol/tx/mux.go
@@ -26,11 +26,16 @@ func newMux(program program) *mux {
 }
 
 func (m *mux) addSource(e entry, value bc.AssetAmount, position uint64) {
+	m.addSourceID(entryID(e), value, position)
+	m.Sources[len(m.Sources)-1] = e
+}
+
+func (m *mux) addSourceID(sourceID bc.Hash, value bc.AssetAmount, position uint64) {
 	src := valueSource{
-		Ref:      entryID(e),
+		Ref:      sourceID,
 		Value:    value,
 		Position: position,
 	}
 	m.body.Sources = append(m.body.Sources, src)
-	m.Sources = append(m.Sources, e)
+	m.Sources = append(m.Sources, nil)
 }

--- a/protocol/tx/mux.go
+++ b/protocol/tx/mux.go
@@ -8,6 +8,10 @@ type mux struct {
 		Program program
 		ExtHash bc.Hash
 	}
+
+	// Sources contains (pointers to) the manifested entries for each
+	// body.Sources[i].Ref.
+	Sources []entry
 }
 
 func (mux) Type() string         { return "mux1" }
@@ -15,9 +19,18 @@ func (m *mux) Body() interface{} { return m.body }
 
 func (mux) Ordinal() int { return -1 }
 
-func newMux(sources []valueSource, program program) *mux {
+func newMux(program program) *mux {
 	m := new(mux)
-	m.body.Sources = sources
 	m.body.Program = program
 	return m
+}
+
+func (m *mux) addSource(e entry, value bc.AssetAmount, position uint64) {
+	src := valueSource{
+		Ref:      entryID(e),
+		Value:    value,
+		Position: position,
+	}
+	m.body.Sources = append(m.body.Sources, src)
+	m.Sources = append(m.Sources, e)
 }

--- a/protocol/tx/nonce.go
+++ b/protocol/tx/nonce.go
@@ -22,9 +22,7 @@ func (nonce) Ordinal() int { return -1 }
 func newNonce(p program, tr *timeRange) *nonce {
 	n := new(nonce)
 	n.body.Program = p
-	if tr != nil {
-		n.body.TimeRange = entryID(tr)
-		n.TimeRange = tr
-	}
+	n.body.TimeRange = entryID(tr)
+	n.TimeRange = tr
 	return n
 }

--- a/protocol/tx/nonce.go
+++ b/protocol/tx/nonce.go
@@ -8,6 +8,10 @@ type nonce struct {
 		TimeRange bc.Hash
 		ExtHash   bc.Hash
 	}
+
+	// TimeRange contains (a pointer to) the manifested entry
+	// corresponding to body.TimeRange.
+	TimeRange *timeRange
 }
 
 func (nonce) Type() string         { return "nonce1" }
@@ -15,9 +19,12 @@ func (n *nonce) Body() interface{} { return n.body }
 
 func (nonce) Ordinal() int { return -1 }
 
-func newNonce(p program, tr bc.Hash) *nonce {
+func newNonce(p program, tr *timeRange) *nonce {
 	n := new(nonce)
 	n.body.Program = p
-	n.body.TimeRange = tr
+	if tr != nil {
+		n.body.TimeRange = entryID(tr)
+		n.TimeRange = tr
+	}
 	return n
 }

--- a/protocol/tx/output.go
+++ b/protocol/tx/output.go
@@ -13,7 +13,7 @@ type output struct {
 
 	// Source contains (a pointer to) the manifested entry corresponding
 	// to body.Source.
-	Source entry
+	Source entry // *issuance, *spend, or *mux
 }
 
 func (output) Type() string         { return "output1" }

--- a/protocol/tx/output.go
+++ b/protocol/tx/output.go
@@ -29,11 +29,19 @@ func newOutput(controlProgram program, data bc.Hash, ordinal int) *output {
 	return out
 }
 
+// setSource is for when you have a complete source entry (e.g. a
+// *mux) for an output. When you don't (you only have the ID of the
+// source), use setSourceID, below.
 func (o *output) setSource(e entry, value bc.AssetAmount, position uint64) {
+	o.setSourceID(entryID(e), value, position)
+	o.Source = e
+}
+
+func (o *output) setSourceID(sourceID bc.Hash, value bc.AssetAmount, position uint64) {
 	o.body.Source = valueSource{
-		Ref:      entryID(e),
+		Ref:      sourceID,
 		Value:    value,
 		Position: position,
 	}
-	o.Source = e
+	o.Source = nil
 }

--- a/protocol/tx/output.go
+++ b/protocol/tx/output.go
@@ -10,6 +10,10 @@ type output struct {
 		ExtHash        bc.Hash
 	}
 	ordinal int
+
+	// Source contains (a pointer to) the manifested entry corresponding
+	// to body.Source.
+	Source entry
 }
 
 func (output) Type() string         { return "output1" }
@@ -17,11 +21,19 @@ func (o *output) Body() interface{} { return o.body }
 
 func (o output) Ordinal() int { return o.ordinal }
 
-func newOutput(source valueSource, controlProgram program, data bc.Hash, ordinal int) *output {
+func newOutput(controlProgram program, data bc.Hash, ordinal int) *output {
 	out := new(output)
-	out.body.Source = source
 	out.body.ControlProgram = controlProgram
 	out.body.Data = data
 	out.ordinal = ordinal
 	return out
+}
+
+func (o *output) setSource(e entry, value bc.AssetAmount, position uint64) {
+	o.body.Source = valueSource{
+		Ref:      entryID(e),
+		Value:    value,
+		Position: position,
+	}
+	o.Source = e
 }

--- a/protocol/tx/retirement.go
+++ b/protocol/tx/retirement.go
@@ -28,10 +28,15 @@ func newRetirement(data bc.Hash, ordinal int) *retirement {
 }
 
 func (r *retirement) setSource(e entry, value bc.AssetAmount, position uint64) {
+	r.setSourceID(entryID(e), value, position)
+	r.Source = e
+}
+
+func (r *retirement) setSourceID(sourceID bc.Hash, value bc.AssetAmount, position uint64) {
 	r.body.Source = valueSource{
-		Ref:      entryID(e),
+		Ref:      sourceID,
 		Value:    value,
 		Position: position,
 	}
-	r.Source = e
+	r.Source = nil
 }

--- a/protocol/tx/retirement.go
+++ b/protocol/tx/retirement.go
@@ -12,7 +12,7 @@ type retirement struct {
 
 	// Source contains (a pointer to) the manifested entry corresponding
 	// to body.Source.
-	Source entry
+	Source entry // *issuance, *spend, or *mux
 }
 
 func (retirement) Type() string         { return "retirement1" }

--- a/protocol/tx/retirement.go
+++ b/protocol/tx/retirement.go
@@ -9,6 +9,10 @@ type retirement struct {
 		ExtHash bc.Hash
 	}
 	ordinal int
+
+	// Source contains (a pointer to) the manifested entry corresponding
+	// to body.Source.
+	Source entry
 }
 
 func (retirement) Type() string         { return "retirement1" }
@@ -16,10 +20,18 @@ func (r *retirement) Body() interface{} { return r.body }
 
 func (r retirement) Ordinal() int { return r.ordinal }
 
-func newRetirement(source valueSource, data bc.Hash, ordinal int) *retirement {
+func newRetirement(data bc.Hash, ordinal int) *retirement {
 	r := new(retirement)
-	r.body.Source = source
 	r.body.Data = data
 	r.ordinal = ordinal
 	return r
+}
+
+func (r *retirement) setSource(e entry, value bc.AssetAmount, position uint64) {
+	r.body.Source = valueSource{
+		Ref:      entryID(e),
+		Value:    value,
+		Position: position,
+	}
+	r.Source = e
 }

--- a/protocol/tx/spend.go
+++ b/protocol/tx/spend.go
@@ -4,25 +4,15 @@ import "chain/protocol/bc"
 
 type spend struct {
 	body struct {
-		SpentOutput bc.Hash // must be an Output entry
+		SpentOutput bc.Hash // the hash of an output entry
 		Data        bc.Hash
 		ExtHash     bc.Hash
 	}
 	ordinal int
 
 	// SpentOutput contains (a pointer to) the manifested entry
-	// corresponding to body.SpentOutput. It may be nil, in which case
-	// spentInfo must be non-nil.
+	// corresponding to body.SpentOutput.
 	SpentOutput *output
-
-	// spentInfo contains validation-essential data in case the spent
-	// output object is not present (in SpentOutput).
-	spentInfo *spentInfo
-}
-
-type spentInfo struct {
-	bc.AssetAmount
-	program
 }
 
 func (spend) Type() string         { return "spend1" }
@@ -30,22 +20,11 @@ func (s *spend) Body() interface{} { return s.body }
 
 func (s spend) Ordinal() int { return s.ordinal }
 
-func newSpend(data bc.Hash, ordinal int) *spend {
+func newSpend(out *output, data bc.Hash, ordinal int) *spend {
 	s := new(spend)
+	s.body.SpentOutput = entryID(out)
 	s.body.Data = data
 	s.ordinal = ordinal
+	s.SpentOutput = out
 	return s
-}
-
-func (s *spend) setSpentOutput(o *output) {
-	s.body.SpentOutput = entryID(o)
-	s.SpentOutput = o
-}
-
-func (s *spend) setSpentInfo(spentOutputID bc.Hash, value bc.AssetAmount, program program) {
-	s.body.SpentOutput = spentOutputID
-	s.spentInfo = &spentInfo{
-		AssetAmount: value,
-		program:     program,
-	}
 }

--- a/protocol/tx/spend.go
+++ b/protocol/tx/spend.go
@@ -42,7 +42,8 @@ func (s *spend) setSpentOutput(o *output) {
 	s.SpentOutput = o
 }
 
-func (s *spend) setSpentInfo(value bc.AssetAmount, program program) {
+func (s *spend) setSpentInfo(spentOutputID bc.Hash, value bc.AssetAmount, program program) {
+	s.body.SpentOutput = spentOutputID
 	s.spentInfo = &spentInfo{
 		AssetAmount: value,
 		program:     program,

--- a/protocol/tx/spend.go
+++ b/protocol/tx/spend.go
@@ -9,6 +9,20 @@ type spend struct {
 		ExtHash     bc.Hash
 	}
 	ordinal int
+
+	// SpentOutput contains (a pointer to) the manifested entry
+	// corresponding to body.SpentOutput. It may be nil, in which case
+	// spentInfo must be non-nil.
+	SpentOutput *output
+
+	// spentInfo contains validation-essential data in case the spent
+	// output object is not present (in SpentOutput).
+	spentInfo *spentInfo
+}
+
+type spentInfo struct {
+	bc.AssetAmount
+	program
 }
 
 func (spend) Type() string         { return "spend1" }
@@ -16,10 +30,21 @@ func (s *spend) Body() interface{} { return s.body }
 
 func (s spend) Ordinal() int { return s.ordinal }
 
-func newSpend(spentOutput bc.Hash, data bc.Hash, ordinal int) *spend {
+func newSpend(data bc.Hash, ordinal int) *spend {
 	s := new(spend)
-	s.body.SpentOutput = spentOutput
 	s.body.Data = data
 	s.ordinal = ordinal
 	return s
+}
+
+func (s *spend) setSpentOutput(o *output) {
+	s.body.SpentOutput = entryID(o)
+	s.SpentOutput = o
+}
+
+func (s *spend) setSpentInfo(value bc.AssetAmount, program program) {
+	s.spentInfo = &spentInfo{
+		AssetAmount: value,
+		program:     program,
+	}
 }

--- a/protocol/tx/transaction.go
+++ b/protocol/tx/transaction.go
@@ -43,7 +43,7 @@ func TxHashes(oldTx *bc.TxData) (hashes *bc.TxHashes, err error) {
 	}
 
 	hashes = new(bc.TxHashes)
-	hashes.ID = bc.Hash(txid)
+	hashes.ID = txid
 
 	// Results
 	hashes.Results = make([]bc.ResultInfo, len(header.body.Results))
@@ -76,16 +76,16 @@ func TxHashes(oldTx *bc.TxData) (hashes *bc.TxHashes, err error) {
 			iss := struct {
 				ID           bc.Hash
 				ExpirationMS uint64
-			}{bc.Hash(entryID), tr.body.MaxTimeMS}
+			}{entryID, tr.body.MaxTimeMS}
 			hashes.Issuances = append(hashes.Issuances, iss)
 
 		case *issuance:
-			vmc := newVMContext(bc.Hash(entryID), hashes.ID, header.body.Data, ent.body.Data)
+			vmc := newVMContext(entryID, hashes.ID, header.body.Data, ent.body.Data)
 			vmc.NonceID = (*bc.Hash)(&ent.body.Anchor)
 			hashes.VMContexts[ent.Ordinal()] = vmc
 
 		case *spend:
-			vmc := newVMContext(bc.Hash(entryID), hashes.ID, header.body.Data, ent.body.Data)
+			vmc := newVMContext(entryID, hashes.ID, header.body.Data, ent.body.Data)
 			vmc.OutputID = (*bc.Hash)(&ent.body.SpentOutput)
 			hashes.VMContexts[ent.Ordinal()] = vmc
 			hashes.SpentOutputIDs[ent.Ordinal()] = ent.body.SpentOutput

--- a/protocol/tx/transaction.go
+++ b/protocol/tx/transaction.go
@@ -25,11 +25,8 @@ func ComputeOutputID(sc *bc.SpendCommitment) (h bc.Hash, err error) {
 			err = r
 		}
 	}()
-	o := newOutput(valueSource{
-		Ref:      sc.SourceID,
-		Value:    sc.AssetAmount,
-		Position: sc.SourcePosition,
-	}, program{VMVersion: sc.VMVersion, Code: sc.ControlProgram}, sc.RefDataHash, 0)
+	o := newOutput(program{VMVersion: sc.VMVersion, Code: sc.ControlProgram}, sc.RefDataHash, 0)
+	o.setSourceID(sc.SourceID, sc.AssetAmount, sc.SourcePosition)
 
 	h = entryID(o)
 	return h, nil
@@ -37,6 +34,12 @@ func ComputeOutputID(sc *bc.SpendCommitment) (h bc.Hash, err error) {
 
 // TxHashes returns all hashes needed for validation and state updates.
 func TxHashes(oldTx *bc.TxData) (hashes *bc.TxHashes, err error) {
+	defer func() {
+		if r, ok := recover().(error); ok {
+			err = r
+		}
+	}()
+
 	txid, header, entries, err := mapTx(oldTx)
 	if err != nil {
 		return nil, errors.Wrap(err, "mapping old transaction to new")

--- a/protocol/vm/vm_test.go
+++ b/protocol/vm/vm_test.go
@@ -226,9 +226,6 @@ func TestVerifyTxInput(t *testing.T) {
 			nil,
 		),
 		wantErr: ErrRunLimitExceeded,
-	}, {
-		input:   &bc.TxInput{},
-		wantErr: ErrUnsupportedTx,
 	}}
 
 	for i, c := range cases {


### PR DESCRIPTION
The pointers are outside each entry's `body` and `witness`. This is an alternative to the approach in https://github.com/chain/chain/pull/623.