### PR TITLE
core/asset: avoid Go loop-variable pitfall

### DIFF
--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -72,6 +72,7 @@ func Annotated(a *Asset) (*query.AnnotatedAsset, error) {
 		pubkeys, quorum, err := vmutil.ParseP2SPMultiSigProgram(a.IssuanceProgram)
 		if err == nil {
 			for _, pubkey := range pubkeys {
+				pubkey := pubkey
 				aa.Keys = append(aa.Keys, &query.AssetKey{
 					AssetPubkey: chainjson.HexBytes(pubkey[:]),
 				})


### PR DESCRIPTION
This is the result of a code audit following the discovery of the bug fixed in https://github.com/chain/chain/pull/716. I found only one other place that needed the same change.