### PR TITLE
database/pg/pgtest: invoke WrapDB func in Prepare

### DIFF
--- a/database/pg/pgtest/wrap.go
+++ b/database/pg/pgtest/wrap.go
@@ -47,17 +47,12 @@ type wrappedConn struct {
 }
 
 func (c wrappedConn) Prepare(query string) (driver.Stmt, error) {
-	// TODO(jackson): Ideally, we could call fn() here, but if fn() panics
-	// the system will deadlock. We call fn() from Stmt.Exec / Stmt.Query
-	// to avoid the deadlock.
-	//
-	// This will be fixed in Go 1.8:
-	// https://go-review.googlesource.com/#/c/23576/
+	c.fn(query)
 	stmt, err := c.backing.Prepare(query)
 	if err != nil {
 		return stmt, err
 	}
-	return wrappedStmt{fn: c.fn, query: query, backing: stmt}, nil
+	return stmt, nil
 }
 
 func (c wrappedConn) Close() error {
@@ -66,28 +61,4 @@ func (c wrappedConn) Close() error {
 
 func (c wrappedConn) Begin() (driver.Tx, error) {
 	return c.backing.Begin()
-}
-
-type wrappedStmt struct {
-	fn      func(string)
-	query   string
-	backing driver.Stmt
-}
-
-func (s wrappedStmt) NumInput() int {
-	return s.backing.NumInput()
-}
-
-func (s wrappedStmt) Close() error {
-	return s.backing.Close()
-}
-
-func (s wrappedStmt) Exec(args []driver.Value) (driver.Result, error) {
-	s.fn(s.query)
-	return s.backing.Exec(args)
-}
-
-func (s wrappedStmt) Query(args []driver.Value) (driver.Rows, error) {
-	s.fn(s.query)
-	return s.backing.Query(args)
 }


### PR DESCRIPTION
Alter `pgtest.WrapDB` to call the provided closure during
`driver.Conn.Prepare` instead of in the `driver.Stmt` functions.
We can do this now that Go 1.8 properly handles panics in
`driver.Conn.Prepare`:

https://go-review.googlesource.com/#/c/23576/