### PR TITLE
docs/internal: don't commit to maintaining 1.0-stable

### DIFF
--- a/docs/internal/package-tags-branches.md
+++ b/docs/internal/package-tags-branches.md
@@ -14,25 +14,16 @@
 
 ## Version branches
 
-Every major/minor version pair will have its own branch named `<major>-<minor>.x`, e.g:
+Every major/minor version pair will have its own branch named `<major>-<minor>-stable`, e.g. `1.1-stable`.<sup>1</sup>
 
-- `1.0-stable`
-- `1.1-stable`
-
-Version branches act as the merge base for point release updates across all packages, and should start with the commit corresponding to `chain-core-server-<major>.<minor>.0`.<sup>1</sup>
+Version branches act as the merge base for point release updates across all packages, and should start with the commit corresponding to `chain-core-server-<major>.<minor>.0`.
 
 Updates to the version branches should be as conservative as possible. We should ensure that the tip of each version branch maintains cross-compatibility across packages, per our [versioning scheme](../core/reference/versioning.md).
 
-<sup>1</sup> `1.0-stable` is an exception, since it precedes this branching scheme.
+<sup>1</sup> Version 1.0 predates this scheme, so there is no `1.0-stable` branch. To make updates to 1.0, please use the 1.0 package-specific release tags.
 
 ## Release tags
 
-Every package release has a **tag** that specifies the package name and its major, minor, and build versions, e.g.:
+Every package release has a **tag** that specifies the package name and its major, minor, and build versions, e.g. `chain-core-server-1.1.0`.
 
-- `chain-core-server-1.1.0`
-- `sdk-ruby-1.0.2`
-
-Naturally, release tags should live on their relevant version branches, e.g.:
-
-- `chain-core-server-1.1.1` is on the `1.1-stable` branch
-- `sdk-ruby-1.0.2` is on the `1.0-stable` branch
+Naturally, release tags should live on their relevant version branches, e.g. `chain-core-server-1.1.1` should be on the `1.1-stable` branch.


### PR DESCRIPTION
It will take a fair amount of legwork to reconstruct 1.0-stable
from our various package release branches, and it may be error-
prone. For now, let's not commit to maintaining that branch, and
hope that updates to 1.0 will be rare.