### PR TITLE
installer/mac: update to version 1.1.1

### DIFF
--- a/installer/mac/CHANGELOG.md
+++ b/installer/mac/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Chain Core Mac Installer changelog
 
-## 1.1.1 (March 7, 2017)
+## 1.1.1 (March 8, 2017)
 
-* Updated to Chain Core [1.1.2](https://github.com/chain/chain/blob/1.1-stable/CHANGELOG.md#1.1.2)
+* Updated to Chain Core [1.1.3](https://github.com/chain/chain/blob/1.1-stable/CHANGELOG.md#1.1.3)
 * Improved startup detection of other Chain Cores
 
 ## 1.1.0 (February 24, 2017)

--- a/installer/mac/tools/build_chain.sh
+++ b/installer/mac/tools/build_chain.sh
@@ -9,7 +9,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 tempBuildPath=`mktemp -d`
 trap "rm -rf $tempBuildPath" EXIT
-"${CHAIN}/bin/build-cored-release" chain-core-server-1.1.2 $tempBuildPath
+"${CHAIN}/bin/build-cored-release" chain-core-server-1.1.3 $tempBuildPath
 
 cp -f $tempBuildPath/cored "${TARGET_DIR}/"
 cp -f $tempBuildPath/corectl "${TARGET_DIR}/"

--- a/installer/mac/updates/updates.xml
+++ b/installer/mac/updates/updates.xml
@@ -13,16 +13,16 @@
               using versions 1.0.x or 1.1.0; please backup any blockchain data you wish to preserve.
             </p>
             <ul>
-              <li>Update the Chain Core server package to version 1.1.2</li>
+              <li>Update the Chain Core server package to version 1.1.3</li>
               <li>Improved startup detection of other Chain Cores</li>
             </ul>
           ]]>
         </description>
-        <pubDate>Mon, 06 Mar 2017 17:25:28 -0800</pubDate>
+        <pubDate>Wed, 08 Mar 2017 17:02:30 -0800</pubDate>
         <enclosure
         	url="https://download.chain.com/mac/Chain_Core_1.1.1.zip"
         	sparkle:version="1.1.1"
-        	length="53949592"
+        	length="54200125"
         	type="application/octet-stream"
         	sparkle:dsaSignature=""
         	/>


### PR DESCRIPTION
This replaces a previous commit that linked macapp 1.1.1 to server
1.1.2. We ended up using server 1.1.3.

This update should also be made to main, to keep main up-to-date.