### PR TITLE
core/coretest: add missing pins to CreatePins

### DIFF
--- a/core/coretest/fixtures.go
+++ b/core/coretest/fixtures.go
@@ -18,7 +18,13 @@ import (
 )
 
 func CreatePins(ctx context.Context, t testing.TB, s *pin.Store) {
-	pins := []string{account.PinName, asset.PinName, query.TxPinName}
+	pins := []string{
+		account.PinName,
+		account.ExpirePinName,
+		account.DeleteSpentsPinName,
+		asset.PinName,
+		query.TxPinName,
+	}
 	for _, p := range pins {
 		err := s.CreatePin(ctx, p, 0)
 		if err != nil {


### PR DESCRIPTION
These two new pins were added in a97b23 and 872e19 but weren't
added to the `coretest.CreatePins` function. The account package's
ProcessBlocks function will start all three of its block processors,
so all three of the pins should be initialized.