### PR TITLE
core/account: fix race in TestCancelReservation

### DIFF
--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -34,7 +34,7 @@ func TestCancelReservation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := prottest.NewChainWithStorage(t, memstore.New(), prottest.WithOutput(outid))
+	c := prottest.NewChainWithStorage(t, memstore.New(), outid)
 
 	utxoDB := newReserver(db, c, nil)
 	res, err := utxoDB.ReserveUTXO(ctx, outid, nil, time.Now())

--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -7,6 +7,7 @@ import (
 
 	"chain/database/pg/pgtest"
 	"chain/protocol/bc"
+	"chain/protocol/memstore"
 	"chain/protocol/prottest"
 )
 
@@ -21,35 +22,19 @@ const sampleAccountUTXOs = `
 
 func TestCancelReservation(t *testing.T) {
 	ctx := context.Background()
-	c := prottest.NewChain(t)
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
-
 	_, err := db.Exec(ctx, sampleAccountUTXOs)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	var h, outid bc.Hash
-	var assetID bc.AssetID
-	err = h.UnmarshalText([]byte("270b725a94429496a178c56b390a89d03f801fe2ee992d90cf4fdf7d7855318e"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Create a Chain with our output already in the state tree.
+	var outid bc.Hash
 	err = outid.UnmarshalText([]byte("9886ae2dc24b6d868c68768038c43801e905a62f1a9b826ca0dc357f00c30117"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = assetID.UnmarshalText([]byte("df1df9d4f66437ab5be715e4d1faeb29d24c80a6dc8276d6a630f05c5f1f7693"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Fake the output in the state tree.
-	_, s := c.State()
-	err = s.Tree.Insert(outid[:])
-	if err != nil {
-		t.Error(err)
-	}
+	c := prottest.NewChainWithStorage(t, memstore.New(), prottest.WithOutput(outid))
 
 	utxoDB := newReserver(db, c, nil)
 	res, err := utxoDB.ReserveUTXO(ctx, outid, nil, time.Now())

--- a/protocol/prottest/block.go
+++ b/protocol/prottest/block.go
@@ -25,24 +25,10 @@ func NewChain(tb testing.TB) *protocol.Chain {
 	return NewChainWithStorage(tb, memstore.New())
 }
 
-// Option defines optional configuration settings a new Chain.
-type Option func(*state.Snapshot)
-
-// WithOutput creates a Chain with the provided output ID hash already
-// in the state tree.
-func WithOutput(outputID bc.Hash) Option {
-	return func(snap *state.Snapshot) {
-		err := snap.Tree.Insert(outputID[:])
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
 // NewChainWithStorage makes a new Chain using store for storage, along
 // with an initial block using a 0/0 multisig program.
 // It commits the initial block before returning the Chain.
-func NewChainWithStorage(tb testing.TB, store protocol.Store, opts ...Option) *protocol.Chain {
+func NewChainWithStorage(tb testing.TB, store protocol.Store, outputIDs ...bc.Hash) *protocol.Chain {
 	ctx := context.Background()
 	b1, err := protocol.NewInitialBlock(nil, 0, time.Now())
 	if err != nil {
@@ -55,8 +41,8 @@ func NewChainWithStorage(tb testing.TB, store protocol.Store, opts ...Option) *p
 	c.MaxIssuanceWindow = 48 * time.Hour // TODO(tessr): consider adding MaxIssuanceWindow to NewChain
 
 	s := state.Empty()
-	for _, opt := range opts {
-		opt(s)
+	for _, outputID := range outputIDs {
+		s.Tree.Insert(outputID[:])
 	}
 
 	err = c.CommitBlock(ctx, b1, s)


### PR DESCRIPTION
Fix the data race in TestCancelReservation caused by manipulating
the Chain's active state tree. Instead, add the output ID to the state
tree before creating the Chain.

Fixes #516.