### PR TITLE
core/account: add expiration block processor

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -312,6 +312,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 	}
 	// Start listeners
 	go pinStore.Listen(ctx, account.PinName, *dbURL)
+	go pinStore.Listen(ctx, account.ExpirePinName, *dbURL)
 	go pinStore.Listen(ctx, asset.PinName, *dbURL)
 
 	// Setup the transaction query indexer to index every transaction.
@@ -389,6 +390,10 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 			height = height - 1
 		}
 		err = pinStore.CreatePin(ctx, account.PinName, height)
+		if err != nil {
+			chainlog.Fatal(ctx, chainlog.KeyError, err)
+		}
+		err = pinStore.CreatePin(ctx, account.ExpirePinName, height)
 		if err != nil {
 			chainlog.Fatal(ctx, chainlog.KeyError, err)
 		}


### PR DESCRIPTION
This runs the expiration of account control programs as a separate
process. This fixes the expiration to wait until the transaction
processor has completed before deleting any data that may be needed.

1.1-stable version of #612