### PR TITLE
core/signers: correctly record xpubs for a signer with multiple keys

### DIFF
--- a/core/signers/signers.go
+++ b/core/signers/signers.go
@@ -94,6 +94,7 @@ func Create(ctx context.Context, db pg.DB, typ string, xpubs []chainkd.XPub, quo
 
 	var xpubBytes [][]byte
 	for _, key := range xpubs {
+		key := key
 		xpubBytes = append(xpubBytes, key[:])
 	}
 


### PR DESCRIPTION
Avoid the Go pitfall involving reuse of loop variables.