### PR TITLE
cmd/slashland: avoid making empty commits

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2818";
+	public final String Id = "main/rev2819";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2818"
+const ID string = "main/rev2819"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2818"
+export const rev_id = "main/rev2819"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2818".freeze
+	ID = "main/rev2819".freeze
 end


### PR DESCRIPTION
Before this change, we would blindly add a commit on
every rebase or attempt to land. Now, if the commit
would be empty, we skip it. This lets us land faster
when the HEAD commit has already been through CI.