### PR TITLE
sdk/java: only advance URL on temporary errors

### DIFF
--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -364,14 +364,14 @@ public class Client {
         // ConnectivityExceptions are always retriable.
         exception = ex;
       } catch (APIException ex) {
-        // This URL's process might be unhealthy; move to the next.
-        this.nextURL(idx);
-
         // Check if this error is retriable (either it's a status code that's
         // always retriable or the error is explicitly marked as temporary.
         if (!isRetriableStatusCode(ex.statusCode) && !ex.temporary) {
           throw ex;
         }
+
+        // This URL's process might be unhealthy; move to the next.
+        this.nextURL(idx);
         exception = ex;
       }
     }


### PR DESCRIPTION
If a call throws an APIException, we should only advance the client
URL index if the error is a temporary, retriable error. Permanent
errors shouldn't cause us to move on to the next Core URL.