### PR TITLE
core: implement http.Handler on *API

### DIFF
--- a/cmd/cored/dev.go
+++ b/cmd/cored/dev.go
@@ -49,10 +49,8 @@ func authLoopbackInDev(req *http.Request) bool {
 	return err == nil && a.IP.IsLoopback()
 }
 
-func hsmRegister(db pg.DB) func(*http.ServeMux, *core.API) {
-	hsm := mockhsm.New(db)
-	handler := &core.MockHSMHandler{MockHSM: hsm}
-	return handler.Register
+func devEnableMockHSM(db pg.DB) []core.RunOption {
+	return []core.RunOption{core.MockHSM(mockhsm.New(db))}
 }
 
 func devHSM(db pg.DB) (blocksigner.Signer, error) {

--- a/cmd/cored/prod.go
+++ b/cmd/cored/prod.go
@@ -19,7 +19,7 @@ func authLoopbackInDev(req *http.Request) bool {
 	return false
 }
 
-func hsmRegister(_ pg.DB) func(*http.ServeMux, *core.API) {
+func devEnableMockHSM(_ pg.DB) []core.RunOption {
 	return nil
 }
 

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -194,9 +195,8 @@ func TestMux(t *testing.T) {
 			t.Fatal("unexpected panic:", err)
 		}
 	}()
-	m := &MockHSMHandler{}
-	api := &API{config: &config.Config{}}
-	api.Handler(m.Register)
+	api := &API{config: &config.Config{}, mux: http.NewServeMux()}
+	api.buildHandler()
 }
 
 func TestTransfer(t *testing.T) {

--- a/core/hsm_test.go
+++ b/core/hsm_test.go
@@ -84,7 +84,7 @@ func TestMockHSM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	handler := &MockHSMHandler{MockHSM: mockhsm}
+	handler := &mockHSMHandler{MockHSM: mockhsm}
 	outTmpls := handler.mockhsmSignTemplates(ctx, struct {
 		Txs   []*txbuilder.Template `json:"transactions"`
 		XPubs []chainkd.XPub        `json:"xpubs"`

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2825";
+	public final String Id = "main/rev2826";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2825"
+const ID string = "main/rev2826"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2825"
+export const rev_id = "main/rev2826"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2825".freeze
+	ID = "main/rev2826".freeze
 end


### PR DESCRIPTION
Rework the construction of the API's http.Handler to avoid a second
function call (to API.Handler). Instead, construct the http.Handler
during Run. Also:
  * move the MockHSMHandler into a RunOption.
  * move the blockchain ID middleware into the core package

Tested locally through dashboard, including transacting on testnet, resetting, reconfiguring and creating mock HSM keys.