### PR TITLE
cmd/cored: update build tag logic for new tagging namescheme

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -86,8 +86,8 @@ var (
 
 func init() {
 	var version string
-	if strings.HasPrefix(buildTag, "cmd.cored-") {
-		// build tag with cmd.cored- prefix indicates official release
+	if strings.HasPrefix(buildTag, "chain-core-server-") {
+		// build tag with chain-core-server- prefix indicates official release
 		version = latestVersion
 	} else if buildTag != "?" {
 		version = latestVersion + "-" + buildTag


### PR DESCRIPTION
This is a backport of #650 for the Chain Core 1.1 server release.