### PR TITLE
cmd/cored: always run expire reservations loop

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -328,6 +328,9 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 	// GC old submitted txs periodically.
 	go core.CleanupSubmittedTxs(ctx, db)
 
+	// Clean up expired UTXO reservations periodically.
+	go accounts.ExpireReservations(ctx, expireReservationsPeriod)
+
 	h := &core.API{
 		Chain:        c,
 		Store:        store,
@@ -399,7 +402,6 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 		} else {
 			go fetch.Fetch(ctx, c, remoteGenerator, fetchhealth, recoveredBlock, recoveredSnapshot)
 		}
-		go h.Accounts.ExpireReservations(ctx, expireReservationsPeriod)
 		go h.Accounts.ProcessBlocks(ctx)
 		go h.Assets.ProcessBlocks(ctx)
 		if *indexTxs {


### PR DESCRIPTION
In the [spirit of reducing responsibility of leader processes](https://github.com/chain/chain/issues/519#issuecomment-280741917), always
run  the goroutine to expire reservations regardless of whether
the process is leader. It's harmless to run on non-leader
processes. There won't be any reservations to expire.