### PR TITLE
core/account: do not delete expired, in-use acps

### DIFF
--- a/core/account/indexer.go
+++ b/core/account/indexer.go
@@ -111,7 +111,7 @@ func (m *Manager) expireControlPrograms(ctx context.Context, b *bc.Block) error 
 		WHERE acp.expires_at IS NOT NULL AND acp.expires_at < $1
 		AND NOT EXISTS (
 			SELECT 1 FROM account_utxos u
-			WHERE acp.control_prgoram = u.control_program
+			WHERE acp.control_program = u.control_program
 		)`
 	_, err := m.db.Exec(ctx, deleteQ, b.Time())
 	return err


### PR DESCRIPTION
Do not delete account control programs that are expired but still hold
assets.

This is a minimal, short-term fix for #668 within the 1.1.x release branch.
In the future, we should use `account_utxos` to annotate inputs &
outputs instead.