### PR TITLE
core/account: delete spents in separate processor

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -310,6 +310,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 	// Start listeners
 	go pinStore.Listen(ctx, account.PinName, *dbURL)
 	go pinStore.Listen(ctx, account.ExpirePinName, *dbURL)
+	go pinStore.Listen(ctx, account.DeleteSpentsPinName, *dbURL)
 	go pinStore.Listen(ctx, asset.PinName, *dbURL)
 
 	// Setup the transaction query indexer to index every transaction.
@@ -394,6 +395,10 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 			chainlog.Fatal(ctx, chainlog.KeyError, err)
 		}
 		err = pinStore.CreatePin(ctx, account.ExpirePinName, pinHeight)
+		if err != nil {
+			chainlog.Fatal(ctx, chainlog.KeyError, err)
+		}
+		err = pinStore.CreatePin(ctx, account.DeleteSpentsPinName, pinHeight)
 		if err != nil {
 			chainlog.Fatal(ctx, chainlog.KeyError, err)
 		}

--- a/core/account/indexer_test.go
+++ b/core/account/indexer_test.go
@@ -57,6 +57,10 @@ func TestDeleteUTXOs(t *testing.T) {
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}
+	err = m.deleteSpentOutputs(ctx, block1)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
 
 	block2 := &bc.Block{Transactions: []*bc.Tx{
 		bc.NewTx(bc.TxData{
@@ -66,6 +70,10 @@ func TestDeleteUTXOs(t *testing.T) {
 		}),
 	}}
 	err = m.indexAccountUTXOs(ctx, block2)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+	err = m.deleteSpentOutputs(ctx, block2)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/core/query/index.go
+++ b/core/query/index.go
@@ -59,6 +59,7 @@ func (ind *Indexer) ProcessBlocks(ctx context.Context) {
 // saves all annotated transactions to the database.
 func (ind *Indexer) IndexTransactions(ctx context.Context, b *bc.Block) error {
 	<-ind.pinStore.PinWaiter("asset", b.Height)
+	<-ind.pinStore.PinWaiter("account", b.Height)
 
 	err := ind.insertBlock(ctx, b)
 	if err != nil {

--- a/core/query/query_test.go
+++ b/core/query/query_test.go
@@ -36,6 +36,7 @@ func setupQueryTest(t *testing.T) (context.Context, *query.Indexer, time.Time, t
 	indexer.RegisterAnnotator(accounts.AnnotateTxs)
 	indexer.RegisterAnnotator(assets.AnnotateTxs)
 	go assets.ProcessBlocks(ctx)
+	go accounts.ProcessBlocks(ctx)
 	go indexer.ProcessBlocks(ctx)
 
 	acct1 := coretest.CreateAccount(ctx, t, accounts, "", nil)

--- a/core/query_test.go
+++ b/core/query_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"chain/core/account"
 	"chain/core/asset"
 	"chain/core/pin"
 	"chain/core/query"
@@ -20,6 +21,10 @@ func TestQueryWithClockSkew(t *testing.T) {
 
 	pinStore := pin.NewStore(db)
 	err := pinStore.CreatePin(ctx, asset.PinName, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pinStore.CreatePin(ctx, account.PinName, 100)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Delete spent account outputs in a separate block processor from the
indexing block processor. This is a prerequisite to removing the `query`
processor's dependency on the `account_control_programs` table.

For #668.

The new ordering of block processor dependencies:
(account, asset) <- query <- (expire ACPs, delete spent outputs)