### PR TITLE
core/account: annotate spend inputs correctly

### DIFF
--- a/core/account/annotate.go
+++ b/core/account/annotate.go
@@ -9,26 +9,30 @@ import (
 
 	"chain/core/query"
 	"chain/database/pg"
+	"chain/errors"
+	"chain/protocol/bc"
 )
+
+var empty = json.RawMessage(`{}`)
 
 // AnnotateTxs adds account data to transactions
 func (m *Manager) AnnotateTxs(ctx context.Context, txs []*query.AnnotatedTx) error {
-	inputs := make(map[string][]*query.AnnotatedInput)
-	outputs := make(map[string][]*query.AnnotatedOutput)
-	controlProgramSet := make(map[string]bool)
-	var controlPrograms [][]byte
+	var (
+		inputs            = make(map[bc.Hash]*query.AnnotatedInput)
+		outputs           = make(map[string][]*query.AnnotatedOutput)
+		controlProgramSet = make(map[string]bool)
+		controlPrograms   [][]byte
+		spentOutputIDs    [][]byte
+	)
 
 	for _, tx := range txs {
 		for _, in := range tx.Inputs {
-			if len(in.ControlProgram) == 0 {
+			if in.SpentOutputID == nil {
 				continue
 			}
-			inputs[string(in.ControlProgram)] = append(inputs[string(in.ControlProgram)], in)
-			if controlProgramSet[string(in.ControlProgram)] {
-				continue
-			}
-			controlPrograms = append(controlPrograms, in.ControlProgram)
-			controlProgramSet[string(in.ControlProgram)] = true
+
+			inputs[*in.SpentOutputID] = in
+			spentOutputIDs = append(spentOutputIDs, in.SpentOutputID[:])
 		}
 		for _, out := range tx.Outputs {
 			if out.Type == "retire" {
@@ -43,69 +47,62 @@ func (m *Manager) AnnotateTxs(ctx context.Context, txs []*query.AnnotatedTx) err
 		}
 	}
 
-	const q = `
-		SELECT signer_id, control_program, change, alias, tags
-		FROM account_control_programs
-		LEFT JOIN signers ON signers.id=account_control_programs.signer_id
-		LEFT JOIN accounts ON accounts.account_id=signers.id
-		WHERE control_program=ANY($1::bytea[])
+	// Look up all of the spent outputs. If any of them are account UTXOs
+	// add the account annotations to the input.
+	const inputsQ = `
+		SELECT o.output_id, o.account_id, a.alias, a.tags
+		FROM account_utxos o
+		LEFT JOIN accounts a ON o.account_id = a.account_id
+		WHERE o.output_id = ANY($1::bytea[])
 	`
-	var (
-		ids         []string
-		programs    [][]byte
-		changeFlags []bool
-		aliases     []sql.NullString
-		tags        []*json.RawMessage
-	)
-	err := pg.ForQueryRows(ctx, m.db, q, pq.ByteaArray(controlPrograms), func(accountID string, program []byte, change bool, alias sql.NullString, accountTags []byte) {
-		ids = append(ids, accountID)
-		programs = append(programs, program)
-		changeFlags = append(changeFlags, change)
-		aliases = append(aliases, alias)
-		if len(accountTags) > 0 {
-			tags = append(tags, (*json.RawMessage)(&accountTags))
-		} else {
-			tags = append(tags, nil)
-		}
-	})
+	err := pg.ForQueryRows(ctx, m.db, inputsQ, pq.ByteaArray(spentOutputIDs),
+		func(outputID bc.Hash, accID string, alias sql.NullString, accountTags []byte) {
+			spendingInput := inputs[outputID]
+			spendingInput.AccountID = accID
+			if alias.Valid {
+				spendingInput.AccountAlias = alias.String
+			}
+			if len(accountTags) > 0 {
+				spendingInput.AccountTags = (*json.RawMessage)(&accountTags)
+			} else {
+				spendingInput.AccountTags = &empty
+			}
+		})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "annotating input account data")
 	}
 
-	empty := json.RawMessage(`{}`)
-	for i := range ids {
-		inps := inputs[string(programs[i])]
-		for _, inp := range inps {
-			inp.AccountID = ids[i]
-			if aliases[i].Valid {
-				inp.AccountAlias = aliases[i].String
+	// Compare all new outputs' control programs to our own account
+	// control programs. If we recognize any, add the relevant account
+	// annotations.
+	//
+	// TODO(jackson): Instead of using `account_control_programs` here,
+	// we should use `account_utxos`. We will need to add and backfill
+	// the `change` field into `account_utxos` first.
+	const outputsQ = `
+		SELECT acp.control_program, a.account_id, acp.change, a.alias, a.tags
+		FROM account_control_programs acp
+		LEFT JOIN accounts a ON a.account_id = acp.signer_id
+		WHERE acp.control_program = ANY($1::bytea[])
+	`
+	err = pg.ForQueryRows(ctx, m.db, outputsQ, pq.ByteaArray(controlPrograms),
+		func(program []byte, accountID string, change bool, alias sql.NullString, accountTags []byte) {
+			for _, out := range outputs[string(program)] {
+				out.AccountID = accountID
+				if alias.Valid {
+					out.AccountAlias = alias.String
+				}
+				if len(accountTags) > 0 {
+					out.AccountTags = (*json.RawMessage)(&accountTags)
+				} else {
+					out.AccountTags = &empty
+				}
+				if change {
+					out.Purpose = "change"
+				} else {
+					out.Purpose = "receive"
+				}
 			}
-			if tags[i] != nil {
-				inp.AccountTags = tags[i]
-			} else {
-				inp.AccountTags = &empty
-			}
-		}
-
-		outs := outputs[string(programs[i])]
-		for _, out := range outs {
-			out.AccountID = ids[i]
-			if aliases[i].Valid {
-				out.AccountAlias = aliases[i].String
-			}
-			if tags[i] != nil {
-				out.AccountTags = tags[i]
-			} else {
-				out.AccountTags = &empty
-			}
-
-			if changeFlags[i] {
-				out.Purpose = "change"
-			} else {
-				out.Purpose = "receive"
-			}
-		}
-	}
-
-	return nil
+		})
+	return errors.Wrap(err, "annotating output account data")
 }


### PR DESCRIPTION
Correctly annotate spend inputs with account data. When annotating
inputs, determine the source account by looking up the spent output in
`account_utxos` instead of looking up the control program in
`account_control_programs`. The control program isn't guaranteed to
still exist once it's expired.

In a follow up, we should change the output annotating to use
`account_utxos` as well. We'll need to add the `change` flag to
the `account_utxos` table.

Fix #668.