### PR TITLE
protocol/bc: export various identifiers

### DIFF
--- a/protocol/bc/blockheader.go
+++ b/protocol/bc/blockheader.go
@@ -1,6 +1,6 @@
 package bc
 
-type blockHeader struct {
+type BlockHeaderEntry struct {
 	body struct {
 		Version              uint64
 		Height               uint64
@@ -13,13 +13,13 @@ type blockHeader struct {
 	}
 }
 
-func (blockHeader) Type() string          { return "blockheader" }
-func (bh *blockHeader) Body() interface{} { return bh.body }
+func (BlockHeaderEntry) Type() string          { return "blockheader" }
+func (bh *BlockHeaderEntry) Body() interface{} { return bh.body }
 
-func (blockHeader) Ordinal() int { return -1 }
+func (BlockHeaderEntry) Ordinal() int { return -1 }
 
-func newBlockHeader(version, height uint64, previousBlockID Hash, timestampMS uint64, transactionsRoot, assetsRoot Hash, nextConsensusProgram []byte) *blockHeader {
-	bh := new(blockHeader)
+func newBlockHeader(version, height uint64, previousBlockID Hash, timestampMS uint64, transactionsRoot, assetsRoot Hash, nextConsensusProgram []byte) *BlockHeaderEntry {
+	bh := new(BlockHeaderEntry)
 	bh.body.Version = version
 	bh.body.Height = height
 	bh.body.PreviousBlockID = previousBlockID

--- a/protocol/bc/blockheader.go
+++ b/protocol/bc/blockheader.go
@@ -18,7 +18,7 @@ func (bh *BlockHeaderEntry) Body() interface{} { return bh.body }
 
 func (BlockHeaderEntry) Ordinal() int { return -1 }
 
-func newBlockHeader(version, height uint64, previousBlockID Hash, timestampMS uint64, transactionsRoot, assetsRoot Hash, nextConsensusProgram []byte) *BlockHeaderEntry {
+func NewBlockHeader(version, height uint64, previousBlockID Hash, timestampMS uint64, transactionsRoot, assetsRoot Hash, nextConsensusProgram []byte) *BlockHeaderEntry {
 	bh := new(BlockHeaderEntry)
 	bh.body.Version = version
 	bh.body.Height = height

--- a/protocol/bc/blockheader.go
+++ b/protocol/bc/blockheader.go
@@ -1,5 +1,7 @@
 package bc
 
+// BlockHeaderEntry contains the header information for a blockchain
+// block. It satisfies the Entry interface.
 type BlockHeaderEntry struct {
 	body struct {
 		Version              uint64
@@ -18,7 +20,9 @@ func (bh *BlockHeaderEntry) Body() interface{} { return bh.body }
 
 func (BlockHeaderEntry) Ordinal() int { return -1 }
 
-func NewBlockHeader(version, height uint64, previousBlockID Hash, timestampMS uint64, transactionsRoot, assetsRoot Hash, nextConsensusProgram []byte) *BlockHeaderEntry {
+// NewBlockHeaderEntry creates a new BlockHeaderEntry and populates
+// its body.
+func NewBlockHeaderEntry(version, height uint64, previousBlockID Hash, timestampMS uint64, transactionsRoot, assetsRoot Hash, nextConsensusProgram []byte) *BlockHeaderEntry {
 	bh := new(BlockHeaderEntry)
 	bh.body.Version = version
 	bh.body.Height = height

--- a/protocol/bc/entry.go
+++ b/protocol/bc/entry.go
@@ -10,7 +10,7 @@ import (
 	"chain/errors"
 )
 
-type entry interface {
+type Entry interface {
 	Type() string
 	Body() interface{}
 
@@ -24,7 +24,7 @@ type entry interface {
 
 var errInvalidValue = errors.New("invalid value")
 
-func entryID(e entry) (hash Hash) {
+func EntryID(e Entry) (hash Hash) {
 	if e == nil {
 		return hash
 	}

--- a/protocol/bc/entry.go
+++ b/protocol/bc/entry.go
@@ -10,20 +10,30 @@ import (
 	"chain/errors"
 )
 
+// Entry is the interface implemented by each addressable unit in a
+// blockchain: transaction components such as spends, issuances,
+// outputs, and retirements (among others), plus blockheaders.
 type Entry interface {
+	// Type produces a short human-readable string uniquely identifying
+	// the type of this entry.
 	Type() string
+
+	// Body produces the entry's body, which is used as input to
+	// EntryID.
 	Body() interface{}
 
-	// When an entry is created from a TxInput or a TxOutput, this
-	// reports the position of that antecedent object within its
-	// transaction. Both inputs (spends and issuances) and outputs
-	// (including retirements) are numbered beginning at zero. Entries
-	// not originating in this way report -1.
+	// Ordinal reports the position of the TxInput or TxOutput within
+	// its transaction, when this entry was created from such an
+	// object. (See mapTx.) Both inputs (spends and issuances) and
+	// outputs (including retirements) are numbered beginning at
+	// zero. Entries not originating in this way report -1.
 	Ordinal() int
 }
 
 var errInvalidValue = errors.New("invalid value")
 
+// EntryID computes the identifier of an entry, as the hash of its
+// body plus some metadata.
 func EntryID(e Entry) (hash Hash) {
 	if e == nil {
 		return hash

--- a/protocol/bc/entry_test.go
+++ b/protocol/bc/entry_test.go
@@ -7,17 +7,17 @@ import (
 )
 
 func BenchmarkEntryID(b *testing.B) {
-	m := newMux(Program{Code: []byte{1}, VMVersion: 1})
+	m := NewMux(Program{Code: []byte{1}, VMVersion: 1})
 	m.addSourceID(Hash{}, AssetAmount{}, 1)
 
 	entries := []Entry{
-		newIssuance(nil, AssetAmount{}, Hash{}, 0),
-		newHeader(1, nil, Hash{}, uint64(time.Now().Unix()), uint64(time.Now().Unix())),
+		NewIssuance(nil, AssetAmount{}, Hash{}, 0),
+		NewTxHeader(1, nil, Hash{}, uint64(time.Now().Unix()), uint64(time.Now().Unix())),
 		m,
-		newNonce(Program{Code: []byte{1}, VMVersion: 1}, nil),
-		newOutput(Program{Code: []byte{1}, VMVersion: 1}, Hash{}, 0),
-		newRetirement(Hash{}, 1),
-		newSpend(newOutput(Program{Code: []byte{1}, VMVersion: 1}, Hash{}, 0), Hash{}, 0),
+		NewNonce(Program{Code: []byte{1}, VMVersion: 1}, nil),
+		NewOutput(Program{Code: []byte{1}, VMVersion: 1}, Hash{}, 0),
+		NewRetirement(Hash{}, 1),
+		NewSpend(NewOutput(Program{Code: []byte{1}, VMVersion: 1}, Hash{}, 0), Hash{}, 0),
 	}
 
 	for _, e := range entries {

--- a/protocol/bc/entry_test.go
+++ b/protocol/bc/entry_test.go
@@ -7,24 +7,24 @@ import (
 )
 
 func BenchmarkEntryID(b *testing.B) {
-	m := newMux(program{Code: []byte{1}, VMVersion: 1})
+	m := newMux(Program{Code: []byte{1}, VMVersion: 1})
 	m.addSourceID(Hash{}, AssetAmount{}, 1)
 
-	entries := []entry{
+	entries := []Entry{
 		newIssuance(nil, AssetAmount{}, Hash{}, 0),
 		newHeader(1, nil, Hash{}, uint64(time.Now().Unix()), uint64(time.Now().Unix())),
 		m,
-		newNonce(program{Code: []byte{1}, VMVersion: 1}, nil),
-		newOutput(program{Code: []byte{1}, VMVersion: 1}, Hash{}, 0),
+		newNonce(Program{Code: []byte{1}, VMVersion: 1}, nil),
+		newOutput(Program{Code: []byte{1}, VMVersion: 1}, Hash{}, 0),
 		newRetirement(Hash{}, 1),
-		newSpend(newOutput(program{Code: []byte{1}, VMVersion: 1}, Hash{}, 0), Hash{}, 0),
+		newSpend(newOutput(Program{Code: []byte{1}, VMVersion: 1}, Hash{}, 0), Hash{}, 0),
 	}
 
 	for _, e := range entries {
 		name := reflect.TypeOf(e).Elem().Name()
 		b.Run(name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				entryID(e)
+				EntryID(e)
 			}
 		})
 	}

--- a/protocol/bc/map.go
+++ b/protocol/bc/map.go
@@ -179,7 +179,7 @@ func mapTx(tx *TxData) (headerID Hash, hdr *TxHeader, entryMap map[Hash]Entry, e
 }
 
 func mapBlockHeader(old *BlockHeader) (bhID Hash, bh *BlockHeaderEntry) {
-	bh = NewBlockHeader(old.Version, old.Height, old.PreviousBlockHash, old.TimestampMS, old.TransactionsMerkleRoot, old.AssetsMerkleRoot, old.ConsensusProgram)
+	bh = NewBlockHeaderEntry(old.Version, old.Height, old.PreviousBlockHash, old.TimestampMS, old.TransactionsMerkleRoot, old.AssetsMerkleRoot, old.ConsensusProgram)
 	bhID = EntryID(bh)
 	return
 }

--- a/protocol/bc/map_test.go
+++ b/protocol/bc/map_test.go
@@ -38,7 +38,7 @@ func TestMapTx(t *testing.T) {
 
 	for i, oldOut := range oldOuts {
 		if resultEntry, ok := entryMap[header.body.Results[i]]; ok {
-			if newOut, ok := resultEntry.(*output); ok {
+			if newOut, ok := resultEntry.(*Output); ok {
 				if newOut.body.Source.Value != oldOut.AssetAmount {
 					t.Errorf("header.body.Results[%d].(*output).body.Source is %v, expected %v", i, newOut.body.Source.Value, oldOut.AssetAmount)
 				}

--- a/protocol/bc/mux.go
+++ b/protocol/bc/mux.go
@@ -1,34 +1,34 @@
 package bc
 
-type mux struct {
+type Mux struct {
 	body struct {
 		Sources []valueSource
-		Program program
+		Program Program
 		ExtHash Hash
 	}
 
 	// Sources contains (pointers to) the manifested entries for each
 	// body.Sources[i].Ref.
-	Sources []entry // each entry is *issuance, *spend, or *mux
+	Sources []Entry // each entry is *issuance, *spend, or *mux
 }
 
-func (mux) Type() string         { return "mux1" }
-func (m *mux) Body() interface{} { return m.body }
+func (Mux) Type() string         { return "mux1" }
+func (m *Mux) Body() interface{} { return m.body }
 
-func (mux) Ordinal() int { return -1 }
+func (Mux) Ordinal() int { return -1 }
 
-func newMux(program program) *mux {
-	m := new(mux)
+func newMux(program Program) *Mux {
+	m := new(Mux)
 	m.body.Program = program
 	return m
 }
 
-func (m *mux) addSource(e entry, value AssetAmount, position uint64) {
-	m.addSourceID(entryID(e), value, position)
+func (m *Mux) addSource(e Entry, value AssetAmount, position uint64) {
+	m.addSourceID(EntryID(e), value, position)
 	m.Sources[len(m.Sources)-1] = e
 }
 
-func (m *mux) addSourceID(sourceID Hash, value AssetAmount, position uint64) {
+func (m *Mux) addSourceID(sourceID Hash, value AssetAmount, position uint64) {
 	src := valueSource{
 		Ref:      sourceID,
 		Value:    value,

--- a/protocol/bc/mux.go
+++ b/protocol/bc/mux.go
@@ -17,7 +17,7 @@ func (m *Mux) Body() interface{} { return m.body }
 
 func (Mux) Ordinal() int { return -1 }
 
-func newMux(program Program) *Mux {
+func NewMux(program Program) *Mux {
 	m := new(Mux)
 	m.body.Program = program
 	return m

--- a/protocol/bc/mux.go
+++ b/protocol/bc/mux.go
@@ -1,5 +1,8 @@
 package bc
 
+// Mux splits and combines value from one or more source entries,
+// making it available to one or more destination entries. It
+// satisfies the Entry interface.
 type Mux struct {
 	body struct {
 		Sources []valueSource
@@ -17,6 +20,8 @@ func (m *Mux) Body() interface{} { return m.body }
 
 func (Mux) Ordinal() int { return -1 }
 
+// NewMux creates a new Mux. Once created, its sources should be added
+// with addSource or addSourceID.
 func NewMux(program Program) *Mux {
 	m := new(Mux)
 	m.body.Program = program

--- a/protocol/bc/nonce.go
+++ b/protocol/bc/nonce.go
@@ -17,7 +17,7 @@ func (n *Nonce) Body() interface{} { return n.body }
 
 func (Nonce) Ordinal() int { return -1 }
 
-func newNonce(p Program, tr *TimeRange) *Nonce {
+func NewNonce(p Program, tr *TimeRange) *Nonce {
 	n := new(Nonce)
 	n.body.Program = p
 	n.body.TimeRange = EntryID(tr)

--- a/protocol/bc/nonce.go
+++ b/protocol/bc/nonce.go
@@ -1,26 +1,26 @@
 package bc
 
-type nonce struct {
+type Nonce struct {
 	body struct {
-		Program   program
+		Program   Program
 		TimeRange Hash
 		ExtHash   Hash
 	}
 
 	// TimeRange contains (a pointer to) the manifested entry
 	// corresponding to body.TimeRange.
-	TimeRange *timeRange
+	TimeRange *TimeRange
 }
 
-func (nonce) Type() string         { return "nonce1" }
-func (n *nonce) Body() interface{} { return n.body }
+func (Nonce) Type() string         { return "nonce1" }
+func (n *Nonce) Body() interface{} { return n.body }
 
-func (nonce) Ordinal() int { return -1 }
+func (Nonce) Ordinal() int { return -1 }
 
-func newNonce(p program, tr *timeRange) *nonce {
-	n := new(nonce)
+func newNonce(p Program, tr *TimeRange) *Nonce {
+	n := new(Nonce)
 	n.body.Program = p
-	n.body.TimeRange = entryID(tr)
+	n.body.TimeRange = EntryID(tr)
 	n.TimeRange = tr
 	return n
 }

--- a/protocol/bc/nonce.go
+++ b/protocol/bc/nonce.go
@@ -1,5 +1,8 @@
 package bc
 
+// Nonce contains data used, among other things, for distinguishing
+// otherwise-identical issuances (when used as those issuances'
+// "anchors"). It satisfies the Entry interface.
 type Nonce struct {
 	body struct {
 		Program   Program
@@ -17,6 +20,7 @@ func (n *Nonce) Body() interface{} { return n.body }
 
 func (Nonce) Ordinal() int { return -1 }
 
+// NewNonce creates a new Nonce.
 func NewNonce(p Program, tr *TimeRange) *Nonce {
 	n := new(Nonce)
 	n.body.Program = p

--- a/protocol/bc/output.go
+++ b/protocol/bc/output.go
@@ -19,7 +19,7 @@ func (o *Output) Body() interface{} { return o.body }
 
 func (o Output) Ordinal() int { return o.ordinal }
 
-func newOutput(controlProgram Program, data Hash, ordinal int) *Output {
+func NewOutput(controlProgram Program, data Hash, ordinal int) *Output {
 	out := new(Output)
 	out.body.ControlProgram = controlProgram
 	out.body.Data = data

--- a/protocol/bc/output.go
+++ b/protocol/bc/output.go
@@ -1,9 +1,9 @@
 package bc
 
-type output struct {
+type Output struct {
 	body struct {
 		Source         valueSource
-		ControlProgram program
+		ControlProgram Program
 		Data           Hash
 		ExtHash        Hash
 	}
@@ -11,16 +11,16 @@ type output struct {
 
 	// Source contains (a pointer to) the manifested entry corresponding
 	// to body.Source.
-	Source entry // *issuance, *spend, or *mux
+	Source Entry // *issuance, *spend, or *mux
 }
 
-func (output) Type() string         { return "output1" }
-func (o *output) Body() interface{} { return o.body }
+func (Output) Type() string         { return "output1" }
+func (o *Output) Body() interface{} { return o.body }
 
-func (o output) Ordinal() int { return o.ordinal }
+func (o Output) Ordinal() int { return o.ordinal }
 
-func newOutput(controlProgram program, data Hash, ordinal int) *output {
-	out := new(output)
+func newOutput(controlProgram Program, data Hash, ordinal int) *Output {
+	out := new(Output)
 	out.body.ControlProgram = controlProgram
 	out.body.Data = data
 	out.ordinal = ordinal
@@ -30,12 +30,12 @@ func newOutput(controlProgram program, data Hash, ordinal int) *output {
 // setSource is for when you have a complete source entry (e.g. a
 // *mux) for an output. When you don't (you only have the ID of the
 // source), use setSourceID, below.
-func (o *output) setSource(e entry, value AssetAmount, position uint64) {
-	o.setSourceID(entryID(e), value, position)
+func (o *Output) setSource(e Entry, value AssetAmount, position uint64) {
+	o.setSourceID(EntryID(e), value, position)
 	o.Source = e
 }
 
-func (o *output) setSourceID(sourceID Hash, value AssetAmount, position uint64) {
+func (o *Output) setSourceID(sourceID Hash, value AssetAmount, position uint64) {
 	o.body.Source = valueSource{
 		Ref:      sourceID,
 		Value:    value,

--- a/protocol/bc/output.go
+++ b/protocol/bc/output.go
@@ -1,5 +1,10 @@
 package bc
 
+// Output is the result of a transfer of value. The value it contains
+// may be accessed by a later Spend entry (if that entry can satisfy
+// the Output's ControlProgram). Output satisfies the Entry interface.
+//
+// (Not to be confused with the deprecated type TxOutput.)
 type Output struct {
 	body struct {
 		Source         valueSource
@@ -19,6 +24,8 @@ func (o *Output) Body() interface{} { return o.body }
 
 func (o Output) Ordinal() int { return o.ordinal }
 
+// NewOutput creates a new Output. Once created, its source should be
+// set with setSource or setSourceID.
 func NewOutput(controlProgram Program, data Hash, ordinal int) *Output {
 	out := new(Output)
 	out.body.ControlProgram = controlProgram

--- a/protocol/bc/program.go
+++ b/protocol/bc/program.go
@@ -1,6 +1,6 @@
 package bc
 
-type program struct {
+type Program struct {
 	VMVersion uint64
 	Code      []byte
 }

--- a/protocol/bc/program.go
+++ b/protocol/bc/program.go
@@ -1,5 +1,7 @@
 package bc
 
+// Program encapsulates the code and vm version for a virtual machine
+// program.
 type Program struct {
 	VMVersion uint64
 	Code      []byte

--- a/protocol/bc/retirement.go
+++ b/protocol/bc/retirement.go
@@ -18,7 +18,7 @@ func (r *Retirement) Body() interface{} { return r.body }
 
 func (r Retirement) Ordinal() int { return r.ordinal }
 
-func newRetirement(data Hash, ordinal int) *Retirement {
+func NewRetirement(data Hash, ordinal int) *Retirement {
 	r := new(Retirement)
 	r.body.Data = data
 	r.ordinal = ordinal

--- a/protocol/bc/retirement.go
+++ b/protocol/bc/retirement.go
@@ -1,6 +1,6 @@
 package bc
 
-type retirement struct {
+type Retirement struct {
 	body struct {
 		Source  valueSource
 		Data    Hash
@@ -10,27 +10,27 @@ type retirement struct {
 
 	// Source contains (a pointer to) the manifested entry corresponding
 	// to body.Source.
-	Source entry // *issuance, *spend, or *mux
+	Source Entry // *issuance, *spend, or *mux
 }
 
-func (retirement) Type() string         { return "retirement1" }
-func (r *retirement) Body() interface{} { return r.body }
+func (Retirement) Type() string         { return "retirement1" }
+func (r *Retirement) Body() interface{} { return r.body }
 
-func (r retirement) Ordinal() int { return r.ordinal }
+func (r Retirement) Ordinal() int { return r.ordinal }
 
-func newRetirement(data Hash, ordinal int) *retirement {
-	r := new(retirement)
+func newRetirement(data Hash, ordinal int) *Retirement {
+	r := new(Retirement)
 	r.body.Data = data
 	r.ordinal = ordinal
 	return r
 }
 
-func (r *retirement) setSource(e entry, value AssetAmount, position uint64) {
-	r.setSourceID(entryID(e), value, position)
+func (r *Retirement) setSource(e Entry, value AssetAmount, position uint64) {
+	r.setSourceID(EntryID(e), value, position)
 	r.Source = e
 }
 
-func (r *retirement) setSourceID(sourceID Hash, value AssetAmount, position uint64) {
+func (r *Retirement) setSourceID(sourceID Hash, value AssetAmount, position uint64) {
 	r.body.Source = valueSource{
 		Ref:      sourceID,
 		Value:    value,

--- a/protocol/bc/retirement.go
+++ b/protocol/bc/retirement.go
@@ -1,5 +1,8 @@
 package bc
 
+// Retirement is for the permanent removal of some value from a
+// blockchain. The value it contains can never be obtained by later
+// entries. Retirement satisfies the Entry interface.
 type Retirement struct {
 	body struct {
 		Source  valueSource
@@ -18,6 +21,8 @@ func (r *Retirement) Body() interface{} { return r.body }
 
 func (r Retirement) Ordinal() int { return r.ordinal }
 
+// NewRetirement creates a new Retirement. Once created, its source
+// should be set with setSource or setSourceID.
 func NewRetirement(data Hash, ordinal int) *Retirement {
 	r := new(Retirement)
 	r.body.Data = data

--- a/protocol/bc/timerange.go
+++ b/protocol/bc/timerange.go
@@ -1,19 +1,19 @@
 package bc
 
-type timeRange struct {
+type TimeRange struct {
 	body struct {
 		MinTimeMS, MaxTimeMS uint64
 		ExtHash              Hash
 	}
 }
 
-func (timeRange) Type() string          { return "timerange1" }
-func (tr *timeRange) Body() interface{} { return tr.body }
+func (TimeRange) Type() string          { return "timerange1" }
+func (tr *TimeRange) Body() interface{} { return tr.body }
 
-func (timeRange) Ordinal() int { return -1 }
+func (TimeRange) Ordinal() int { return -1 }
 
-func newTimeRange(minTimeMS, maxTimeMS uint64) *timeRange {
-	tr := new(timeRange)
+func newTimeRange(minTimeMS, maxTimeMS uint64) *TimeRange {
+	tr := new(TimeRange)
 	tr.body.MinTimeMS = minTimeMS
 	tr.body.MaxTimeMS = maxTimeMS
 	return tr

--- a/protocol/bc/timerange.go
+++ b/protocol/bc/timerange.go
@@ -12,7 +12,7 @@ func (tr *TimeRange) Body() interface{} { return tr.body }
 
 func (TimeRange) Ordinal() int { return -1 }
 
-func newTimeRange(minTimeMS, maxTimeMS uint64) *TimeRange {
+func NewTimeRange(minTimeMS, maxTimeMS uint64) *TimeRange {
 	tr := new(TimeRange)
 	tr.body.MinTimeMS = minTimeMS
 	tr.body.MaxTimeMS = maxTimeMS

--- a/protocol/bc/timerange.go
+++ b/protocol/bc/timerange.go
@@ -1,5 +1,6 @@
 package bc
 
+// TimeRange denotes a time range. It satisfies the Entry interface.
 type TimeRange struct {
 	body struct {
 		MinTimeMS, MaxTimeMS uint64
@@ -12,6 +13,7 @@ func (tr *TimeRange) Body() interface{} { return tr.body }
 
 func (TimeRange) Ordinal() int { return -1 }
 
+// NewTimeRange creates a new TimeRange.
 func NewTimeRange(minTimeMS, maxTimeMS uint64) *TimeRange {
 	tr := new(TimeRange)
 	tr.body.MinTimeMS = minTimeMS

--- a/protocol/bc/txheader.go
+++ b/protocol/bc/txheader.go
@@ -1,6 +1,6 @@
 package bc
 
-type header struct {
+type TxHeader struct {
 	body struct {
 		Version              uint64
 		Results              []Hash
@@ -11,16 +11,16 @@ type header struct {
 
 	// Results contains (pointers to) the manifested entries for the
 	// items in body.Results.
-	Results []entry // each entry is *output or *retirement
+	Results []Entry // each entry is *output or *retirement
 }
 
-func (header) Type() string         { return "txheader" }
-func (h *header) Body() interface{} { return h.body }
+func (TxHeader) Type() string         { return "txheader" }
+func (h *TxHeader) Body() interface{} { return h.body }
 
-func (header) Ordinal() int { return -1 }
+func (TxHeader) Ordinal() int { return -1 }
 
-func newHeader(version uint64, results []entry, data Hash, minTimeMS, maxTimeMS uint64) *header {
-	h := new(header)
+func newHeader(version uint64, results []Entry, data Hash, minTimeMS, maxTimeMS uint64) *TxHeader {
+	h := new(TxHeader)
 	h.body.Version = version
 	h.body.Data = data
 	h.body.MinTimeMS = minTimeMS
@@ -28,7 +28,7 @@ func newHeader(version uint64, results []entry, data Hash, minTimeMS, maxTimeMS 
 
 	h.Results = results
 	for _, r := range results {
-		h.body.Results = append(h.body.Results, entryID(r))
+		h.body.Results = append(h.body.Results, EntryID(r))
 	}
 
 	return h

--- a/protocol/bc/txheader.go
+++ b/protocol/bc/txheader.go
@@ -19,7 +19,7 @@ func (h *TxHeader) Body() interface{} { return h.body }
 
 func (TxHeader) Ordinal() int { return -1 }
 
-func newHeader(version uint64, results []Entry, data Hash, minTimeMS, maxTimeMS uint64) *TxHeader {
+func NewTxHeader(version uint64, results []Entry, data Hash, minTimeMS, maxTimeMS uint64) *TxHeader {
 	h := new(TxHeader)
 	h.body.Version = version
 	h.body.Data = data

--- a/protocol/bc/txheader.go
+++ b/protocol/bc/txheader.go
@@ -1,5 +1,9 @@
 package bc
 
+// TxHeader contains header information for a transaction. Every
+// transaction on a blockchain contains exactly one TxHeader. The ID
+// of the TxHeader is the ID of the transaction. TxHeader satisfies
+// the Entry interface.
 type TxHeader struct {
 	body struct {
 		Version              uint64
@@ -19,6 +23,7 @@ func (h *TxHeader) Body() interface{} { return h.body }
 
 func (TxHeader) Ordinal() int { return -1 }
 
+// NewTxHeader creates an new TxHeader.
 func NewTxHeader(version uint64, results []Entry, data Hash, minTimeMS, maxTimeMS uint64) *TxHeader {
 	h := new(TxHeader)
 	h.body.Version = version

--- a/protocol/bc/txissuance.go
+++ b/protocol/bc/txissuance.go
@@ -1,6 +1,6 @@
 package bc
 
-type issuance struct {
+type Issuance struct {
 	body struct {
 		Anchor  Hash
 		Value   AssetAmount
@@ -11,17 +11,17 @@ type issuance struct {
 
 	// Anchor is a pointer to the manifested entry corresponding to
 	// body.Anchor.
-	Anchor entry // *nonce or *spend
+	Anchor Entry // *nonce or *spend
 }
 
-func (issuance) Type() string           { return "issuance1" }
-func (iss *issuance) Body() interface{} { return iss.body }
+func (Issuance) Type() string           { return "issuance1" }
+func (iss *Issuance) Body() interface{} { return iss.body }
 
-func (iss issuance) Ordinal() int { return iss.ordinal }
+func (iss Issuance) Ordinal() int { return iss.ordinal }
 
-func newIssuance(anchor entry, value AssetAmount, data Hash, ordinal int) *issuance {
-	iss := new(issuance)
-	iss.body.Anchor = entryID(anchor)
+func newIssuance(anchor Entry, value AssetAmount, data Hash, ordinal int) *Issuance {
+	iss := new(Issuance)
+	iss.body.Anchor = EntryID(anchor)
 	iss.Anchor = anchor
 	iss.body.Value = value
 	iss.body.Data = data

--- a/protocol/bc/txissuance.go
+++ b/protocol/bc/txissuance.go
@@ -19,7 +19,7 @@ func (iss *Issuance) Body() interface{} { return iss.body }
 
 func (iss Issuance) Ordinal() int { return iss.ordinal }
 
-func newIssuance(anchor Entry, value AssetAmount, data Hash, ordinal int) *Issuance {
+func NewIssuance(anchor Entry, value AssetAmount, data Hash, ordinal int) *Issuance {
 	iss := new(Issuance)
 	iss.body.Anchor = EntryID(anchor)
 	iss.Anchor = anchor

--- a/protocol/bc/txissuance.go
+++ b/protocol/bc/txissuance.go
@@ -1,5 +1,9 @@
 package bc
 
+// Issuance is a source of new value on a blockchain. It satisfies the
+// Entry interface.
+//
+// (Not to be confused with the deprecated type IssuanceInput.)
 type Issuance struct {
 	body struct {
 		Anchor  Hash
@@ -19,6 +23,7 @@ func (iss *Issuance) Body() interface{} { return iss.body }
 
 func (iss Issuance) Ordinal() int { return iss.ordinal }
 
+// NewIssuance creates a new Issuance.
 func NewIssuance(anchor Entry, value AssetAmount, data Hash, ordinal int) *Issuance {
 	iss := new(Issuance)
 	iss.body.Anchor = EntryID(anchor)

--- a/protocol/bc/txspend.go
+++ b/protocol/bc/txspend.go
@@ -18,7 +18,7 @@ func (s *Spend) Body() interface{} { return s.body }
 
 func (s Spend) Ordinal() int { return s.ordinal }
 
-func newSpend(out *Output, data Hash, ordinal int) *Spend {
+func NewSpend(out *Output, data Hash, ordinal int) *Spend {
 	s := new(Spend)
 	s.body.SpentOutput = EntryID(out)
 	s.body.Data = data

--- a/protocol/bc/txspend.go
+++ b/protocol/bc/txspend.go
@@ -1,6 +1,6 @@
 package bc
 
-type spend struct {
+type Spend struct {
 	body struct {
 		SpentOutput Hash // the hash of an output entry
 		Data        Hash
@@ -10,17 +10,17 @@ type spend struct {
 
 	// SpentOutput contains (a pointer to) the manifested entry
 	// corresponding to body.SpentOutput.
-	SpentOutput *output
+	SpentOutput *Output
 }
 
-func (spend) Type() string         { return "spend1" }
-func (s *spend) Body() interface{} { return s.body }
+func (Spend) Type() string         { return "spend1" }
+func (s *Spend) Body() interface{} { return s.body }
 
-func (s spend) Ordinal() int { return s.ordinal }
+func (s Spend) Ordinal() int { return s.ordinal }
 
-func newSpend(out *output, data Hash, ordinal int) *spend {
-	s := new(spend)
-	s.body.SpentOutput = entryID(out)
+func newSpend(out *Output, data Hash, ordinal int) *Spend {
+	s := new(Spend)
+	s.body.SpentOutput = EntryID(out)
 	s.body.Data = data
 	s.ordinal = ordinal
 	s.SpentOutput = out

--- a/protocol/bc/txspend.go
+++ b/protocol/bc/txspend.go
@@ -1,5 +1,9 @@
 package bc
 
+// Spend accesses the value in a prior Output for transfer
+// elsewhere. It satisfies the Entry interface.
+//
+// (Not to be confused with the deprecated type SpendInput.)
 type Spend struct {
 	body struct {
 		SpentOutput Hash // the hash of an output entry
@@ -18,6 +22,7 @@ func (s *Spend) Body() interface{} { return s.body }
 
 func (s Spend) Ordinal() int { return s.ordinal }
 
+// NewSpend creates a new Spend.
 func NewSpend(out *Output, data Hash, ordinal int) *Spend {
 	s := new(Spend)
 	s.body.SpentOutput = EntryID(out)

--- a/protocol/bc/txtransaction.go
+++ b/protocol/bc/txtransaction.go
@@ -15,7 +15,7 @@ func ComputeOutputID(sc *SpendCommitment) (h Hash, err error) {
 			err = r
 		}
 	}()
-	o := newOutput(Program{VMVersion: sc.VMVersion, Code: sc.ControlProgram}, sc.RefDataHash, 0)
+	o := NewOutput(Program{VMVersion: sc.VMVersion, Code: sc.ControlProgram}, sc.RefDataHash, 0)
 	o.setSourceID(sc.SourceID, sc.AssetAmount, sc.SourcePosition)
 
 	h = EntryID(o)


### PR DESCRIPTION
This is in anticipation of landing the `entries-validation` branch, which uses some of the new data structures in `protocol/bc` in other packages.