### PR TITLE
core/account: use pgtest.NewTx where possible

### DIFF
--- a/core/account/accounts_test.go
+++ b/core/account/accounts_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestCreateAccount(t *testing.T) {
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	db := pgtest.NewTx(t)
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 
@@ -39,7 +39,7 @@ func TestCreateAccount(t *testing.T) {
 }
 
 func TestCreateAccountIdempotency(t *testing.T) {
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	db := pgtest.NewTx(t)
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 	var clientToken = "a-unique-client-token"
@@ -58,7 +58,7 @@ func TestCreateAccountIdempotency(t *testing.T) {
 }
 
 func TestCreateAccountReusedAlias(t *testing.T) {
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	db := pgtest.NewTx(t)
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 	m.createTestAccount(ctx, t, "some-account", nil)
@@ -150,7 +150,7 @@ func (m *Manager) createTestUTXO(ctx context.Context, t testing.TB, accountID st
 }
 
 func TestFindByID(t *testing.T) {
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	db := pgtest.NewTx(t)
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 	account := m.createTestAccount(ctx, t, "", nil)
@@ -166,7 +166,7 @@ func TestFindByID(t *testing.T) {
 }
 
 func TestFindByAlias(t *testing.T) {
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	db := pgtest.NewTx(t)
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 	account := m.createTestAccount(ctx, t, "some-alias", nil)

--- a/core/account/annotate_test.go
+++ b/core/account/annotate_test.go
@@ -13,14 +13,14 @@ import (
 
 func TestAnnotateTxs(t *testing.T) {
 	var (
-		_, db = pgtest.NewDB(t, pgtest.SchemaPath)
-		m     = NewManager(db, prottest.NewChain(t), nil)
-		ctx   = context.Background()
-		acc1  = m.createTestAccount(ctx, t, "", nil)
-		acc2  = m.createTestAccount(ctx, t, "", map[string]interface{}{"one": "foo", "two": "bar"})
-		u1    = m.createTestUTXO(ctx, t, acc1.ID)
-		u2    = m.createTestUTXO(ctx, t, acc2.ID)
-		u3    = m.createTestUTXO(ctx, t, acc2.ID)
+		db   = pgtest.NewTx(t)
+		m    = NewManager(db, prottest.NewChain(t), nil)
+		ctx  = context.Background()
+		acc1 = m.createTestAccount(ctx, t, "", nil)
+		acc2 = m.createTestAccount(ctx, t, "", map[string]interface{}{"one": "foo", "two": "bar"})
+		u1   = m.createTestUTXO(ctx, t, acc1.ID)
+		u2   = m.createTestUTXO(ctx, t, acc2.ID)
+		u3   = m.createTestUTXO(ctx, t, acc2.ID)
 	)
 
 	txs := []*query.AnnotatedTx{

--- a/core/account/indexer_test.go
+++ b/core/account/indexer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLoadAccountInfo(t *testing.T) {
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	db := pgtest.NewTx(t)
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 
@@ -40,7 +40,7 @@ func TestLoadAccountInfo(t *testing.T) {
 }
 
 func TestDeleteUTXOs(t *testing.T) {
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	db := pgtest.NewTx(t)
 	m := NewManager(db, prottest.NewChain(t), nil)
 	ctx := context.Background()
 

--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -25,7 +25,7 @@ const sampleAccountUTXOs = `
 
 func TestCancelReservation(t *testing.T) {
 	ctx := context.Background()
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	db := pgtest.NewTx(t)
 	_, err := db.Exec(ctx, sampleAccountUTXOs)
 	if err != nil {
 		t.Fatal(err)

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2821";
+	public final String Id = "main/rev2822";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2821"
+const ID string = "main/rev2822"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2821"
+export const rev_id = "main/rev2822"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2821".freeze
+	ID = "main/rev2822".freeze
 end


### PR DESCRIPTION
Some of the `core/account` tests can use `pgtest.NewTx` now that
`NewManager` takes a `pg.DB`. This shaves a few seconds off the
package's test time.

```
PASS
ok  	chain/core/account	5.309s
```

vs

```
PASS
ok  	chain/core/account	9.114s
```