### PR TITLE
all: use pg.DB

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -226,7 +226,7 @@ func runServer() {
 	}
 }
 
-func launchConfiguredCore(ctx context.Context, db *sql.DB, conf *config.Config, processID string) http.Handler {
+func launchConfiguredCore(ctx context.Context, db pg.DB, conf *config.Config, processID string) http.Handler {
 	// Initialize the protocol.Chain.
 	heights, err := txdb.ListenBlocks(ctx, *dbURL)
 	if err != nil {

--- a/core/account/accounts.go
+++ b/core/account/accounts.go
@@ -16,7 +16,6 @@ import (
 	"chain/core/txbuilder"
 	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg"
-	"chain/database/sql"
 	"chain/errors"
 	"chain/log"
 	"chain/protocol"
@@ -27,7 +26,7 @@ const maxAccountCache = 1000
 
 var ErrDuplicateAlias = errors.New("duplicate account alias")
 
-func NewManager(db *sql.DB, chain *protocol.Chain, pinStore *pin.Store) *Manager {
+func NewManager(db pg.DB, chain *protocol.Chain, pinStore *pin.Store) *Manager {
 	return &Manager{
 		db:          db,
 		chain:       chain,
@@ -41,7 +40,7 @@ func NewManager(db *sql.DB, chain *protocol.Chain, pinStore *pin.Store) *Manager
 
 // Manager stores accounts and their associated control programs.
 type Manager struct {
-	db       *sql.DB
+	db       pg.DB
 	chain    *protocol.Chain
 	utxoDB   *reserver
 	indexer  Saver

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -178,7 +178,7 @@ func Configure(ctx context.Context, db pg.DB, c *Config) error {
 
 		initialBlockHash := block.Hash()
 
-		store := txdb.NewStore(db.(*sql.DB))
+		store := txdb.NewStore(db)
 		chain, err := protocol.NewChain(ctx, initialBlockHash, store, nil)
 		if err != nil {
 			return err

--- a/core/leader/leader.go
+++ b/core/leader/leader.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"chain/database/pg"
-	"chain/database/sql"
 	"chain/errors"
 	"chain/log"
 )
@@ -35,7 +34,7 @@ func IsLeading() bool {
 //
 // The Chain Core has up to a 10-second refractory period after
 // shutdown, during which no process can become the new leader.
-func Run(db *sql.DB, addr string, lead func(context.Context)) {
+func Run(db pg.DB, addr string, lead func(context.Context)) {
 	ctx := context.Background()
 	// We use our process's address as the key, because it's unique
 	// among all processes within a Core and it allows a restarted
@@ -97,7 +96,7 @@ func leadershipChanges(ctx context.Context, l *leader) chan bool {
 
 type leader struct {
 	// config
-	db      *sql.DB
+	db      pg.DB
 	key     string
 	lead    func(context.Context)
 	address string

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -17,8 +17,8 @@ import (
 	"chain/core/query"
 	"chain/core/txbuilder"
 	"chain/core/txdb"
+	"chain/database/pg"
 	"chain/database/pg/pgtest"
-	"chain/database/sql"
 	"chain/protocol"
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
@@ -152,7 +152,7 @@ func TestRecovery(t *testing.T) {
 	}
 }
 
-func generateBlock(ctx context.Context, t testing.TB, db *sql.DB, timestamp time.Time, poolTxs []*bc.Tx) error {
+func generateBlock(ctx context.Context, t testing.TB, db pg.DB, timestamp time.Time, poolTxs []*bc.Tx) error {
 	store := txdb.NewStore(db)
 	b1, err := store.GetBlock(ctx, 1)
 	if err != nil {

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -14,7 +14,6 @@ import (
 	. "chain/core/txbuilder"
 	"chain/database/pg"
 	"chain/database/pg/pgtest"
-	"chain/database/sql"
 	"chain/errors"
 	"chain/protocol"
 	"chain/protocol/bc"
@@ -347,7 +346,7 @@ type testInfo struct {
 
 // TODO(kr): refactor this into new package core/coreutil
 // and consume it from cmd/corectl.
-func bootdb(ctx context.Context, db *sql.DB, t testing.TB) (*testInfo, error) {
+func bootdb(ctx context.Context, db pg.DB, t testing.TB) (*testInfo, error) {
 	c := prottest.NewChain(t)
 	pinStore := pin.NewStore(db)
 	coretest.CreatePins(ctx, t, pinStore)

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2814";
+	public final String Id = "main/rev2815";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2814"
+const ID string = "main/rev2815"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2814"
+export const rev_id = "main/rev2815"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2814".freeze
+	ID = "main/rev2815".freeze
 end


### PR DESCRIPTION
Most places in the code base take a `pg.DB` in their external
interfaces. Some take a `*sql.DB`. Update the remaining instances of
`*sql.DB` to `pg.DB`.

This was motivated by trying to call `accounts.NewManager` with a
`pg.DB` and haing to do a `db.(*sql.DB)` cast.