### PR TITLE
installer/mac: improve startup port detection, 1.1.1

### DIFF
--- a/installer/mac/CHANGELOG.md
+++ b/installer/mac/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Chain Core Mac Installer changelog
 
+## 1.1.1 (March 1, 2017)
+
+* Improved startup detection of other Chain Cores
+
 ## 1.1.0 (February 24, 2017)
 
 * Updated to Chain Core [1.1.0](../../CHANGELOG.md#1.1.0)

--- a/installer/mac/Chain Core.xcodeproj/project.pbxproj
+++ b/installer/mac/Chain Core.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 		83FB57281D1B05F000A903A3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_VERSION = 1.1.0;
+				APP_VERSION = 1.1.1;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -463,7 +463,7 @@
 		83FB57291D1B05F000A903A3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_VERSION = 1.1.0;
+				APP_VERSION = 1.1.1;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/installer/mac/updates/updates.xml
+++ b/installer/mac/updates/updates.xml
@@ -6,22 +6,23 @@
     <description>Most recent changes with links to updates.</description>
     <language>en</language>
       <item>
-        <title>Chain Core Developer Edition 1.1.0</title>
+        <title>Chain Core Developer Edition 1.1.1</title>
         <description>
           <![CDATA[
-            <p><b>NOTE:</b> This update will create a fresh blockchain; please backup
-              any blockchain data you wish to preserve.
+            <p><b>NOTE:</b> This update will create a fresh blockchain if you were previously
+              using versions 1.0.x; please backup any blockchain data you wish to preserve.
             </p>
             <ul>
               <li>Update to Chain Core 1.1.0</li>
+              <li>Improved startup detection of other Chain Cores</li>
             </ul>
           ]]>
         </description>
-        <pubDate>Fri, 24 Feb 2017 16:09:42 -0800</pubDate>
+        <pubDate>Wed, 01 Mar 2017 14:04:59 -0800</pubDate>
         <enclosure
-        	url="https://download.chain.com/mac/Chain_Core_1.1.0.zip"
-        	sparkle:version="1.1.0"
-        	length="54259396"
+        	url="https://download.chain.com/mac/Chain_Core_1.1.1.zip"
+        	sparkle:version="1.1.1"
+        	length="54257974"
         	type="application/octet-stream"
         	sparkle:dsaSignature=""
         	/>


### PR DESCRIPTION
Use `lsof` to check for a process listening on a required port instead of
creating and binding a new socket. The previous implementation was prone
to false negatives when checking if a port was available.

This is a 1.1-stable backport of #647 
