### PR TITLE
core/account: carry `change` onto `account_utxos`

### DIFF
--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -14,12 +14,13 @@ import (
 const sampleAccountUTXOs = `
 	INSERT INTO account_utxos
 	(output_id, asset_id, amount, account_id, control_program_index,
-     control_program, confirmed_in, source_id, source_pos, ref_data_hash) VALUES (
+     control_program, confirmed_in, source_id, source_pos, ref_data_hash, change) VALUES (
 		decode('9886ae2dc24b6d868c68768038c43801e905a62f1a9b826ca0dc357f00c30117', 'hex'),
 		decode('df1df9d4f66437ab5be715e4d1faeb29d24c80a6dc8276d6a630f05c5f1f7693', 'hex'),
 		1000, 'accEXAMPLE', 1, '\x6a'::bytea, 1,
 		decode('905a62f1a9b826ca0dc357f00c301179886ae2dc24b6d868c68768038c43801e', 'hex'),
-		0, decode('0000000000000000000000000000000000000000000000000000000000000000', 'hex'));
+		0, decode('0000000000000000000000000000000000000000000000000000000000000000', 'hex'),
+		false);
 `
 
 func TestCancelReservation(t *testing.T) {

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -48,4 +48,13 @@ var migrations = []migration{
 			ADD COLUMN source_pos bigint NOT NULL,
 			ADD COLUMN ref_data_hash bytea NOT NULL;
 	`},
+	{Name: `2017-03-09.0.core.account-utxos-change.sql`, SQL: `
+		BEGIN;
+		ALTER TABLE account_utxos ADD COLUMN change bool;
+		UPDATE account_utxos AS u SET change = acp.change
+			FROM account_control_programs AS acp
+			WHERE acp.control_program = u.control_program;
+		ALTER TABLE account_utxos ALTER COLUMN change SET NOT NULL;
+		COMMIT;
+	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -197,7 +197,8 @@ CREATE TABLE account_utxos (
     output_id bytea NOT NULL,
     source_id bytea NOT NULL,
     source_pos bigint NOT NULL,
-    ref_data_hash bytea NOT NULL
+    ref_data_hash bytea NOT NULL,
+    change boolean NOT NULL
 );
 
 
@@ -899,3 +900,4 @@ insert into migrations (filename, hash) values ('2017-02-07.0.query.non-null-ali
 insert into migrations (filename, hash) values ('2017-02-16.0.query.spent-output.sql', '7cd52095b6f202d7a25ffe666b7b7d60e7700d314a7559b911e236b72661a738');
 insert into migrations (filename, hash) values ('2017-02-28.0.core.remove-outpoints.sql', '067638e2a826eac70d548f2d6bb234660f3200064072baf42db741456ecf8deb');
 insert into migrations (filename, hash) values ('2017-03-02.0.core.add-output-source-info.sql', 'f44c7cfbff346f6f797d497910c0a76f2a7600ca8b5be4fe4e4a04feaf32e0df');
+insert into migrations (filename, hash) values ('2017-03-09.0.core.account-utxos-change.sql', 'a99e0e41be3da126a8c47151454098669334bf7e30de6cd539ba535add4e85d1');


### PR DESCRIPTION
When indexing account UTXOs, carry the `change` flag onto the
`account_utxos` SQL table from `account_control_programs`. This
will allow the query block processor to use exclusively `account_utxos`
for annotating transactions.

Note that this migration creates a new, non-nullable column. The
migration atomically backfills the column. However, in a rolling deploy,
an older cored binary may try to insert nulls into the `change` column.
This is okay because new rows are only ever inserted by the account
block processor. If the block processor is running on an older 1.1.x
cored, the block processor will error out and be reattempted until it
succeeds. It'll succeed when a 1.2.x process becomes leader and
reattempts the block processor.

Practically, this means the processing of blocks may be delayed for
the duration of the rolling deploy during an upgrade to 1.2.