### PR TITLE
core/leader: add State enum

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -288,7 +288,7 @@ func (a *API) leaderSignHandler(f func(context.Context, *bc.Block) ([]byte, erro
 		if f == nil {
 			return nil, errNotFound // TODO(kr): is this really the right error here?
 		}
-		if leader.IsLeading() {
+		if leader.State() == leader.Leading {
 			return f(ctx, b)
 		}
 		var resp []byte

--- a/core/core.go
+++ b/core/core.go
@@ -50,12 +50,13 @@ func (a *API) info(ctx context.Context) (map[string]interface{}, error) {
 			"build_date":    config.BuildDate,
 		}, nil
 	}
-	if leader.IsLeading() {
-		return a.leaderInfo(ctx)
+	// If we're not the leader, forward to the leader.
+	if leader.State() == leader.Following {
+		var resp map[string]interface{}
+		err := a.forwardToLeader(ctx, "/info", nil, &resp)
+		return resp, err
 	}
-	var resp map[string]interface{}
-	err := a.forwardToLeader(ctx, "/info", nil, &resp)
-	return resp, err
+	return a.leaderInfo(ctx)
 }
 
 func (a *API) leaderInfo(ctx context.Context) (map[string]interface{}, error) {
@@ -87,6 +88,7 @@ func (a *API) leaderInfo(ctx context.Context) (map[string]interface{}, error) {
 	}
 
 	m := map[string]interface{}{
+		"state":                             leader.State().String(),
 		"is_configured":                     true,
 		"configured_at":                     a.config.ConfiguredAt,
 		"is_signer":                         a.config.IsSigner,

--- a/core/leader/leader.go
+++ b/core/leader/leader.go
@@ -4,6 +4,7 @@ package leader
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -12,16 +13,40 @@ import (
 	"chain/log"
 )
 
-var isLeading atomic.Value
+// ProcessState is an enum describing the current state of the
+// process. A recovering process has become leader but is still
+// recovering the blockchain state. Some functionality is not
+// available until the process enters the Leading state.
+type ProcessState int
 
-// IsLeading returns true if this process is
-// the core leader.
-func IsLeading() bool {
-	v := isLeading.Load()
-	if v == nil {
-		return false
+const (
+	Following ProcessState = iota
+	Recovering
+	Leading
+)
+
+func (ps ProcessState) String() string {
+	switch ps {
+	case Following:
+		return "FOLLOWING"
+	case Recovering:
+		return "RECOVERING"
+	case Leading:
+		return "LEADING"
+	default:
+		panic(fmt.Errorf("unknown process state %d", ps))
 	}
-	return v.(bool)
+}
+
+var leadingState atomic.Value
+
+// State returns the current state of this process.
+func State() ProcessState {
+	v := leadingState.Load()
+	if v == nil {
+		return Following
+	}
+	return v.(ProcessState)
 }
 
 // Run runs as a goroutine, trying once every five seconds to become
@@ -52,14 +77,15 @@ func Run(db pg.DB, addr string, lead func(context.Context)) {
 	for leader := range leadershipChanges(ctx, l) {
 		if leader {
 			log.Printf(ctx, "I am the core leader")
+			leadingState.Store(Recovering)
 			leadCtx, cancel = context.WithCancel(ctx)
 			l.lead(leadCtx)
+			leadingState.Store(Leading)
 		} else {
 			log.Printf(ctx, "No longer core leader")
+			leadingState.Store(Following)
 			cancel()
 		}
-
-		isLeading.Store(leader)
 	}
 	panic("unreachable")
 }

--- a/core/leader/leader.go
+++ b/core/leader/leader.go
@@ -28,11 +28,11 @@ const (
 func (ps ProcessState) String() string {
 	switch ps {
 	case Following:
-		return "FOLLOWING"
+		return "following"
 	case Recovering:
-		return "RECOVERING"
+		return "recovering"
 	case Leading:
-		return "LEADING"
+		return "leading"
 	default:
 		panic(fmt.Errorf("unknown process state %d", ps))
 	}

--- a/core/transact.go
+++ b/core/transact.go
@@ -98,7 +98,7 @@ func (a *API) build(ctx context.Context, buildReqs []*buildRequest) (interface{}
 	// If we're not the leader, we don't have access to the current
 	// reservations. Forward the build call to the leader process.
 	// TODO(jackson): Distribute reservations across cored processes.
-	if !leader.IsLeading() {
+	if leader.State() != leader.Leading {
 		var resp interface{}
 		err := a.forwardToLeader(ctx, "/build-transaction", buildReqs, &resp)
 		return resp, err
@@ -289,7 +289,7 @@ type submitArg struct {
 
 // POST /submit-transaction
 func (a *API) submit(ctx context.Context, x submitArg) (interface{}, error) {
-	if !leader.IsLeading() {
+	if leader.State() != leader.Leading {
 		var resp json.RawMessage
 		err := a.forwardToLeader(ctx, "/submit-transaction", x, &resp)
 		return resp, err

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2827";
+	public final String Id = "main/rev2828";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2827"
+const ID string = "main/rev2828"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2827"
+export const rev_id = "main/rev2828"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2827".freeze
+	ID = "main/rev2828".freeze
 end


### PR DESCRIPTION
Replace IsLeader() with an enum that can be FOLLOWING, RECOVERING or
LEADING. RECOVERING is used when a process has been elected leader but
has not yet finished recovering the blockchain and becoming leader.

Use this more fine-grained status to enable the /info endpoint even when
RECOVERING. This fixes snapshot downloads so that the /info endpoint can
be used to track the progress of a downloading snapshot.

It's OK for a Recovering process to call forwardToLeader. It'll detect that
it's trying to forward to itself and return a 503 status code.

I tested this locally by connecting to testnet through dashboard. I was able to
watch the snapshot download progress in the lefthand bar.