### PR TITLE
core: fix TestRecovery

### DIFF
--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -153,6 +153,7 @@ func TestRecovery(t *testing.T) {
 			if err != nil {
 				t.Errorf("generateBlock returned err %s", err)
 			}
+			cancel()
 			close(completed)
 		}()
 

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -166,8 +166,8 @@ func TestRecovery(t *testing.T) {
 		}
 
 		if atomic.LoadInt64(&calls) < n {
-			// The driver never crashed the goroutine, so n is now greater than
-			// the total number of queries performed during `generateBlock`.
+			// calls never reached n, so the goroutine completed without
+			// simulating a crash.
 			databaseDumps = append(databaseDumps, pgtest.Dump(t, cloneURL, false, "*_id_seq", "block_processors"))
 			break
 		}

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -174,7 +174,7 @@ func TestRecovery(t *testing.T) {
 
 		// We crashed at some point during block generation. Do it again,
 		// without crashing.
-		err = generateBlock(context.Background(), t, wrappedDB, timestamp, poolTxs)
+		err = generateBlock(ctx, t, wrappedDB, timestamp, poolTxs)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2820";
+	public final String Id = "main/rev2821";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2820"
+const ID string = "main/rev2821"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2820"
+export const rev_id = "main/rev2821"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2820".freeze
+	ID = "main/rev2821".freeze
 end


### PR DESCRIPTION
TestRecovery has been broken for a while. It only runs when the `LONG=1`
environment variable is set, so it's easy to accidentally break.