### PR TITLE
all: update tag references to reflect new namescheme

### DIFF
--- a/bin/build-docker-de
+++ b/bin/build-docker-de
@@ -8,7 +8,7 @@ cleanup() {
 trap cleanup EXIT
 
 imageVersion=${IMAGE_VERSION:-1.1.0}
-coredVersion=${CORED_VERSION:-cmd.cored-1.1.0}
+coredVersion=${CORED_VERSION:-chain-core-server-1.1.0}
 
 GOOS=linux GOARCH=amd64 bin/build-cored-release "$coredVersion" $CHAIN/docker/de/
 docker build --tag chaincore/developer $CHAIN/docker/de/

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -86,8 +86,8 @@ var (
 
 func init() {
 	var version string
-	if strings.HasPrefix(buildTag, "cmd.cored-") {
-		// build tag with cmd.cored- prefix indicates official release
+	if strings.HasPrefix(buildTag, "chain-core-server-") {
+		// build tag with chain-core-server- prefix indicates official release
 		version = latestVersion
 	} else if buildTag != "?" {
 		version = latestVersion + "-" + buildTag

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,13 +41,11 @@ Log into `aws` with the command:
 $ aws configure
 ```
 
-#### The `docs-release` branch
+#### The `docs-<major>.<minor>.x` branches
 
 Before uploading documentation, make sure your local state reflects the correct documentation. The `main` branch is generally not safe for this purpose, since it may contain documentation updates that reflect changes that have yet to make it into an official relase.
 
-The state of production documentation is tracked in the `docs-release` branch. This branch that reflects the last known safe version of the documentation. Typically, it will contain the contents of `main`, **minus** updates to the `docs` and `sdk` directories that reflect unreleased updates.
-
-Since this contents of `docs-release` are assembled ad hoc, the history of this branch is relatively unimportant. It's fine to use force-pushes to synchronize the branch with `main`. Our current convention is to find a stable baseline commit on `main`, and then add cherry-picked commits that refer to commits in `main` that contain releasable updates to the `docs` and `sdk` directories.
+The state of production documentation is tracked in the `docs-<major>.<minor>.x` family of branches. Each such branch reflects the last known safe version of the documentation for the corresponding major/minor version pair.
 
 #### Uploading the docs
 
@@ -55,7 +53,7 @@ Staging:
 
 ```
 cd $CHAIN
-git checkout docs-release
+git checkout docs-<major>.<minor>.x
 ./bin/upload-docs
 ```
 
@@ -63,6 +61,6 @@ Production:
 
 ```
 cd $CHAIN
-git checkout docs-release
+git checkout docs-<major>.<minor>.x
 ./bin/upload-docs prod
 ```

--- a/installer/mac/tools/build_chain.sh
+++ b/installer/mac/tools/build_chain.sh
@@ -9,7 +9,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 tempBuildPath=`mktemp -d`
 trap "rm -rf $tempBuildPath" EXIT
-"${CHAIN}/bin/build-cored-release" cmd.cored-1.1.0 $tempBuildPath
+"${CHAIN}/bin/build-cored-release" chain-core-server-1.1.0 $tempBuildPath
 
 cp -f $tempBuildPath/cored "${TARGET_DIR}/"
 cp -f $tempBuildPath/corectl "${TARGET_DIR}/"


### PR DESCRIPTION
#640 introduced a new namescheme for release tags. This change should be
reflected in build scripts and documentation.