### PR TITLE
sdk/node: ensure correct version semantics for Node SDK

### DIFF
--- a/docs/core/get-started/sdk.md
+++ b/docs/core/get-started/sdk.md
@@ -36,10 +36,14 @@ You can also [download the JAR](https://search.maven.org/remotecontent?filepath=
 
 The Chain Node.js SDK is available [via npm](https://www.npmjs.com/package/chain-sdk). Node 4 or greater is required.
 
-To install, run the following command from your project directory:
+To install, add Chain to your `package.json` using a tilde range (`~`) and specifying the patch version:
 
 ```
-npm install --save chain-sdk@1.1.0
+{
+  "dependencies": {
+    "chain-sdk": "~1.1.0"
+  }
+}
 ```
 
 ## Ruby
@@ -49,5 +53,5 @@ The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). R
 To install, add the following to your `Gemfile`:
 
 ```
-gem 'chain-sdk', '~> 1.1.0', require: 'chain'
+gem 'chain-sdk', '>= 1.1.0', '< 1.2.0' require: 'chain'
 ```

--- a/docs/core/get-started/sdk.md
+++ b/docs/core/get-started/sdk.md
@@ -53,5 +53,5 @@ The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). R
 To install, add the following to your `Gemfile`:
 
 ```
-gem 'chain-sdk', '>= 1.1.0', '< 1.2.0' require: 'chain'
+gem 'chain-sdk', '~> 1.1.0', require: 'chain'
 ```

--- a/docs/core/get-started/sdk.md
+++ b/docs/core/get-started/sdk.md
@@ -36,7 +36,7 @@ You can also [download the JAR](https://search.maven.org/remotecontent?filepath=
 
 The Chain Node.js SDK is available [via npm](https://www.npmjs.com/package/chain-sdk). Node 4 or greater is required.
 
-To install, add Chain to your `package.json` using a tilde range (`~`) and specifying the patch version:
+To install, add the `chain-sdk` NPM module to your `package.json`, using a tilde range (`~`) and specifying the patch version:
 
 ```
 {

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -6,7 +6,7 @@
 
 The Chain Node SDK is available [via npm](https://www.npmjs.com/package/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Node 4 or greater is required.
 
-Add Chain to your `package.json` using a tilde range (`~`) and specifying the patch version:
+To install, add the `chain-sdk` NPM module to your `package.json`, using a tilde range (`~`) and specifying the patch version:
 
 ```
 {

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -6,10 +6,14 @@
 
 The Chain Node SDK is available [via npm](https://www.npmjs.com/package/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Node 4 or greater is required.
 
-For most applications, you can simply add Chain to your `package.json` with the following command:
+Add Chain to your `package.json` using a tilde range (`~`) and specifying the patch version:
 
 ```
-npm install --save chain-sdk@1.1.0
+{
+  "dependencies": {
+    "chain-sdk": "~1.1.0"
+  }
+}
 ```
 
 ### In your code

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -11,7 +11,7 @@ Ruby 2.0 or greater is required. We strongly recommend upgrading to Ruby 2.1 or 
 For most applications, you can simply add the following to your `Gemfile`:
 
 ```
-gem 'chain-sdk', '~> 1.1.1', require: 'chain'
+gem 'chain-sdk', '>= 1.1.0', '< 1.2.0' require: 'chain'
 ```
 
 ### In your code

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -11,7 +11,7 @@ Ruby 2.0 or greater is required. We strongly recommend upgrading to Ruby 2.1 or 
 For most applications, you can simply add the following to your `Gemfile`:
 
 ```
-gem 'chain-sdk', '>= 1.1.0', '< 1.2.0' require: 'chain'
+gem 'chain-sdk', '~> 1.1.1', require: 'chain'
 ```
 
 ### In your code


### PR DESCRIPTION
The Node SDK installation instructions used to yield a package.json that will allow updates to the minor version, which is bad.