### PR TITLE
core/query: remove unused AnnotatedAsset fields

### DIFF
--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -43,10 +43,8 @@ func Annotated(a *Asset) (*query.AnnotatedAsset, error) {
 
 	aa := &query.AnnotatedAsset{
 		ID:              a.AssetID,
-		VMVersion:       a.VMVersion,
 		Definition:      &jsonDefinition,
 		Tags:            &jsonTags,
-		RawDefinition:   chainjson.HexBytes(a.RawDefinition()),
 		IssuanceProgram: chainjson.HexBytes(a.IssuanceProgram),
 	}
 	if a.Alias != nil {

--- a/core/query/annotated.go
+++ b/core/query/annotated.go
@@ -79,12 +79,10 @@ type AccountKey struct {
 type AnnotatedAsset struct {
 	ID              bc.AssetID         `json:"id"`
 	Alias           string             `json:"alias,omitempty"`
-	VMVersion       uint64             `json:"vm_version"`
 	IssuanceProgram chainjson.HexBytes `json:"issuance_program"`
 	Keys            []*AssetKey        `json:"keys"`
 	Quorum          int                `json:"quorum"`
 	Definition      *json.RawMessage   `json:"definition"`
-	RawDefinition   chainjson.HexBytes `json:"raw_definition"`
 	Tags            *json.RawMessage   `json:"tags"`
 	IsLocal         Bool               `json:"is_local"`
 }


### PR DESCRIPTION
The VMVersion and RawDefinition fields on the query.AnnotatedAsset
struct were not used or populated except in the response of a
/create-asset request. The SDKs also do not expose these fields.