### PR TITLE
sdk/ruby: support Ruby 2.0 in 1.0 SDK

### DIFF
--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -4,7 +4,9 @@
 
 ### Get the gem
 
-The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2.1 or greater is required.
+The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core.
+
+Ruby 2.0 or greater is required. We strongly recommend upgrading to Ruby 2.1 or greater, as [Ruby 2.0 has reached end-of-life](https://www.ruby-lang.org/en/downloads/branches/) and will no longer receive security updates and bugfixes.
 
 For most applications, you can simply add the following to your `Gemfile`:
 

--- a/sdk/ruby/chain-sdk.gemspec
+++ b/sdk/ruby/chain-sdk.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary = 'The Official Ruby SDK for Chain Core'
   s.licenses = ['Apache-2.0']
   s.homepage = 'https://github.com/chain/chain/tree/main/sdk/ruby'
-  s.required_ruby_version = '~> 2.1'
+  s.required_ruby_version = '~> 2.0'
 
   s.files = ['README.md', 'LICENSE']
   s.files += Dir['lib/**/*.rb']


### PR DESCRIPTION
Due to customer requests, we are relaxing the Ruby 2.1 requirement in the
Ruby SDK. A warning about Ruby 2.0 end-of-life has been added to the
README.

This is a backport of #658 for the 1.0 branch of the Ruby SDK.