### PR TITLE
docs: use release branches as source of production docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,11 +41,13 @@ Log into `aws` with the command:
 $ aws configure
 ```
 
-#### The `docs-<major>.<minor>.x` branches
+#### Checking out the right version of docs
 
 Before uploading documentation, make sure your local state reflects the correct documentation. The `main` branch is generally not safe for this purpose, since it may contain documentation updates that reflect changes that have yet to make it into an official relase.
 
-The state of production documentation is tracked in the `docs-<major>.<minor>.x` family of branches. Each such branch reflects the last known safe version of the documentation for the corresponding major/minor version pair.
+The state of production documentation is tracked in the `<major>.<minor>-stable` family of release branches. Each such branch reflects the last known safe version of the documentation for the corresponding major/minor version pair.
+
+For the time being, only the most recent version of the documentation is published online. Please make sure you are on the most recent release branch before uploading.
 
 #### Uploading the docs
 
@@ -53,7 +55,7 @@ Staging:
 
 ```
 cd $CHAIN
-git checkout docs-<major>.<minor>.x
+git checkout <major>.<minor>-stable
 ./bin/upload-docs
 ```
 
@@ -61,6 +63,6 @@ Production:
 
 ```
 cd $CHAIN
-git checkout docs-<major>.<minor>.x
+git checkout <major>.<minor>-stable
 ./bin/upload-docs prod
 ```

--- a/docs/internal/package-tags-branches.md
+++ b/docs/internal/package-tags-branches.md
@@ -4,7 +4,6 @@
 
 - `chain-core-server`: `cored` and associated utilities. Previously known as `cmd.cored`.
 - `chain-enclave`: HSM utilities, such as `signerd`.
-- `docs`: Markdown documentation, not including SDK-specific docs.
 - `chain-core-docker`: Docker image. Previously known as `docker.de`.
 - `chain-core-mac`: Mac app. Previously known as `installer.mac`.
 - `chain-core-windows`: Windows installer. Previously known as `installer.windows`.


### PR DESCRIPTION
Now that we have the 1.1-stable branch, we can simplify our
documentation workflow by simply generating and uploading
documentation from the tip of that branch. For the time being, it
doesn't seem like a separate docs tag is necessary.

This commit updates various pieces of documentation to account for
this simplified workflow.