### PR TITLE
core/leader: try more frequently; failover faster

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2817";
+	public final String Id = "main/rev2818";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2817"
+const ID string = "main/rev2818"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2817"
+export const rev_id = "main/rev2818"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2817".freeze
+	ID = "main/rev2818".freeze
 end


### PR DESCRIPTION
Update the leader failover to update every 500 milliseconds. Allow a
new cored to takeover if the existing leader hasn't updated within 1
second.

Note, in practice, this means that when upgrading to 1.2 in a rolling
deploy, the first deployed 1.2 cored will quickly become leader.

Tested this locally by running a java program that creates
transactions sequentially. Tried killing cored and failing over
between the two.