### PR TITLE
all: update main branch with server 1.1.3 build updates

### DIFF
--- a/bin/build-docker-de
+++ b/bin/build-docker-de
@@ -8,7 +8,7 @@ cleanup() {
 trap cleanup EXIT
 
 imageVersion=${IMAGE_VERSION:-1.1.1}
-coredVersion=${CORED_VERSION:-chain-core-server-1.1.2}
+coredVersion=${CORED_VERSION:-chain-core-server-1.1.3}
 
 GOOS=linux GOARCH=amd64 bin/build-cored-release "$coredVersion" $CHAIN/docker/de/
 docker build --tag chaincore/developer $CHAIN/docker/de/

--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -22,7 +22,7 @@ import (
 	_ "chain/protocol/tx" // for BlockHeaderHashFunc
 )
 
-const version = "1.1.2"
+const version = "1.1.3"
 
 // config vars
 var (

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -53,7 +53,7 @@ import (
 const (
 	httpReadTimeout  = 2 * time.Minute
 	httpWriteTimeout = time.Hour
-	latestVersion    = "1.1.2"
+	latestVersion    = "1.1.3"
 )
 
 var (

--- a/docs/core/get-started/sdk.md
+++ b/docs/core/get-started/sdk.md
@@ -19,7 +19,7 @@ The Java SDK is available via [Maven](https://search.maven.org/#search%7Cga%7C1%
   <dependency>
     <groupId>com.chain</groupId>
     <artifactId>chain-sdk-java</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.3</version>
   </dependency>
 </dependencies>
 ```
@@ -27,10 +27,10 @@ The Java SDK is available via [Maven](https://search.maven.org/#search%7Cga%7C1%
 **Gradle** users should add the following to `build.gradle`:
 
 ```
-compile 'com.chain:chain-sdk-java:1.1.1'
+compile 'com.chain:chain-sdk-java:1.1.3'
 ```
 
-You can also [download the JAR](https://search.maven.org/remotecontent?filepath=com/chain/chain-sdk-java/1.1.0/chain-sdk-java-1.1.1.jar) as a binary.
+You can also [download the JAR](https://search.maven.org/remotecontent?filepath=com/chain/chain-sdk-java/1.1.3/chain-sdk-java-1.1.3.jar) as a binary.
 
 ## Node.js
 

--- a/installer/mac/CHANGELOG.md
+++ b/installer/mac/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Chain Core Mac Installer changelog
 
-## 1.1.1 (March 7, 2017)
+## 1.1.1 (March 8, 2017)
 
-* Updated to Chain Core [1.1.2](https://github.com/chain/chain/blob/1.1-stable/CHANGELOG.md#1.1.2)
+* Updated to Chain Core [1.1.3](https://github.com/chain/chain/blob/1.1-stable/CHANGELOG.md#1.1.3)
 * Improved startup detection of other Chain Cores
 
 ## 1.1.0 (February 24, 2017)

--- a/installer/mac/tools/build_chain.sh
+++ b/installer/mac/tools/build_chain.sh
@@ -9,7 +9,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 tempBuildPath=`mktemp -d`
 trap "rm -rf $tempBuildPath" EXIT
-"${CHAIN}/bin/build-cored-release" chain-core-server-1.1.2 $tempBuildPath
+"${CHAIN}/bin/build-cored-release" chain-core-server-1.1.3 $tempBuildPath
 
 cp -f $tempBuildPath/cored "${TARGET_DIR}/"
 cp -f $tempBuildPath/corectl "${TARGET_DIR}/"

--- a/installer/mac/updates/updates.xml
+++ b/installer/mac/updates/updates.xml
@@ -13,16 +13,16 @@
               using versions 1.0.x or 1.1.0; please backup any blockchain data you wish to preserve.
             </p>
             <ul>
-              <li>Update the Chain Core server package to version 1.1.2</li>
+              <li>Update the Chain Core server package to version 1.1.3</li>
               <li>Improved startup detection of other Chain Cores</li>
             </ul>
           ]]>
         </description>
-        <pubDate>Mon, 06 Mar 2017 17:25:28 -0800</pubDate>
+        <pubDate>Wed, 08 Mar 2017 17:02:30 -0800</pubDate>
         <enclosure
         	url="https://download.chain.com/mac/Chain_Core_1.1.1.zip"
         	sparkle:version="1.1.1"
-        	length="53949592"
+        	length="54200125"
         	type="application/octet-stream"
         	sparkle:dsaSignature=""
         	/>

--- a/installer/windows/CHANGELOG.md
+++ b/installer/windows/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Chain Core Windows Installer changelog
 
-## 1.1.1 (March 7, 2017)
+## 1.1.1 (March 8, 2017)
 
-* Updated to Chain Core [1.1.2](https://github.com/chain/chain/blob/1.1-stable/CHANGELOG.md#1.1.2)
+* Updated to Chain Core [1.1.3](https://github.com/chain/chain/blob/1.1-stable/CHANGELOG.md#1.1.3)
 
 ## 1.1.0 (February 24, 2017)
 


### PR DESCRIPTION
This commit refreshes `main` with the latest build updates on `1.1-stable` (cored 1.1.3 and the corresponding installer updates).