### PR TITLE
sdk/java: increase index to core url monotically

### DIFF
--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -318,7 +318,7 @@ public class Client {
       int idx = this.urlIndex.get();
       URL endpointURL;
       try {
-        URI u = new URI(this.urls.get(idx).toString() + "/" + path);
+        URI u = new URI(this.urls.get(idx % this.urls.size()).toString() + "/" + path);
         u = u.normalize();
         endpointURL = new URL(u.toString());
       } catch (MalformedURLException ex) {
@@ -473,7 +473,7 @@ public class Client {
 
     // A request to the url at failedIndex just failed. Move to the next
     // URL in the list.
-    int nextIndex = (failedIndex + 1) % this.urls.size();
+    int nextIndex = failedIndex + 1;
     this.urlIndex.compareAndSet(failedIndex, nextIndex);
   }
 


### PR DESCRIPTION
The client keeps a list of core URLs which it uses
to load balance requests to the server. An index
is kept corresponding to a position in this list. When
an error occurs the index is increased. 

Previously, it was possible for separate requests to
read the same index and increase it separately. We have
updated the logic to mitigate this by finding the position 
in the list (performing the modulo operation) just before
a request is made.