### PR TITLE
installer/mac/tools: update build script for new tagging namescheme

### DIFF
--- a/installer/mac/tools/build_chain.sh
+++ b/installer/mac/tools/build_chain.sh
@@ -9,7 +9,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 tempBuildPath=`mktemp -d`
 trap "rm -rf $tempBuildPath" EXIT
-"${CHAIN}/bin/build-cored-release" cmd.cored-1.1.0 $tempBuildPath
+"${CHAIN}/bin/build-cored-release" chain-core-server-1.1.0 $tempBuildPath
 
 cp -f $tempBuildPath/cored "${TARGET_DIR}/"
 cp -f $tempBuildPath/corectl "${TARGET_DIR}/"


### PR DESCRIPTION
This is a backport of #650 for the Chain Core 1.1 Mac release.