### PR TITLE
cmd/corectl: print additional version info

### DIFF
--- a/cmd/corectl/dev.go
+++ b/cmd/corectl/dev.go
@@ -37,3 +37,7 @@ func createBlockKeyPair(db *sql.DB, args []string) {
 
 	fmt.Printf("%x\n", pub.Pub)
 }
+
+func versionProdPrintln() {
+	fmt.Println("production: false")
+}

--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"chain/core/accesstoken"
@@ -18,14 +19,18 @@ import (
 	"chain/database/sql"
 	chainjson "chain/encoding/json"
 	"chain/env"
+	"chain/generated/rev"
 	"chain/log"
 )
-
-const version = "1.1.3"
 
 // config vars
 var (
 	dbURL = env.String("DATABASE_URL", "postgres:///core?sslmode=disable")
+
+	// build vars; initialized by the linker
+	buildTag    = "?"
+	buildCommit = "?"
+	buildDate   = "?"
 )
 
 // We collect log output in this buffer,
@@ -50,7 +55,18 @@ func main() {
 	env.Parse()
 
 	if len(os.Args) >= 2 && os.Args[1] == "-version" {
+		var version string
+		if buildTag != "?" {
+			// build tag with chain-core-server- prefix indicates official release
+			version = strings.TrimPrefix(buildTag, "chain-core-server-")
+		} else {
+			// version of the form rev123 indicates non-release build
+			version = rev.ID
+		}
 		fmt.Printf("corectl (Chain Core) %s\n", version)
+		versionProdPrintln()
+		fmt.Printf("build-commit: %v\n", buildCommit)
+		fmt.Printf("build-date: %v\n", buildDate)
 		return
 	}
 

--- a/cmd/corectl/prod.go
+++ b/cmd/corectl/prod.go
@@ -2,7 +2,11 @@
 
 package main
 
-import "chain/database/sql"
+import (
+	"fmt"
+
+	"chain/database/sql"
+)
 
 func reset(db *sql.DB, args []string) {
 	fatalln("error: reset disabled in prod build")
@@ -10,4 +14,8 @@ func reset(db *sql.DB, args []string) {
 
 func createBlockKeyPair(db *sql.DB, args []string) {
 	fatalln("error: create-block-keypair disabled in prod build")
+}
+
+func versionProdPrintln() {
+	fmt.Println("production: true")
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2819";
+	public final String Id = "main/rev2820";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2819"
+const ID string = "main/rev2820"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2819"
+export const rev_id = "main/rev2820"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2819".freeze
+	ID = "main/rev2820".freeze
 end


### PR DESCRIPTION
This output mirrors what cored prints with its -version
flag. We also take this opportunity to switch from a
hard-coded "latest release version" string to using the
automatically-generated revid.