### PR TITLE
core: tick network RPC version to 3

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -24,7 +24,7 @@ var (
 
 // reserved mockhsm key alias
 const (
-	networkRPCVersion = 2
+	networkRPCVersion = 3
 )
 
 func (a *API) reset(ctx context.Context, req struct {


### PR DESCRIPTION
This accounts for updates affecting validation-critical hashing
in #665 (#677 in 1.1-stable).

This is a 1.1-stable backport of #703.