### PR TITLE
core/asset, core/signers: correctly record xpubs for a signer with multiple keys; avoid Go loop pitfall

### DIFF
--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -72,6 +72,7 @@ func Annotated(a *Asset) (*query.AnnotatedAsset, error) {
 		pubkeys, quorum, err := vmutil.ParseP2SPMultiSigProgram(a.IssuanceProgram)
 		if err == nil {
 			for _, pubkey := range pubkeys {
+				pubkey := pubkey
 				aa.Keys = append(aa.Keys, &query.AssetKey{
 					AssetPubkey: chainjson.HexBytes(pubkey[:]),
 				})

--- a/core/signers/signers.go
+++ b/core/signers/signers.go
@@ -94,6 +94,7 @@ func Create(ctx context.Context, db pg.DB, typ string, xpubs []chainkd.XPub, quo
 
 	var xpubBytes [][]byte
 	for _, key := range xpubs {
+		key := key
 		xpubBytes = append(xpubBytes, key[:])
 	}
 


### PR DESCRIPTION
This is https://github.com/chain/chain/pull/716 + https://github.com/chain/chain/pull/717.