### PR TITLE
docker/ci: Revert "Add Rust tools to Dockerfile"

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -20,10 +20,6 @@ RUN apk --no-cache add bash clang git g++ make nodejs openjdk8 python perl \
     && cd $(go env GOPATH)/src/github.com/GoASTScanner/gas \
     && git reset --hard d30c5cde3613e9ba0129febda849e4d4df1d57cd \
     && go install github.com/GoASTScanner/gas
-    && curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2017-02-25
-    && ~/.cargo/bin/cargo install rustfmt
-    && ~/.cargo/bin/cargo install clippy
-    && ~/.cargo/bin/cargo install cargo-audit
 
 ADD bin /usr/bin
 ENV CHAIN ${GOPATH:-$HOME/go}/src/chain


### PR DESCRIPTION
This reverts commit 58c1cd0ee36aa0ee70d3bcfadff9a74ec9dccd71.

Since Alpine uses musl and Rust doesn't easily work with
musl out of the box, it'll take some more work to get
this up and running. See also #636 for some discussion.

So let's back this out for now and we can try again.