### PR TITLE
cmd/slashland: fix revid computation

### DIFF
--- a/cmd/slashland/main.go
+++ b/cmd/slashland/main.go
@@ -184,7 +184,7 @@ func land(req *landReq) {
 		return
 	}
 
-	err = commitRevIDs(landdir)
+	err = commitRevIDs(landdir, prState.Base.Ref)
 	if err != nil {
 		sayf("<@%s|%s> failed to land %s: could not commit revision id: %s",
 			req.userID,
@@ -255,8 +255,8 @@ func land(req *landReq) {
 	runIn(landdir, exec.Command("git", "branch", "-D", req.ref))
 }
 
-func commitRevIDs(landdir string) error {
-	revID, err := revID(landdir)
+func commitRevIDs(landdir, baseBranch string) error {
+	revID, err := revID(landdir, baseBranch)
 	if err != nil {
 		return err
 	}

--- a/cmd/slashland/revid.go
+++ b/cmd/slashland/revid.go
@@ -38,12 +38,12 @@ end
 
 // revID returns a string to use
 // for the revid of the next commit on main.
-func revID(landdir string) (string, error) {
-	cmd := dirCmd(landdir, "git", "rev-list", "--count", "main")
+func revID(landdir, baseBranch string) (string, error) {
+	cmd := dirCmd(landdir, "git", "rev-list", "--count", "origin/"+baseBranch, "--")
 	cmd.Stderr = os.Stderr
 	b, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
-	return "rev" + string(bytes.TrimSpace(b)), nil
+	return baseBranch + "/rev" + string(bytes.TrimSpace(b)), nil
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,3 +1,4 @@
+
 public final class RevId {
-	public final String Id = "?";
+	public final String Id = "main/rev2814";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,4 @@
+
 package rev
 
-const ID string = "?"
+const ID string = "main/rev2814"

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,4 +1,3 @@
-
 package rev
 
 const ID string = "main/rev2814"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,1 +1,2 @@
-export const rev_id = "?"
+
+export const rev_id = "main/rev2814"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,3 +1,4 @@
+
 module Chain::Rev
-	ID = "?".freeze
+	ID = "main/rev2814".freeze
 end


### PR DESCRIPTION
Two fixes here:

1. The revid is now measured on the base branch,
which is not always main. If a local main has never been
checked out, the rev-list command fails, so we must use
the remote ref (e.g. "origin/main" or "origin/1.1-stable").

2. Include the branch name in the revid string. This
lets us distinguish between rev123 on main vs rev123 on
1.1-stable (which can be a different commit).