### PR TITLE
cmd/cored: support https for intra-Core RPCs

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -110,6 +110,7 @@ func init() {
 	expvar.NewString("runtime.GOARCH").Set(runtime.GOARCH)
 	expvar.NewString("runtime.Version").Set(runtime.Version())
 
+	config.TLS = *tlsCrt != ""
 	config.Version = version
 	config.BuildCommit = buildCommit
 	config.BuildDate = buildDate

--- a/core/api.go
+++ b/core/api.go
@@ -295,10 +295,13 @@ func (a *API) forwardToLeader(ctx context.Context, path string, body interface{}
 		return errLeaderElection
 	}
 
-	// TODO(jackson): If using TLS, use https:// here.
-	l := &rpc.Client{
-		BaseURL: "http://" + addr,
+	leaderURL := "http://" + addr
+	if config.TLS {
+		// Issue #674: If cored is configured to use TLS, assume the
+		// leader is reachable via https. This is a fix for the 1.1.1 release.
+		leaderURL = "https://" + addr
 	}
+	l := &rpc.Client{BaseURL: leaderURL}
 
 	// Forward the request credentials if we have them.
 	// TODO(jackson): Don't use the incoming request's credentials and

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -36,6 +36,7 @@ var (
 
 	Version, BuildCommit, BuildDate string
 	Production                      bool
+	TLS                             bool
 )
 
 // Config encapsulates Core-level, persistent configuration options.


### PR DESCRIPTION
Use https for interprocess RPCs if the current cored process was
configured with a TLS cert. This is a short-term fix for the 1.1.1
release only.

Fixes #674.