### PR TITLE
sdk/node: ensure correct version semantics for Node SDK

### DIFF
--- a/docs/core/get-started/sdk.md
+++ b/docs/core/get-started/sdk.md
@@ -36,10 +36,14 @@ You can also [download the JAR](https://search.maven.org/remotecontent?filepath=
 
 The Chain Node.js SDK is available [via npm](https://www.npmjs.com/package/chain-sdk). Node 4 or greater is required.
 
-To install, run the following command from your project directory:
+To install, add the `chain-sdk` NPM module to your `package.json`, using a tilde range (`~`) and specifying the patch version:
 
 ```
-npm install --save chain-sdk@1.1.0
+{
+  "dependencies": {
+    "chain-sdk": "~1.1.0"
+  }
+}
 ```
 
 ## Ruby

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -6,10 +6,14 @@
 
 The Chain Node SDK is available [via npm](https://www.npmjs.com/package/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Node 4 or greater is required.
 
-For most applications, you can simply add Chain to your `package.json` with the following command:
+To install, add the `chain-sdk` NPM module to your `package.json`, using a tilde range (`~`) and specifying the patch version:
 
 ```
-npm install --save chain-sdk@1.1.0
+{
+  "dependencies": {
+    "chain-sdk": "~1.1.0"
+  }
+}
 ```
 
 ### In your code


### PR DESCRIPTION
This is a backport of #691 to ensure proper production documentation deploys