### PR TITLE
protocol/state: remove PriorIssuances type

### DIFF
--- a/core/txdb/snapshot.go
+++ b/core/txdb/snapshot.go
@@ -31,7 +31,7 @@ func DecodeSnapshot(data []byte) (*state.Snapshot, error) {
 		}
 	}
 
-	issuances := make(state.PriorIssuances, len(storedSnapshot.Issuances))
+	issuances := make(map[bc.Hash]uint64, len(storedSnapshot.Issuances))
 	for _, issuance := range storedSnapshot.Issuances {
 		var hash bc.Hash
 		copy(hash[:], issuance.Hash)

--- a/core/txdb/snapshot_test.go
+++ b/core/txdb/snapshot_test.go
@@ -26,11 +26,11 @@ func TestReadWriteStateSnapshotIssuanceMemory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error reading state snapshot from db: %s\n", err)
 	}
-	want := state.PriorIssuances(map[bc.Hash]uint64{
+	want := map[bc.Hash]uint64{
 		bc.Hash{0x01}: 10,
 		bc.Hash{0x02}: 10,
 		bc.Hash{0x03}: 45,
-	})
+	}
 	if !testutil.DeepEqual(got.Issuances, want) {
 		t.Errorf("storing and loading snapshot issuance memory, got %#v, want %#v", got.Issuances, want)
 	}

--- a/protocol/state/snapshot.go
+++ b/protocol/state/snapshot.go
@@ -6,15 +6,14 @@ import (
 	"chain/protocol/patricia"
 )
 
-// PriorIssuances maps an "issuance hash" to the time (in Unix millis)
-// at which it should expire from the issuance memory.
-type PriorIssuances map[bc.Hash]uint64
-
 // Snapshot encompasses a snapshot of entire blockchain state. It
 // consists of a patricia state tree and the issuances memory.
+//
+// Issuances maps an "issuance hash" to the time (in Unix millis)
+// at which it should expire from the issuance memory.
 type Snapshot struct {
 	Tree      *patricia.Tree
-	Issuances PriorIssuances
+	Issuances map[bc.Hash]uint64
 }
 
 // PruneIssuances modifies a Snapshot, removing all issuance hashes
@@ -36,7 +35,7 @@ func Copy(original *Snapshot) *Snapshot {
 	// calls to Copy to get the right behavior).
 	c := &Snapshot{
 		Tree:      new(patricia.Tree),
-		Issuances: make(PriorIssuances, len(original.Issuances)),
+		Issuances: make(map[bc.Hash]uint64, len(original.Issuances)),
 	}
 	*c.Tree = *original.Tree
 	for k, v := range original.Issuances {
@@ -49,6 +48,6 @@ func Copy(original *Snapshot) *Snapshot {
 func Empty() *Snapshot {
 	return &Snapshot{
 		Tree:      new(patricia.Tree),
-		Issuances: make(PriorIssuances),
+		Issuances: make(map[bc.Hash]uint64),
 	}
 }


### PR DESCRIPTION
Remove the PriorIssuances type. We only ever use it as a
`map[bc.Hash]uint64`.