### PR TITLE
bin/build-docker-de: update build tag for new namescheme

### DIFF
--- a/bin/build-docker-de
+++ b/bin/build-docker-de
@@ -8,7 +8,7 @@ cleanup() {
 trap cleanup EXIT
 
 imageVersion=${IMAGE_VERSION:-1.1.0}
-coredVersion=${CORED_VERSION:-cmd.cored-1.1.0}
+coredVersion=${CORED_VERSION:-chain-core-server-1.1.0}
 
 GOOS=linux GOARCH=amd64 bin/build-cored-release "$coredVersion" $CHAIN/docker/de/
 docker build --tag chaincore/developer $CHAIN/docker/de/


### PR DESCRIPTION
This is a backport of #650 for the Chain Core 1.1 Docker release.