### PR TITLE
sdk/ruby: support Ruby 2.0 in 1.1 SDK

### DIFF
--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Chain Ruby SDK
 
+This changelog is for the 1.1.x branch of the Ruby SDK. Older versions:
+
+- [1.0.x](https://github.com/chain/chain/blob/sdk-ruby-1.0.x/sdk/ruby/CHANGELOG.md)
+
+## 1.1.1 (March 2, 2017)
+
+* Relax minimum Ruby version requirement from 2.1 to 2.0. While the Ruby SDK is now compatible with Ruby 2.0, we strongly recommend using Ruby 2.1 or greater, since Ruby 2.0 has reached end-of-life and is no longer receiving critical security updates.
+
 ## 1.1.0 (February 24, 2017)
 
 This release is a minor version update, and contains **new features** and **deprecations**. It is not compatible with cored 1.0.x; please upgrade cored before updating your SDKs.
@@ -144,17 +152,3 @@ client.transactions.query(
   ...
 end
 ```
-
-## 1.0.2 (February 21, 2017)
-
-* Syntax compatibility update
-
-## 1.0.1 (January 24, 2017)
-
-* Set minimum Ruby version requirement to 2.1
-* Enhanced transaction feed API support
-* Fixed issue reading attributers with array getter syntax (@donce in [#422](https://github.com/chain/chain/pull/422))
-
-## 1.0.0 (November 17, 2016)
-
-* Initial release

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -4,7 +4,9 @@
 
 ### Get the gem
 
-The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2.1 or greater is required.
+The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core.
+
+Ruby 2.0 or greater is required. We strongly recommend upgrading to Ruby 2.1 or greater, as [Ruby 2.0 has reached end-of-life](https://www.ruby-lang.org/en/downloads/branches/) and will no longer receive security updates and bugfixes.
 
 For most applications, you can simply add the following to your `Gemfile`:
 

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -11,7 +11,7 @@ Ruby 2.0 or greater is required. We strongly recommend upgrading to Ruby 2.1 or 
 For most applications, you can simply add the following to your `Gemfile`:
 
 ```
-gem 'chain-sdk', '~> 1.1.0', require: 'chain'
+gem 'chain-sdk', '~> 1.1.1', require: 'chain'
 ```
 
 ### In your code

--- a/sdk/ruby/chain-sdk.gemspec
+++ b/sdk/ruby/chain-sdk.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary = 'The Official Ruby SDK for Chain Core'
   s.licenses = ['Apache-2.0']
   s.homepage = 'https://github.com/chain/chain/tree/main/sdk/ruby'
-  s.required_ruby_version = '~> 2.1'
+  s.required_ruby_version = '~> 2.0'
 
   s.files = ['README.md', 'LICENSE']
   s.files += Dir['lib/**/*.rb']

--- a/sdk/ruby/lib/chain/version.rb
+++ b/sdk/ruby/lib/chain/version.rb
@@ -1,3 +1,3 @@
 module Chain
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
This commit relaxes the Ruby version requirement to 2.0, and ticks the SDK version to 1.1.1.

This is a backport of #658 and #670 for the 1.1-stable branch.