### PR TITLE
net/http/reqid: add log prefix

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -137,7 +137,7 @@ func Printkv(ctx context.Context, keyvals ...interface{}) {
 
 	// Prepend the log entry with auto-generated fields.
 	out := fmt.Sprintf(
-		"%s=%s %s=%s %s=%s",
+		"%s=%s %s=%s",
 		KeyCaller, vcaller,
 		KeyTime, formatValue(t.Format(rfc3339NanoFixed)),
 	)

--- a/log/log.go
+++ b/log/log.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"chain/errors"
-	"chain/net/http/reqid"
 )
 
 const rfc3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
@@ -44,11 +43,8 @@ var (
 
 // Conventional key names for log entries
 const (
-	KeyCaller   = "at"       // location of caller
-	KeyTime     = "t"        // time of call
-	KeyReqID    = "reqid"    // request ID from context
-	KeyCoreID   = "coreid"   // core ID from context
-	KeySubReqID = "subreqid" // potential sub-request ID from context
+	KeyCaller = "at" // location of caller
+	KeyTime   = "t"  // time of call
 
 	KeyMessage = "message" // produced by Message
 	KeyError   = "error"   // produced by Error
@@ -110,9 +106,8 @@ func prefix(ctx context.Context) []byte {
 //
 // Duplicate keys will be preserved.
 //
-// Several fields are automatically added to the log entry: a timestamp, a
-// string indicating the file and line number of the caller, and a request ID
-// taken from the context.
+// Two fields are automatically added to the log entry: a timestamp
+// and a string indicating the file and line number of the caller.
 //
 // As a special case, the auto-generated caller may be overridden by passing in
 // a new value for the KeyCaller key as the first key-value pair. The override
@@ -143,17 +138,9 @@ func Printkv(ctx context.Context, keyvals ...interface{}) {
 	// Prepend the log entry with auto-generated fields.
 	out := fmt.Sprintf(
 		"%s=%s %s=%s %s=%s",
-		KeyReqID, formatValue(reqid.FromContext(ctx)),
 		KeyCaller, vcaller,
 		KeyTime, formatValue(t.Format(rfc3339NanoFixed)),
 	)
-	if s := reqid.CoreIDFromContext(ctx); s != "" {
-		out += " " + KeyCoreID + "=" + formatValue(reqid.CoreIDFromContext(ctx))
-	}
-
-	if subreqid := reqid.FromSubContext(ctx); subreqid != reqid.Unknown {
-		out += " " + KeySubReqID + "=" + formatValue(subreqid)
-	}
 
 	var stack interface{}
 	for i := 0; i < len(keyvals); i += 2 {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"chain/errors"
-	"chain/net/http/reqid"
 )
 
 func TestSetOutput(t *testing.T) {
@@ -99,7 +98,6 @@ func TestPrintkv(t *testing.T) {
 		{
 			keyvals: []interface{}{"msg", "hello world"},
 			want: []string{
-				"reqid=unknown_req_id",
 				"at=log_test.go:",
 				"t=",
 				`msg="hello world"`,
@@ -110,7 +108,6 @@ func TestPrintkv(t *testing.T) {
 		{
 			keyvals: []interface{}{"msg", "hello world", "msg", "goodbye world"},
 			want: []string{
-				"reqid=unknown_req_id",
 				"at=log_test.go:",
 				"t=",
 				`msg="hello world"`,
@@ -122,7 +119,6 @@ func TestPrintkv(t *testing.T) {
 		{
 			keyvals: nil,
 			want: []string{
-				"reqid=unknown_req_id",
 				"at=log_test.go:",
 				"t=",
 			},
@@ -132,7 +128,6 @@ func TestPrintkv(t *testing.T) {
 		{
 			keyvals: []interface{}{"k1", "v1", "k2"},
 			want: []string{
-				"reqid=unknown_req_id",
 				"at=log_test.go:",
 				"t=",
 				"k1=v1",
@@ -168,26 +163,6 @@ func TestPrintkv(t *testing.T) {
 		}
 
 		SetOutput(os.Stdout)
-	}
-}
-
-func TestPrintkvRequestID(t *testing.T) {
-	buf := new(bytes.Buffer)
-	SetOutput(buf)
-	defer SetOutput(os.Stdout)
-
-	Printkv(reqid.NewContext(context.Background(), "example-request-id"))
-
-	read, err := ioutil.ReadAll(buf)
-	if err != nil {
-		t.Fatal("read buffer error:", err)
-	}
-
-	got := string(read)
-	want := "reqid=example-request-id"
-
-	if !strings.Contains(got, want) {
-		t.Errorf("Result did not contain string:\ngot:  %s\nwant: %s", got, want)
 	}
 }
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -24,6 +24,18 @@ func TestSetOutput(t *testing.T) {
 	}
 }
 
+func TestNoExtraFormatDirectives(t *testing.T) {
+	buf := new(bytes.Buffer)
+	SetOutput(buf)
+	SetPrefix("foo", "bar")
+	Printkv(context.Background(), "baz", 1)
+	SetOutput(os.Stdout)
+	got := buf.String()
+	if strings.Contains(got, "%") {
+		t.Errorf("log line appears to contain format directive: %q", got)
+	}
+}
+
 func TestPrefix(t *testing.T) {
 	buf := new(bytes.Buffer)
 	SetOutput(buf)

--- a/net/http/reqid/reqid.go
+++ b/net/http/reqid/reqid.go
@@ -71,8 +71,6 @@ func FromContext(ctx context.Context) string {
 
 // CoreIDFromContext returns the Chain-Core-ID stored in ctx,
 // or the empty string.
-// It also adds a log prefix to print the Core ID using
-// package chain/log.
 func CoreIDFromContext(ctx context.Context) string {
 	id, _ := ctx.Value(coreIDKey).(string)
 	return id

--- a/net/http/reqid/reqid_test.go
+++ b/net/http/reqid/reqid_test.go
@@ -3,7 +3,6 @@ package reqid
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -18,14 +17,8 @@ func TestPrintkvRequestID(t *testing.T) {
 
 	log.Printkv(NewContext(context.Background(), "example-request-id"))
 
-	read, err := ioutil.ReadAll(buf)
-	if err != nil {
-		t.Fatal("read buffer error:", err)
-	}
-
-	got := string(read)
+	got := buf.String()
 	want := "reqid=example-request-id"
-
 	if !strings.Contains(got, want) {
 		t.Errorf("Result did not contain string:\ngot:  %s\nwant: %s", got, want)
 	}

--- a/net/http/reqid/reqid_test.go
+++ b/net/http/reqid/reqid_test.go
@@ -1,0 +1,32 @@
+package reqid
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"chain/log"
+)
+
+func TestPrintkvRequestID(t *testing.T) {
+	buf := new(bytes.Buffer)
+	log.SetOutput(buf)
+	defer log.SetOutput(os.Stdout)
+
+	log.Printkv(NewContext(context.Background(), "example-request-id"))
+
+	read, err := ioutil.ReadAll(buf)
+	if err != nil {
+		t.Fatal("read buffer error:", err)
+	}
+
+	got := string(read)
+	want := "reqid=example-request-id"
+
+	if !strings.Contains(got, want) {
+		t.Errorf("Result did not contain string:\ngot:  %s\nwant: %s", got, want)
+	}
+}


### PR DESCRIPTION
With this change, package chain/net/http/reqid uses
log.AddPrefixkv to add the request ID to the log prefix
in the context.

It also removes special-case code from chain/log to add
the request ID there.

This also reverses the dependency between these two
packages, and allows reqid to use other logging
functions from chain/log instead of needing to use
standard library package log.