### PR TITLE
protocol: remove Store getter method

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -373,7 +373,7 @@ func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, 
 			// If don't have any blocks, bootstrap from the generator's
 			// latest snapshot.
 			if c.Height() == 0 {
-				fetch.BootstrapSnapshot(ctx, c, remoteGenerator, fetchhealth)
+				fetch.BootstrapSnapshot(ctx, c, store, remoteGenerator, fetchhealth)
 			}
 		}
 

--- a/core/fetch/fetch.go
+++ b/core/fetch/fetch.go
@@ -56,10 +56,10 @@ func Init(ctx context.Context, peer *rpc.Client) {
 // BootstrapSnapshot downloads and stores the most recent snapshot from the
 // provided peer. It's run when bootstrapping a new Core to an existing
 // network. It should be run before invoking Chain.Recover.
-func BootstrapSnapshot(ctx context.Context, c *protocol.Chain, peer *rpc.Client, health func(error)) {
+func BootstrapSnapshot(ctx context.Context, c *protocol.Chain, store protocol.Store, peer *rpc.Client, health func(error)) {
 	const maxAttempts = 5
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		err := fetchSnapshot(ctx, peer, c.Store(), attempt)
+		err := fetchSnapshot(ctx, peer, store, attempt)
 		health(err)
 		if err == nil {
 			break

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -157,11 +157,6 @@ func (c *Chain) Height() uint64 {
 	return c.state.height
 }
 
-// Store returns the Store used by the blockchain.
-func (c *Chain) Store() Store {
-	return c.store
-}
-
 // State returns the most recent state available. It will not be current
 // unless the current process is the leader. Callers should examine the
 // returned block header's height if they need to verify the current state.


### PR DESCRIPTION
The `protocol.Chain.Store` method for getting a `Chain`'s underlying Store
is only used in one place, `core/fetch.BootstrapSnapshot`. We have
access to the store at its callsite, so pass the store in instead. This
keeps the `protocol.Chain` type cleaner. Generally, the store should
only be used by the `Chain` type itself.