### PR TITLE
core/txbuilder: remove unneeded code, unexport some identifiers

### DIFF
--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -158,9 +158,7 @@ func utxoToInputs(ctx context.Context, account *signers.Signer, u *utxo, refData
 	}
 
 	path := signers.Path(account, signers.AccountKeySpace, u.ControlProgramIndex)
-	keyIDs := txbuilder.KeyIDs(account.XPubs, path)
-
-	sigInst.AddWitnessKeys(keyIDs, account.Quorum)
+	sigInst.AddWitnessKeys(account.XPubs, path, account.Quorum)
 
 	return txInput, sigInst, nil
 }

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -86,7 +86,7 @@ func TestBuildFinal(t *testing.T) {
 	coretest.SignTxTemplate(t, ctx, tmpl, nil)
 	coretest.SignTxTemplate(t, ctx, &tmpl2, nil)
 
-	prog1 := tmpl.SigningInstructions[0].WitnessComponents[0].(*txbuilder.SignatureWitness).Program
+	prog1 := tmpl.SigningInstructions[0].SignatureWitnesses[0].Program
 	insts1, err := vm.ParseProgram(prog1)
 	if err != nil {
 		t.Fatal(err)
@@ -117,7 +117,7 @@ func TestBuildFinal(t *testing.T) {
 		t.Fatalf("sigwitness program1 opcode %d is %02x, expected %02x", 18, insts1[18].Op, vm.OP_CHECKOUTPUT)
 	}
 
-	prog2 := tmpl2.SigningInstructions[0].WitnessComponents[0].(*txbuilder.SignatureWitness).Program
+	prog2 := tmpl2.SigningInstructions[0].SignatureWitnesses[0].Program
 	insts2, err := vm.ParseProgram(prog2)
 	if err != nil {
 		t.Fatal(err)

--- a/core/asset/builder.go
+++ b/core/asset/builder.go
@@ -59,8 +59,7 @@ func (a *issueAction) Build(ctx context.Context, builder *txbuilder.TemplateBuil
 
 	tplIn := &txbuilder.SigningInstruction{AssetAmount: a.AssetAmount}
 	path := signers.Path(asset.Signer, signers.AssetKeySpace)
-	keyIDs := txbuilder.KeyIDs(asset.Signer.XPubs, path)
-	tplIn.AddWitnessKeys(keyIDs, asset.Signer.Quorum)
+	tplIn.AddWitnessKeys(asset.Signer.XPubs, path, asset.Signer.Quorum)
 
 	builder.RestrictMinTime(time.Now())
 	return builder.AddInput(txin, tplIn)

--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -105,13 +105,10 @@ func TestMockHSM(t *testing.T) {
 }
 
 func inspectSigInst(t *testing.T, si *txbuilder.SigningInstruction, expectSig bool) {
-	if len(si.WitnessComponents) != 1 {
-		t.Fatalf("len(si.WitnessComponents) is %d, want 1", len(si.WitnessComponents))
+	if len(si.SignatureWitnesses) != 1 {
+		t.Fatalf("len(si.SignatureWitnesses) is %d, want 1", len(si.SignatureWitnesses))
 	}
-	s, ok := si.WitnessComponents[0].(*txbuilder.SignatureWitness)
-	if !ok {
-		t.Fatalf("si.WitnessComponents[0] has type %T, want *txbuilder.SignatureWitness", si.WitnessComponents[0])
-	}
+	s := si.SignatureWitnesses[0]
 	if len(s.Sigs) != 1 {
 		t.Fatalf("len(s.Sigs) is %d, want 1", len(s.Sigs))
 	}

--- a/core/txbuilder/builder.go
+++ b/core/txbuilder/builder.go
@@ -132,8 +132,8 @@ func (b *TemplateBuilder) Build() (*Template, *bc.TxData, error) {
 		instruction.Position = uint32(len(tx.Inputs))
 
 		// Empty signature arrays should be serialized as empty arrays, not null.
-		if instruction.WitnessComponents == nil {
-			instruction.WitnessComponents = []WitnessComponent{}
+		if instruction.SignatureWitnesses == nil {
+			instruction.SignatureWitnesses = []*SignatureWitness{}
 		}
 		tpl.SigningInstructions = append(tpl.SigningInstructions, instruction)
 		tx.Inputs = append(tx.Inputs, in)

--- a/core/txbuilder/builder.go
+++ b/core/txbuilder/builder.go
@@ -133,7 +133,7 @@ func (b *TemplateBuilder) Build() (*Template, *bc.TxData, error) {
 
 		// Empty signature arrays should be serialized as empty arrays, not null.
 		if instruction.SignatureWitnesses == nil {
-			instruction.SignatureWitnesses = []*SignatureWitness{}
+			instruction.SignatureWitnesses = []*signatureWitness{}
 		}
 		tpl.SigningInstructions = append(tpl.SigningInstructions, instruction)
 		tx.Inputs = append(tx.Inputs, in)

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -144,8 +144,8 @@ func TestConflictingTxsInPool(t *testing.T) {
 		SigningInstructions: firstTemplate.SigningInstructions,
 		Local:               true,
 	}
-	secondTemplate.SigningInstructions[0].WitnessComponents[0].(*SignatureWitness).Program = nil
-	secondTemplate.SigningInstructions[0].WitnessComponents[0].(*SignatureWitness).Sigs = nil
+	secondTemplate.SigningInstructions[0].SignatureWitnesses[0].Program = nil
+	secondTemplate.SigningInstructions[0].SignatureWitnesses[0].Sigs = nil
 	coretest.SignTxTemplate(t, ctx, secondTemplate, nil)
 	err = FinalizeTx(ctx, info.Chain, g, secondTemplate.Transaction)
 	if err != nil {

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"chain/crypto/ed25519/chainkd"
-	"chain/encoding/json"
 	"chain/errors"
 	"chain/math/checked"
 	"chain/protocol/bc"
@@ -66,24 +65,10 @@ func Build(ctx context.Context, tx *bc.TxData, actions []Action, maxTime time.Ti
 	return tpl, nil
 }
 
-// KeyIDs produces KeyIDs from a list of xpubs and a derivation path
-// (applied to all the xpubs).
-func KeyIDs(xpubs []chainkd.XPub, path [][]byte) []KeyID {
-	result := make([]KeyID, 0, len(xpubs))
-	var hexPath []json.HexBytes
-	for _, p := range path {
-		hexPath = append(hexPath, p)
-	}
-	for _, xpub := range xpubs {
-		result = append(result, KeyID{xpub, hexPath})
-	}
-	return result
-}
-
 func Sign(ctx context.Context, tpl *Template, xpubs []chainkd.XPub, signFn SignFunc) error {
 	for i, sigInst := range tpl.SigningInstructions {
 		for j, sw := range sigInst.SignatureWitnesses {
-			err := sw.Sign(ctx, tpl, uint32(i), xpubs, signFn)
+			err := sw.sign(ctx, tpl, uint32(i), xpubs, signFn)
 			if err != nil {
 				return errors.WithDetailf(err, "adding signature(s) to witness component %d of input %d", j, i)
 			}

--- a/core/txbuilder/txbuilder.go
+++ b/core/txbuilder/txbuilder.go
@@ -82,8 +82,8 @@ func KeyIDs(xpubs []chainkd.XPub, path [][]byte) []KeyID {
 
 func Sign(ctx context.Context, tpl *Template, xpubs []chainkd.XPub, signFn SignFunc) error {
 	for i, sigInst := range tpl.SigningInstructions {
-		for j, c := range sigInst.WitnessComponents {
-			err := c.Sign(ctx, tpl, uint32(i), xpubs, signFn)
+		for j, sw := range sigInst.SignatureWitnesses {
+			err := sw.Sign(ctx, tpl, uint32(i), xpubs, signFn)
 			if err != nil {
 				return errors.WithDetailf(err, "adding signature(s) to witness component %d of input %d", j, i)
 			}

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -68,7 +68,7 @@ func TestBuild(t *testing.T) {
 			ReferenceData: []byte("xyz"),
 		}),
 		SigningInstructions: []*SigningInstruction{{
-			SignatureWitnesses: []*SignatureWitness{},
+			SignatureWitnesses: []*signatureWitness{},
 		}},
 	}
 
@@ -127,10 +127,10 @@ func TestMaterializeWitnesses(t *testing.T) {
 	tpl := &Template{
 		Transaction: unsigned,
 		SigningInstructions: []*SigningInstruction{{
-			SignatureWitnesses: []*SignatureWitness{
-				&SignatureWitness{
+			SignatureWitnesses: []*signatureWitness{
+				&signatureWitness{
 					Quorum: 1,
-					Keys: []KeyID{{
+					Keys: []keyID{{
 						XPub:           pubkey,
 						DerivationPath: []json.HexBytes{{0, 0, 0, 0}},
 					}},
@@ -206,10 +206,10 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 
 	// Test with more signatures than required, in correct order
 	tpl.SigningInstructions = []*SigningInstruction{{
-		SignatureWitnesses: []*SignatureWitness{
-			&SignatureWitness{
+		SignatureWitnesses: []*signatureWitness{
+			&signatureWitness{
 				Quorum: 2,
-				Keys: []KeyID{
+				Keys: []keyID{
 					{
 						XPub:           pubkey1,
 						DerivationPath: []json.HexBytes{{0, 0, 0, 0}},

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -68,7 +68,7 @@ func TestBuild(t *testing.T) {
 			ReferenceData: []byte("xyz"),
 		}),
 		SigningInstructions: []*SigningInstruction{{
-			WitnessComponents: []WitnessComponent{},
+			SignatureWitnesses: []*SignatureWitness{},
 		}},
 	}
 
@@ -127,7 +127,7 @@ func TestMaterializeWitnesses(t *testing.T) {
 	tpl := &Template{
 		Transaction: unsigned,
 		SigningInstructions: []*SigningInstruction{{
-			WitnessComponents: []WitnessComponent{
+			SignatureWitnesses: []*SignatureWitness{
 				&SignatureWitness{
 					Quorum: 1,
 					Keys: []KeyID{{
@@ -206,7 +206,7 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 
 	// Test with more signatures than required, in correct order
 	tpl.SigningInstructions = []*SigningInstruction{{
-		WitnessComponents: []WitnessComponent{
+		SignatureWitnesses: []*SignatureWitness{
 			&SignatureWitness{
 				Quorum: 2,
 				Keys: []KeyID{
@@ -238,10 +238,7 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 	}
 
 	// Test with exact amount of signatures required, in correct order
-	component, ok := tpl.SigningInstructions[0].WitnessComponents[0].(*SignatureWitness)
-	if !ok {
-		t.Fatal("expecting WitnessComponent of type SignatureWitness")
-	}
+	component := tpl.SigningInstructions[0].SignatureWitnesses[0]
 	component.Sigs = []json.HexBytes{sig1, sig2}
 	err = materializeWitnesses(tpl)
 	if err != nil {

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -37,7 +37,7 @@ func (t *Template) Hash(idx uint32) bc.Hash {
 type SigningInstruction struct {
 	Position uint32 `json:"position"`
 	bc.AssetAmount
-	SignatureWitnesses []*SignatureWitness `json:"witness_components,omitempty"`
+	SignatureWitnesses []*signatureWitness `json:"witness_components,omitempty"`
 }
 
 func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
@@ -46,7 +46,7 @@ func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 		Position           uint32 `json:"position"`
 		SignatureWitnesses []struct {
 			Type string
-			SignatureWitness
+			signatureWitness
 		} `json:"witness_components"`
 	}
 	err := json.Unmarshal(b, &pre)
@@ -56,12 +56,12 @@ func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 
 	si.AssetAmount = pre.AssetAmount
 	si.Position = pre.Position
-	si.SignatureWitnesses = make([]*SignatureWitness, 0, len(pre.SignatureWitnesses))
+	si.SignatureWitnesses = make([]*signatureWitness, 0, len(pre.SignatureWitnesses))
 	for i, w := range pre.SignatureWitnesses {
 		if w.Type != "signature" {
 			return errors.WithDetailf(ErrBadWitnessComponent, "witness component %d has unknown type '%s'", i, w.Type)
 		}
-		si.SignatureWitnesses = append(si.SignatureWitnesses, &w.SignatureWitness)
+		si.SignatureWitnesses = append(si.SignatureWitnesses, &w.signatureWitness)
 	}
 	return nil
 }

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -37,14 +37,14 @@ func (t *Template) Hash(idx uint32) bc.Hash {
 type SigningInstruction struct {
 	Position uint32 `json:"position"`
 	bc.AssetAmount
-	WitnessComponents []WitnessComponent `json:"witness_components,omitempty"`
+	SignatureWitnesses []*SignatureWitness `json:"witness_components,omitempty"`
 }
 
 func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 	var pre struct {
 		bc.AssetAmount
-		Position          uint32 `json:"position"`
-		WitnessComponents []struct {
+		Position           uint32 `json:"position"`
+		SignatureWitnesses []struct {
 			Type string
 			SignatureWitness
 		} `json:"witness_components"`
@@ -56,12 +56,12 @@ func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 
 	si.AssetAmount = pre.AssetAmount
 	si.Position = pre.Position
-	si.WitnessComponents = make([]WitnessComponent, 0, len(pre.WitnessComponents))
-	for i, w := range pre.WitnessComponents {
+	si.SignatureWitnesses = make([]*SignatureWitness, 0, len(pre.SignatureWitnesses))
+	for i, w := range pre.SignatureWitnesses {
 		if w.Type != "signature" {
 			return errors.WithDetailf(ErrBadWitnessComponent, "witness component %d has unknown type '%s'", i, w.Type)
 		}
-		si.WitnessComponents = append(si.WitnessComponents, &w.SignatureWitness)
+		si.SignatureWitnesses = append(si.SignatureWitnesses, &w.SignatureWitness)
 	}
 	return nil
 }

--- a/core/txbuilder/witness_test.go
+++ b/core/txbuilder/witness_test.go
@@ -47,7 +47,7 @@ func TestWitnessJSON(t *testing.T) {
 			Amount:  21,
 		},
 		Position: 17,
-		WitnessComponents: []WitnessComponent{
+		SignatureWitnesses: []*SignatureWitness{
 			&SignatureWitness{
 				Quorum: 4,
 				Keys: []KeyID{{

--- a/core/txbuilder/witness_test.go
+++ b/core/txbuilder/witness_test.go
@@ -47,10 +47,10 @@ func TestWitnessJSON(t *testing.T) {
 			Amount:  21,
 		},
 		Position: 17,
-		SignatureWitnesses: []*SignatureWitness{
-			&SignatureWitness{
+		SignatureWitnesses: []*signatureWitness{
+			&signatureWitness{
 				Quorum: 4,
-				Keys: []KeyID{{
+				Keys: []keyID{{
 					XPub:           testutil.TestXPub,
 					DerivationPath: []chainjson.HexBytes{{5, 6, 7}},
 				}},


### PR DESCRIPTION
The `WitnessComponent` interface used to be instantiated by a few different types relating to smart contracts. Now there's only `SignatureWitness` so there's no need for an interface.

`KeyIDs` and `AddWitnessKeys` were only ever being used together, so they're now coalesced.

Some previously exported identifiers didn't need to be, so no longer are.