### PR TITLE
log: adopt -kv naming convention

### DIFF
--- a/cmd/blockcache/main.go
+++ b/cmd/blockcache/main.go
@@ -52,12 +52,12 @@ func main() {
 
 	u, err := url.Parse(*target)
 	if err != nil {
-		log.Fatal(context.Background(), log.KeyError, err)
+		log.Fatalkv(context.Background(), log.KeyError, err)
 	}
 
 	db, err := sql.Open("postgres", *dbURL)
 	if err != nil {
-		log.Fatal(context.Background(), log.KeyError, err)
+		log.Fatalkv(context.Background(), log.KeyError, err)
 	}
 
 	peer := &rpc.Client{
@@ -75,7 +75,7 @@ func main() {
 		id, err = getBlockchainID(peer)
 	}
 	if err != nil {
-		log.Fatal(context.Background(), log.KeyError, err)
+		log.Fatalkv(context.Background(), log.KeyError, err)
 	}
 
 	peer.BlockchainID = id
@@ -122,7 +122,7 @@ func main() {
 	if *tlsCrt != "" {
 		cert, err := tls.X509KeyPair([]byte(*tlsCrt), []byte(*tlsKey))
 		if err != nil {
-			log.Fatal(context.Background(), log.KeyError, errors.Wrap(err, "parsing tls X509 key pair"))
+			log.Fatalkv(context.Background(), log.KeyError, errors.Wrap(err, "parsing tls X509 key pair"))
 		}
 
 		server := &http.Server{
@@ -255,14 +255,14 @@ func cacheBlocks(cache *blockCache, peer *rpc.Client) {
 				peer.BlockchainID = "" // prevent ErrWrongNetwork
 				peer.BlockchainID, err = getBlockchainID(peer)
 				if err != nil {
-					log.Fatal(ctx, log.KeyError, err)
+					log.Fatalkv(ctx, log.KeyError, err)
 				}
 				height = 1
 
 				ctx, cancel = context.WithCancel(context.Background())
 				blocks, errs = fetch.DownloadBlocks(ctx, peer, height)
 			} else {
-				log.Fatal(ctx, log.KeyError, err)
+				log.Fatalkv(ctx, log.KeyError, err)
 			}
 		}
 	}

--- a/cmd/cored/dev.go
+++ b/cmd/cored/dev.go
@@ -35,10 +35,10 @@ func resetInDevIfRequested(db pg.DB) {
 		case "everything":
 			err = coreunsafe.ResetEverything(ctx, db)
 		default:
-			log.Fatal(ctx, log.KeyError, fmt.Errorf("unrecognized argument to reset: %s", *reset))
+			log.Fatalkv(ctx, log.KeyError, fmt.Errorf("unrecognized argument to reset: %s", *reset))
 		}
 		if err != nil {
-			log.Fatal(ctx, log.KeyError, err)
+			log.Fatalkv(ctx, log.KeyError, err)
 		}
 	}
 }

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -146,26 +146,26 @@ func runServer() {
 	sql.EnableQueryLogging(*logQueries)
 	db, err := sql.Open("hapg", *dbURL)
 	if err != nil {
-		chainlog.Fatal(ctx, chainlog.KeyError, err)
+		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 	db.SetMaxOpenConns(*maxDBConns)
 	db.SetMaxIdleConns(*maxDBConns)
 
 	err = migrate.Run(db)
 	if err != nil {
-		chainlog.Fatal(ctx, chainlog.KeyError, err)
+		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 	resetInDevIfRequested(db)
 
 	conf, err := config.Load(ctx, db)
 	if err != nil {
-		chainlog.Fatal(ctx, chainlog.KeyError, err)
+		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 
 	// Initialize internode rpc clients.
 	hostname, err := os.Hostname()
 	if err != nil {
-		chainlog.Fatal(ctx, chainlog.KeyError, err)
+		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 	processID := fmt.Sprintf("chain-%s-%d", hostname, os.Getpid())
 	if conf != nil {
@@ -193,7 +193,7 @@ func runServer() {
 	// ListenAndServe call, then log a welcome message.
 	go func() {
 		time.Sleep(time.Second)
-		chainlog.Messagef(ctx, "Chain Core online and listening at %s", *listenAddr)
+		chainlog.Printf(ctx, "Chain Core online and listening at %s", *listenAddr)
 	}()
 
 	server := &http.Server{
@@ -209,7 +209,7 @@ func runServer() {
 	if *tlsCrt != "" {
 		cert, err := tls.X509KeyPair([]byte(*tlsCrt), []byte(*tlsKey))
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, errors.Wrap(err, "parsing tls X509 key pair"))
+			chainlog.Fatalkv(ctx, chainlog.KeyError, errors.Wrap(err, "parsing tls X509 key pair"))
 		}
 
 		server.TLSConfig = &tls.Config{
@@ -217,12 +217,12 @@ func runServer() {
 		}
 		err = server.ListenAndServeTLS("", "") // uses TLS certs from above
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, errors.Wrap(err, "ListenAndServeTLS"))
+			chainlog.Fatalkv(ctx, chainlog.KeyError, errors.Wrap(err, "ListenAndServeTLS"))
 		}
 	} else {
 		err = server.ListenAndServe()
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, errors.Wrap(err, "ListenAndServe"))
+			chainlog.Fatalkv(ctx, chainlog.KeyError, errors.Wrap(err, "ListenAndServe"))
 		}
 	}
 }
@@ -231,12 +231,12 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 	// Initialize the protocol.Chain.
 	heights, err := txdb.ListenBlocks(ctx, *dbURL)
 	if err != nil {
-		chainlog.Fatal(ctx, chainlog.KeyError, err)
+		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 	store := txdb.NewStore(db)
 	c, err := protocol.NewChain(ctx, conf.BlockchainID, store, heights)
 	if err != nil {
-		chainlog.Fatal(ctx, chainlog.KeyError, err)
+		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 
 	var generatorSigners []generator.BlockSigner
@@ -244,7 +244,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 	if conf.IsSigner {
 		blockPub, err := hex.DecodeString(conf.BlockPub)
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, err)
+			chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 		}
 
 		var hsm blocksigner.Signer
@@ -262,7 +262,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 		} else {
 			hsm, err = devHSM(db)
 			if err != nil {
-				chainlog.Fatal(ctx, chainlog.KeyError, err)
+				chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 			}
 		}
 		s := blocksigner.New(blockPub, hsm, db, c)
@@ -271,7 +271,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 		signBlockHandler = func(ctx context.Context, b *bc.Block) ([]byte, error) {
 			sig, err := s.ValidateAndSignBlock(ctx, b)
 			if errors.Root(err) == blocksigner.ErrInvalidKey {
-				chainlog.Fatal(ctx, chainlog.KeyError, err)
+				chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 			}
 			return sig, err
 		}
@@ -305,7 +305,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 	pinStore := pin.NewStore(db)
 	err = pinStore.LoadAll(ctx)
 	if err != nil {
-		chainlog.Fatal(ctx, chainlog.KeyError, err)
+		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 	// Start listeners
 	go pinStore.Listen(ctx, account.PinName, *dbURL)
@@ -382,7 +382,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 		// for recovering after the previous leader's exit.
 		recoveredBlock, recoveredSnapshot, err := c.Recover(ctx)
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, err)
+			chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 		}
 
 		// Create all of the block processor pins.
@@ -392,23 +392,23 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 		}
 		err = pinStore.CreatePin(ctx, account.PinName, pinHeight)
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, err)
+			chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 		}
 		err = pinStore.CreatePin(ctx, account.ExpirePinName, pinHeight)
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, err)
+			chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 		}
 		err = pinStore.CreatePin(ctx, account.DeleteSpentsPinName, pinHeight)
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, err)
+			chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 		}
 		err = pinStore.CreatePin(ctx, asset.PinName, pinHeight)
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, err)
+			chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 		}
 		err = pinStore.CreatePin(ctx, query.TxPinName, pinHeight)
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, err)
+			chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 		}
 
 		if conf.IsGenerator {
@@ -432,7 +432,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 }
 
 func launchUnconfiguredCore(ctx context.Context, db pg.DB) http.Handler {
-	chainlog.Messagef(ctx, "Launching as unconfigured Core.")
+	chainlog.Printf(ctx, "Launching as unconfigured Core.")
 	return core.Handler(&core.API{
 		DB:           db,
 		AltAuth:      authLoopbackInDev,
@@ -465,10 +465,10 @@ func remoteSignerInfo(ctx context.Context, processID, buildTag, blockchainID str
 	for _, signer := range conf.Signers {
 		u, err := url.Parse(signer.URL)
 		if err != nil {
-			chainlog.Fatal(ctx, chainlog.KeyError, err)
+			chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 		}
 		if len(signer.Pubkey) != ed25519.PublicKeySize {
-			chainlog.Fatal(ctx, chainlog.KeyError, errors.Wrap(err), "at", "decoding signer public key")
+			chainlog.Fatalkv(ctx, chainlog.KeyError, errors.Wrap(err), "at", "decoding signer public key")
 		}
 		client := &rpc.Client{
 			BaseURL:      u.String(),

--- a/cmd/metricsd/main.go
+++ b/cmd/metricsd/main.go
@@ -57,9 +57,9 @@ func main() {
 	// Ensure that we can access cored.
 	err := client.Call(ctx, "/health", nil, nil)
 	if err != nil {
-		log.Fatal(ctx, log.KeyError, err)
+		log.Fatalkv(ctx, log.KeyError, err)
 	}
-	log.Messagef(ctx, "Successfully pinged cored at %s.", *coredAddr)
+	log.Printf(ctx, "Successfully pinged cored at %s.", *coredAddr)
 
 	// Periodically, report metrics.
 	latestNumRots := make(map[string]int)

--- a/cmd/vet/logparity.go
+++ b/cmd/vet/logparity.go
@@ -30,7 +30,7 @@ func checkLogCall(f *File, node ast.Node) {
 		return
 	}
 
-	if fun.FullName() != "chain/log.Write" && fun.FullName() != "chain/log.Fatal" {
+	if fun.FullName() != "chain/log.Printkv" && fun.FullName() != "chain/log.Fatalkv" {
 		return
 	}
 

--- a/cmd/vet/testdata/logparity.go
+++ b/cmd/vet/testdata/logparity.go
@@ -6,20 +6,20 @@ import "chain/log"
 
 // This function never executes, but it serves as a simple test for the program.
 // Test with (cd ..; go test).
-func WriteTests() {
-	log.Write(nil, "k", "v")       // ok
-	log.Write(nil)                 // zero is ok too
-	log.Write(nil, []int{0}...)    // any 'arg...' is ok too
-	log.Write(nil, "k")            // ERROR "odd number of arguments in call to log.Write"
-	log.Write(nil, "k", "v", "k2") // ERROR "odd number of arguments in call to log.Write"
+func PrintkvTests() {
+	log.Printkv(nil, "k", "v")            // ok
+	log.Printkv(nil)                      // zero is ok too
+	log.Printkv(nil, []interface{}{0}...) // any 'arg...' is ok too
+	log.Printkv(nil, "k")                 // ERROR "odd number of arguments in call to log.Printkv"
+	log.Printkv(nil, "k", "v", "k2")      // ERROR "odd number of arguments in call to log.Printkv"
 
 	var log writer
-	log.Write(nil, "k", "v")       // ok
-	log.Write(nil)                 // zero is ok too
-	log.Write(nil, "k")            // ok, log is not the package
-	log.Write(nil, "k", "v", "k2") // ok, log is not the package
+	log.Printkv(nil, "k", "v")       // ok
+	log.Printkv(nil)                 // zero is ok too
+	log.Printkv(nil, "k")            // ok, log is not the package
+	log.Printkv(nil, "k", "v", "k2") // ok, log is not the package
 }
 
 type writer struct{}
 
-func (w writer) Write(interface{}, ...interface{}) {}
+func (w writer) Printkv(interface{}, ...interface{}) {}

--- a/cmd/vet/testdata/logparity_rename.go
+++ b/cmd/vet/testdata/logparity_rename.go
@@ -4,11 +4,11 @@ package testdata
 
 import chainlog "chain/log"
 
-// WriteTestsWithRename never executes, but it serves as a simple test for
+// PrintkvTestsWithRename never executes, but it serves as a simple test for
 // the program. Test with (cd ..; go test).
-func WriteTestsWithRename() {
-	chainlog.Write(nil, "k", "v")       // ok
-	chainlog.Write(nil)                 // zero is ok too
-	chainlog.Write(nil, "k")            // ERROR "odd number of arguments in call to chainlog.Write"
-	chainlog.Write(nil, "k", "v", "k2") // ERROR "odd number of arguments in call to chainlog.Write"
+func PrintkvTestsWithRename() {
+	chainlog.Printkv(nil, "k", "v")       // ok
+	chainlog.Printkv(nil)                 // zero is ok too
+	chainlog.Printkv(nil, "k")            // ERROR "odd number of arguments in call to chainlog.Printkv"
+	chainlog.Printkv(nil, "k", "v", "k2") // ERROR "odd number of arguments in call to chainlog.Printkv"
 }

--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -70,7 +70,7 @@ func (m *Manager) ExpireReservations(ctx context.Context, period time.Duration) 
 	for {
 		select {
 		case <-ctx.Done():
-			log.Messagef(ctx, "Deposed, ExpireReservations exiting")
+			log.Printf(ctx, "Deposed, ExpireReservations exiting")
 			return
 		case <-ticks:
 			err := m.utxoDB.ExpireReservations(ctx)

--- a/core/config/dev.go
+++ b/core/config/dev.go
@@ -20,9 +20,9 @@ func getOrCreateDevKey(ctx context.Context, db pg.DB, c *Config) (blockPub []byt
 	blockPub = corePub.Pub
 	blockPubStr := hex.EncodeToString(blockPub)
 	if created {
-		log.Messagef(ctx, "Generated new block-signing key %s\n", blockPubStr)
+		log.Printf(ctx, "Generated new block-signing key %s\n", blockPubStr)
 	} else {
-		log.Messagef(ctx, "Using block-signing key %s\n", blockPubStr)
+		log.Printf(ctx, "Using block-signing key %s\n", blockPubStr)
 	}
 	c.BlockPub = blockPubStr
 

--- a/core/core.go
+++ b/core/core.go
@@ -144,21 +144,21 @@ func closeConnOK(w http.ResponseWriter, req *http.Request) {
 
 	hijacker, ok := w.(http.Hijacker)
 	if !ok {
-		log.Messagef(req.Context(), "no hijacker")
+		log.Printf(req.Context(), "no hijacker")
 		return
 	}
 	conn, buf, err := hijacker.Hijack()
 	if err != nil {
-		log.Messagef(req.Context(), "could not hijack connection: %s\n", err)
+		log.Printf(req.Context(), "could not hijack connection: %s\n", err)
 		return
 	}
 	err = buf.Flush()
 	if err != nil {
-		log.Messagef(req.Context(), "could not flush connection buffer: %s\n", err)
+		log.Printf(req.Context(), "could not flush connection buffer: %s\n", err)
 	}
 	err = conn.Close()
 	if err != nil {
-		log.Messagef(req.Context(), "could not close connection: %s\n", err)
+		log.Printf(req.Context(), "could not close connection: %s\n", err)
 	}
 }
 

--- a/core/fetch/fetch.go
+++ b/core/fetch/fetch.go
@@ -94,7 +94,7 @@ func Fetch(ctx context.Context, c *protocol.Chain, peer *rpc.Client, health func
 	for {
 		select {
 		case <-ctx.Done():
-			log.Messagef(ctx, "Deposed, Fetch exiting")
+			log.Printf(ctx, "Deposed, Fetch exiting")
 			return
 		case err = <-errch:
 			health(err)
@@ -103,7 +103,7 @@ func Fetch(ctx context.Context, c *protocol.Chain, peer *rpc.Client, health func
 			for {
 				prevSnapshot, prevBlock, err = applyBlock(ctx, c, prevSnapshot, prevBlock, b)
 				if err == protocol.ErrBadBlock {
-					log.Fatal(ctx, log.KeyError, err)
+					log.Fatalkv(ctx, log.KeyError, err)
 				} else if err != nil {
 					// This is a serious I/O error.
 					health(err)
@@ -174,7 +174,7 @@ func pollGeneratorHeight(ctx context.Context, peer *rpc.Client) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Messagef(ctx, "Deposed, fetchGeneratorHeight exiting")
+			log.Printf(ctx, "Deposed, fetchGeneratorHeight exiting")
 			ticker.Stop()
 			return
 		case <-ticker.C:
@@ -259,7 +259,7 @@ func getHeight(ctx context.Context, peer *rpc.Client) (uint64, error) {
 
 func logNetworkError(ctx context.Context, err error) {
 	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-		log.Messagef(ctx, "%s", err.Error())
+		log.Printf(ctx, "%s", err.Error())
 	} else {
 		log.Error(ctx, err)
 	}

--- a/core/generator/block.go
+++ b/core/generator/block.go
@@ -115,7 +115,7 @@ func (g *Generator) getAndAddBlockSignatures(ctx context.Context, b, prevBlock *
 			goodSigs[k] = sig
 			nready++
 		} else if k < 0 {
-			log.Write(ctx, "error", "invalid signature", "block", b.Hash(), "signature", sig)
+			log.Printkv(ctx, "error", "invalid signature", "block", b.Hash(), "signature", sig)
 		}
 	}
 
@@ -139,7 +139,7 @@ func getSig(ctx context.Context, signer BlockSigner, b *bc.Block, sig *[]byte, i
 	var err error
 	*sig, err = signer.SignBlock(ctx, b)
 	if err != nil && ctx.Err() != context.Canceled {
-		log.Write(ctx, "error", err, "signer", signer)
+		log.Printkv(ctx, "error", err, "signer", signer)
 	}
 	done <- i
 }

--- a/core/generator/generator.go
+++ b/core/generator/generator.go
@@ -103,19 +103,19 @@ func (g *Generator) Generate(
 	// the block and committing the signed block to the blockchain.
 	b, err := getPendingBlock(ctx, g.db)
 	if err != nil {
-		log.Fatal(ctx, log.KeyError, err)
+		log.Fatalkv(ctx, log.KeyError, err)
 	}
 	if b != nil && (g.latestBlock == nil || b.Height == g.latestBlock.Height+1) {
 		s := state.Copy(g.latestSnapshot)
 		err := validation.ApplyBlock(s, b)
 		if err != nil {
-			log.Fatal(ctx, log.KeyError, err)
+			log.Fatalkv(ctx, log.KeyError, err)
 		}
 
 		// g.commitBlock will update g.latestBlock and g.latestSnapshot.
 		err = g.commitBlock(ctx, b, s)
 		if err != nil {
-			log.Fatal(ctx, log.KeyError, err)
+			log.Fatalkv(ctx, log.KeyError, err)
 		}
 	}
 
@@ -123,7 +123,7 @@ func (g *Generator) Generate(
 	for {
 		select {
 		case <-ctx.Done():
-			log.Messagef(ctx, "Deposed, Generate exiting")
+			log.Printf(ctx, "Deposed, Generate exiting")
 			return
 		case <-ticks:
 			err := g.makeBlock(ctx)

--- a/core/http.go
+++ b/core/http.go
@@ -49,7 +49,7 @@ func logHTTPError(ctx context.Context, err error) {
 	if info.HTTPStatus == 500 {
 		keyvals = append(keyvals, log.KeyStack, errors.Stack(err))
 	}
-	log.Write(ctx, keyvals...)
+	log.Printkv(ctx, keyvals...)
 }
 
 func alwaysError(err error) http.Handler {

--- a/core/leader/leader.go
+++ b/core/leader/leader.go
@@ -46,17 +46,17 @@ func Run(db *sql.DB, addr string, lead func(context.Context)) {
 		lead:    lead,
 		address: addr,
 	}
-	log.Messagef(ctx, "Using leaderKey: %q", l.key)
+	log.Printf(ctx, "Using leaderKey: %q", l.key)
 
 	var leadCtx context.Context
 	var cancel func()
 	for leader := range leadershipChanges(ctx, l) {
 		if leader {
-			log.Messagef(ctx, "I am the core leader")
+			log.Printf(ctx, "I am the core leader")
 			leadCtx, cancel = context.WithCancel(ctx)
 			l.lead(leadCtx)
 		} else {
-			log.Messagef(ctx, "No longer core leader")
+			log.Printf(ctx, "No longer core leader")
 			cancel()
 		}
 

--- a/core/migrate/migrate.go
+++ b/core/migrate/migrate.go
@@ -49,7 +49,7 @@ func Run(db pg.DB) error {
 			return err
 		}
 
-		log.Write(ctx, "migration", m.Name, "status", "success")
+		log.Printkv(ctx, "migration", m.Name, "status", "success")
 	}
 	return nil
 }
@@ -98,7 +98,7 @@ func loadStatus(db pg.DB, ms []migration) error {
 	var n int
 	err := db.QueryRow(ctx, q).Scan(&n)
 	if err != nil {
-		log.Fatal(ctx, log.KeyError, err)
+		log.Fatalkv(ctx, log.KeyError, err)
 	}
 	if n == 0 {
 		return nil // no schema; nothing has been applied

--- a/database/sql/sql.go
+++ b/database/sql/sql.go
@@ -51,7 +51,7 @@ func logQuery(ctx context.Context, query string, args interface{}) {
 		if len(s) > maxArgsLogLen {
 			s = s[:maxArgsLogLen-3] + "..."
 		}
-		log.Write(ctx, "query", query, "args", s)
+		log.Printkv(ctx, "query", query, "args", s)
 	}
 }
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -43,7 +43,7 @@ func TestPrefix(t *testing.T) {
 	}
 }
 
-func TestWrite(t *testing.T) {
+func TestPrintkv(t *testing.T) {
 	examples := []struct {
 		keyvals []interface{}
 		want    []string
@@ -124,7 +124,7 @@ func TestWrite(t *testing.T) {
 	}
 }
 
-func TestWriteRequestID(t *testing.T) {
+func TestPrintkvRequestID(t *testing.T) {
 	buf := new(bytes.Buffer)
 	SetOutput(buf)
 	defer SetOutput(os.Stdout)
@@ -169,7 +169,7 @@ func TestMessagef(t *testing.T) {
 	}
 }
 
-func TestWriteStack(t *testing.T) {
+func TestPrintkvStack(t *testing.T) {
 	buf := new(bytes.Buffer)
 	SetOutput(buf)
 	defer SetOutput(os.Stdout)
@@ -189,7 +189,7 @@ func TestWriteStack(t *testing.T) {
 		"error=boo",
 
 		// stack trace
-		"TestWriteStack\n",
+		"TestPrintkvStack\n",
 		"/go/",
 	}
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -16,7 +16,7 @@ func TestSetOutput(t *testing.T) {
 	var buf bytes.Buffer
 	want := "foobar"
 	SetOutput(&buf)
-	Messagef(context.Background(), want)
+	Printf(context.Background(), want)
 	SetOutput(os.Stdout)
 	got := buf.String()
 	if !strings.Contains(got, want) {
@@ -28,7 +28,7 @@ func TestPrefix(t *testing.T) {
 	buf := new(bytes.Buffer)
 	SetOutput(buf)
 	SetPrefix("foo", "bar")
-	Write(context.Background(), "baz", 1)
+	Printkv(context.Background(), "baz", 1)
 	SetOutput(os.Stdout)
 
 	got := buf.String()
@@ -101,7 +101,7 @@ func TestWrite(t *testing.T) {
 		buf := new(bytes.Buffer)
 		SetOutput(buf)
 
-		Write(context.Background(), ex.keyvals...)
+		Printkv(context.Background(), ex.keyvals...)
 
 		read, err := ioutil.ReadAll(buf)
 		if err != nil {
@@ -129,7 +129,7 @@ func TestWriteRequestID(t *testing.T) {
 	SetOutput(buf)
 	defer SetOutput(os.Stdout)
 
-	Write(reqid.NewContext(context.Background(), "example-request-id"))
+	Printkv(reqid.NewContext(context.Background(), "example-request-id"))
 
 	read, err := ioutil.ReadAll(buf)
 	if err != nil {
@@ -149,7 +149,7 @@ func TestMessagef(t *testing.T) {
 	SetOutput(buf)
 	defer SetOutput(os.Stdout)
 
-	Messagef(context.Background(), "test round %d", 0)
+	Printf(context.Background(), "test round %d", 0)
 
 	read, err := ioutil.ReadAll(buf)
 	if err != nil {
@@ -176,7 +176,7 @@ func TestWriteStack(t *testing.T) {
 
 	root := errors.New("boo")
 	wrapped := errors.Wrap(root)
-	Write(context.Background(), KeyError, wrapped)
+	Printkv(context.Background(), KeyError, wrapped)
 
 	read, err := ioutil.ReadAll(buf)
 	if err != nil {
@@ -239,7 +239,7 @@ func TestRawStack(t *testing.T) {
 	defer SetOutput(os.Stdout)
 
 	stack := []byte("this\nis\na\nraw\nstack")
-	Write(context.Background(), "message", "foo", "stack", stack)
+	Printkv(context.Background(), "message", "foo", "stack", stack)
 
 	got := buf.String()
 	if !strings.HasSuffix(got, "\n"+string(stack)+"\n") {

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -152,7 +152,7 @@ func (c *Chain) queueSnapshot(ctx context.Context, height uint64, timestamp time
 		c.lastQueuedSnapshot = timestamp
 	default:
 		// Skip it; saving snapshots is taking longer than the snapshotting period.
-		log.Messagef(ctx, "snapshot storage is taking too long; last queued at %s",
+		log.Printf(ctx, "snapshot storage is taking too long; last queued at %s",
 			c.lastQueuedSnapshot)
 	}
 }


### PR DESCRIPTION
Standard library package log uses the suffix "f" to
indicate that a function takes a format string. We adopt
the same convention here, plus we use the suffix "kv" to
incicate the arguments are key-value pairs.