### PR TITLE
sdk/ruby: backport Ruby SDK 1.0.1 to 1.0-stable

### DIFF
--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Chain Ruby SDK
 
+## 1.0.1 (January 24, 2017)
+
+* Set minimum Ruby version requirement to 2.1
+* Enhanced transaction feed API support
+* Fixed issue reading attributers with array getter syntax (@donce in [#422](https://github.com/chain/chain/pull/422))
+
 ## 1.0.0 (November 17, 2016)
 
 * Initial release

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -4,12 +4,12 @@
 
 ### Get the gem
 
-The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2 is required.
+The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2.1 or greater is required.
 
 For most applications, you can simply add the following to your `Gemfile`:
 
 ```
-gem 'chain-sdk', '~> 1.0.0', require: 'chain'
+gem 'chain-sdk', '~> 1.0.1', require: 'chain'
 ```
 
 ### In your code

--- a/sdk/ruby/chain-sdk.gemspec
+++ b/sdk/ruby/chain-sdk.gemspec
@@ -4,10 +4,11 @@ Gem::Specification.new do |s|
   s.name = 'chain-sdk'
   s.version = Chain::VERSION
   s.authors = ['Chain Engineering']
-  s.description = 'The Official Ruby SDK for the Chain Core Developer Edition'
-  s.summary = 'The Official Ruby SDK for the Chain Core Developer Edition'
+  s.description = 'The Official Ruby SDK for Chain Core'
+  s.summary = 'The Official Ruby SDK for Chain Core'
   s.licenses = ['Apache-2.0']
   s.homepage = 'https://github.com/chain/chain/tree/main/sdk/ruby'
+  s.required_ruby_version = '~> 2.1'
 
   s.files = ['README.md', 'LICENSE']
   s.files += Dir['lib/**/*.rb']

--- a/sdk/ruby/lib/chain/response_object.rb
+++ b/sdk/ruby/lib/chain/response_object.rb
@@ -25,7 +25,7 @@ module Chain
       attrib_name = attrib_name.to_sym
       raise KeyError.new("key not found: #{attrib_name}") unless self.class.attrib_opts.key?(attrib_name)
 
-      instance_variable_get "@{attrib_name}"
+      instance_variable_get "@#{attrib_name}"
     end
 
     def []=(attrib_name, value)

--- a/sdk/ruby/lib/chain/version.rb
+++ b/sdk/ruby/lib/chain/version.rb
@@ -1,3 +1,3 @@
 module Chain
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/sdk/ruby/spec/integration/integration_spec.rb
+++ b/sdk/ruby/spec/integration/integration_spec.rb
@@ -84,7 +84,7 @@ context 'Chain SDK integration test' do
       chain.assets.create(alias: :unobtanium)
     }.to raise_error(Chain::APIError)
 
-    # Batch account creation
+    # Batch asset creation
 
     asset_batch = chain.assets.create_batch([
       {alias: :bronze, root_xpubs: [chain.mock_hsm.keys.create.xpub], quorum: 1}, # success


### PR DESCRIPTION
This should contain all relevant changes when running the following command:

```
git diff cmd.cored-1.0.2...sdk.ruby-1.0.1 sdk/ruby
```