### PR TITLE
cmd/cored: use revid constant for dev builds

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -86,9 +86,10 @@ var (
 func init() {
 	var version string
 	if buildTag != "?" {
+		// build tag with chain-core-server- prefix indicates official release
 		version = strings.TrimPrefix(buildTag, "chain-core-server-")
 	} else {
-		// +changes suffix indicates non-release build
+		// version of the form rev123 indicates non-release build
 		version = rev.ID
 	}
 

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -41,6 +41,7 @@ import (
 	"chain/encoding/json"
 	"chain/env"
 	"chain/errors"
+	"chain/generated/rev"
 	chainlog "chain/log"
 	"chain/log/rotation"
 	"chain/log/splunk"
@@ -52,7 +53,6 @@ import (
 const (
 	httpReadTimeout  = 2 * time.Minute
 	httpWriteTimeout = time.Hour
-	latestVersion    = "1.1.3"
 )
 
 var (
@@ -85,14 +85,11 @@ var (
 
 func init() {
 	var version string
-	if strings.HasPrefix(buildTag, "chain-core-server-") {
-		// build tag with chain-core-server- prefix indicates official release
-		version = latestVersion
-	} else if buildTag != "?" {
-		version = latestVersion + "-" + buildTag
+	if buildTag != "?" {
+		version = strings.TrimPrefix(buildTag, "chain-core-server-")
 	} else {
-		// -dev suffix indicates intermediate, non-release build
-		version = latestVersion + "+changes"
+		// +changes suffix indicates non-release build
+		version = rev.ID
 	}
 
 	prodStr := "no"

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2816";
+	public final String Id = "main/rev2817";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2816"
+const ID string = "main/rev2817"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2816"
+export const rev_id = "main/rev2817"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2816".freeze
+	ID = "main/rev2817".freeze
 end


### PR DESCRIPTION
This gives us more precise information on what code
contributed to a fresh-from-git build, and slightly
simplifies the logic for initializing the version string
on startup.