### PR TITLE
log: omit functions from 'at' field by name

### DIFF
--- a/core/http.go
+++ b/core/http.go
@@ -12,8 +12,8 @@ import (
 )
 
 func init() {
-	log.FilterFunc("chain/core.logHTTPError")
-	log.FilterFunc("chain/core.WriteHTTPError")
+	log.SkipFunc("chain/core.logHTTPError")
+	log.SkipFunc("chain/core.WriteHTTPError")
 }
 
 // errBadReqHeader indicates the user supplied a malformed request header,

--- a/core/http.go
+++ b/core/http.go
@@ -11,6 +11,11 @@ import (
 	"chain/net/http/reqid"
 )
 
+func init() {
+	log.FilterFunc("chain/core.logHTTPError")
+	log.FilterFunc("chain/core.WriteHTTPError")
+}
+
 // errBadReqHeader indicates the user supplied a malformed request header,
 // possibly including a datatype that doesn't match what we expected.
 var errBadReqHeader = errors.New("bad request header")

--- a/log/log.go
+++ b/log/log.go
@@ -107,7 +107,7 @@ func prefix(ctx context.Context) []byte {
 //
 // Two fields are automatically added to the log entry: t=[time]
 // and at=[file:line] indicating the location of the caller.
-// Use FilterFunc to prevent helper functions from showing up in the
+// Use SkipFunc to prevent helper functions from showing up in the
 // at=[file:line] entry.
 //
 // Printkv will also print the stack trace, if any, on separate lines

--- a/log/log.go
+++ b/log/log.go
@@ -108,7 +108,7 @@ func prefix(ctx context.Context) []byte {
 // Two fields are automatically added to the log entry: t=[time]
 // and at=[file:line] indicating the location of the caller.
 // Use SkipFunc to prevent helper functions from showing up in the
-// at=[file:line] entry.
+// at=[file:line] field.
 //
 // Printkv will also print the stack trace, if any, on separate lines
 // following the message. The stack is obtained from the following,

--- a/log/stack.go
+++ b/log/stack.go
@@ -6,26 +6,26 @@ import (
 	"strconv"
 )
 
-var filterFunc = map[string]bool{
+var skipFunc = map[string]bool{
 	"chain/log.Printkv": true,
 	"chain/log.Printf":  true,
 	"chain/log.Error":   true,
 }
 
-// FilterFunc removes the named function from stack traces
+// SkipFunc removes the named function from stack traces
 // and at=[file:line] entries printed to the log output.
 // The provided name should be a fully-qualified function name
 // comprising the import path and identifier separated by a dot.
 // For example, chain/log.Printkv.
-// FilterFunc must not be called concurrently with any function
+// SkipFunc must not be called concurrently with any function
 // in this package (including itself).
-func FilterFunc(name string) {
-	filterFunc[name] = true
+func SkipFunc(name string) {
+	skipFunc[name] = true
 }
 
 // caller returns a string containing filename and line number of
 // the deepest function invocation on the calling goroutine's stack,
-// after skipping functions in filterFunc.
+// after skipping functions in skipFunc.
 // If no stack information is available, it returns "?:?".
 func caller() string {
 	for i := 1; ; i++ {
@@ -33,7 +33,7 @@ func caller() string {
 		if !ok {
 			return "?:?"
 		}
-		if !filterFunc[runtime.FuncForPC(pc).Name()] {
+		if !skipFunc[runtime.FuncForPC(pc).Name()] {
 			return filepath.Base(file) + ":" + strconv.Itoa(line)
 		}
 	}

--- a/log/stack.go
+++ b/log/stack.go
@@ -31,6 +31,8 @@ func SkipFunc(name string) {
 // If no stack information is available, it returns "?:?".
 func caller() string {
 	for i := 1; ; i++ {
+		// NOTE(kr): This is quadratic in the number of frames we
+		// ultimately have to skip. Consider using Callers instead.
 		pc, file, line, ok := runtime.Caller(i)
 		if !ok {
 			return "?:?"

--- a/log/stack.go
+++ b/log/stack.go
@@ -7,9 +7,11 @@ import (
 )
 
 var skipFunc = map[string]bool{
-	"chain/log.Printkv": true,
-	"chain/log.Printf":  true,
-	"chain/log.Error":   true,
+	"chain/log.Printkv":            true,
+	"chain/log.Printf":             true,
+	"chain/log.Error":              true,
+	"chain/log.Fatalkv":            true,
+	"chain/log.RecoverAndLogError": true,
 }
 
 // SkipFunc removes the named function from stack traces

--- a/log/stack.go
+++ b/log/stack.go
@@ -1,0 +1,40 @@
+package log
+
+import (
+	"path/filepath"
+	"runtime"
+	"strconv"
+)
+
+var filterFunc = map[string]bool{
+	"chain/log.Printkv": true,
+	"chain/log.Printf":  true,
+	"chain/log.Error":   true,
+}
+
+// FilterFunc removes the named function from stack traces
+// and at=[file:line] entries printed to the log output.
+// The provided name should be a fully-qualified function name
+// comprising the import path and plain name separated by a dot.
+// For example, chain/log.Printkv.
+// FilterFunc must not be called concurrently with any function
+// in this package (including itself).
+func FilterFunc(name string) {
+	filterFunc[name] = true
+}
+
+// caller returns a string containing filename and line number of
+// the deepest function invocation on the calling goroutine's stack,
+// after skipping functions in filterFunc.
+// If no stack information is available, it returns "?:?".
+func caller() string {
+	for i := 1; ; i++ {
+		pc, file, line, ok := runtime.Caller(i)
+		if !ok {
+			return "?:?"
+		}
+		if !filterFunc[runtime.FuncForPC(pc).Name()] {
+			return filepath.Base(file) + ":" + strconv.Itoa(line)
+		}
+	}
+}

--- a/log/stack.go
+++ b/log/stack.go
@@ -15,7 +15,7 @@ var filterFunc = map[string]bool{
 // FilterFunc removes the named function from stack traces
 // and at=[file:line] entries printed to the log output.
 // The provided name should be a fully-qualified function name
-// comprising the import path and plain name separated by a dot.
+// comprising the import path and identifier separated by a dot.
 // For example, chain/log.Printkv.
 // FilterFunc must not be called concurrently with any function
 // in this package (including itself).


### PR DESCRIPTION
Each log line has an entry of the form at=main.go:123
added to it by Printkv. It's not helpful for this
file-line information to point to a logging helper
function (such as log.Printf or core.logHTTPError), so
there were mechanisms to supply an alternative:

- Outside of package log, helper functions were expected
to include an at=foo.go:456 key-value pair to override
the item added by Printkv. In practice, none ever did.
The code to obtain this information is fiddly and gross.

- Within package log, function 'caller' took a 'skip'
argument specifying how many frames to skip before
returning file-line information. This was used
inconsistently. Helper functions Printf and Error used
it to add override entries; Fatalkv and
RecoverAndLogError should have but didn't.

Hopefully, the new mechanism in this patch is easy
enough to use that it'll be used appropriately.

The new approach keeps a lookup table of names of
functions to avoid. Package log then walks up the call
stack, skipping any filtered functions, and prints to
the log output the first unfiltered location it finds.