### PR TITLE
core/fetch: refactor snapshot bootstrap

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -14,6 +14,7 @@ import (
 	"chain/core/account"
 	"chain/core/asset"
 	"chain/core/config"
+	"chain/core/fetch"
 	"chain/core/generator"
 	"chain/core/leader"
 	"chain/core/pin"
@@ -72,6 +73,9 @@ type API struct {
 	generator       *generator.Generator
 	remoteGenerator *rpc.Client
 	indexTxs        bool
+
+	downloadingSnapshotMu sync.Mutex
+	downloadingSnapshot   *fetch.SnapshotProgress
 
 	healthMu     sync.Mutex
 	healthErrors map[string]interface{}

--- a/core/fetch/bootstrap.go
+++ b/core/fetch/bootstrap.go
@@ -32,12 +32,16 @@ type SnapshotProgress struct {
 // or encounters any kind of validation error, it'll re-attempt the
 // snapshot download a few times.
 func (s *SnapshotProgress) Attempt() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.attempt
 }
 
 // Height returns the blockchain height of the snapshot being
 // downloaded.
 func (s *SnapshotProgress) Height() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.height
 }
 

--- a/core/fetch/bootstrap.go
+++ b/core/fetch/bootstrap.go
@@ -1,0 +1,206 @@
+package fetch
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"chain/core/rpc"
+	"chain/core/txdb"
+	"chain/errors"
+	"chain/protocol"
+	"chain/protocol/bc"
+)
+
+// SnapshotProgress describes a snapshot being downloaded from a peer Core.
+type SnapshotProgress struct {
+	mu               sync.Mutex
+	attempt          int
+	height           uint64
+	size             uint64
+	downloadProgress *progressReader
+
+	stopped chan struct{}
+}
+
+// Attempt returns the how many times Core has attempted to
+// download a bootstrap snapshot. If a download request times out
+// or encounters any kind of validation error, it'll re-attempt the
+// snapshot download a few times.
+func (s *SnapshotProgress) Attempt() int {
+	return s.attempt
+}
+
+// Height returns the blockchain height of the snapshot being
+// downloaded.
+func (s *SnapshotProgress) Height() uint64 {
+	return s.height
+}
+
+// Progress returns the number of bytes download and the total number
+// of the bytes of the snapshot.
+func (s *SnapshotProgress) Progress() (downloaded, total uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.downloadProgress == nil {
+		return 0, s.size
+	}
+	return s.downloadProgress.BytesRead(), s.size
+}
+
+// Wait blocks until the snapshot is either successfully downloaded and
+// stored or the Core has given up on bootstrapping through a snapshot.
+func (s *SnapshotProgress) Wait() {
+	<-s.stopped
+}
+
+// BootstrapSnapshot downloads and stores the most recent snapshot from the
+// provided peer. It's run when bootstrapping a new Core to an existing
+// network. It should be run before invoking Chain.Recover.
+func BootstrapSnapshot(ctx context.Context, c *protocol.Chain, store protocol.Store, peer *rpc.Client, health func(error)) *SnapshotProgress {
+	const maxAttempts = 5
+
+	// Return a *SnapshotProgress so that the caller can track the
+	// progress of the download.
+	progress := &SnapshotProgress{stopped: make(chan struct{})}
+	go func() {
+		for attempt := 1; attempt <= maxAttempts; attempt++ {
+			progress.mu.Lock()
+			progress.attempt = attempt
+			progress.downloadProgress = nil
+			progress.mu.Unlock()
+
+			err := fetchSnapshot(ctx, peer, store, progress)
+			health(err)
+			if err == nil {
+				break
+			}
+			logNetworkError(ctx, err)
+		}
+		close(progress.stopped)
+	}()
+	return progress
+}
+
+// fetchSnapshot fetches the latest snapshot from the generator and applies it
+// to the store. It should only be called on freshly configured cores--
+// cores that have been operating should replay all transactions so that
+// they can index them properly.
+func fetchSnapshot(ctx context.Context, peer *rpc.Client, s protocol.Store, progress *SnapshotProgress) error {
+	const getBlockTimeout = 30 * time.Second
+	const readSnapshotTimeout = 30 * time.Second
+
+	var info struct {
+		Height       uint64  `json:"height"`
+		Size         uint64  `json:"size"`
+		BlockchainID bc.Hash `json:"blockchain_id"`
+	}
+	err := peer.Call(ctx, "/rpc/get-snapshot-info", nil, &info)
+	if err != nil {
+		return errors.Wrap(err, "getting snapshot info")
+	}
+	if info.Height == 0 {
+		return nil
+	}
+
+	downloadCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	// Download the snapshot, recording our progress as we go.
+	body, err := peer.CallRaw(downloadCtx, "/rpc/get-snapshot", info.Height)
+	if err != nil {
+		return errors.Wrap(err, "getting snapshot")
+	}
+	defer body.Close()
+
+	// Wrap the response body reader in our progress reader and save
+	// snapshot metadata.
+	progress.mu.Lock()
+	progress.size = info.Size
+	progress.height = info.Height
+	progress.downloadProgress = new(progressReader)
+	progress.downloadProgress.reader = body
+	progress.downloadProgress.setTimeout(readSnapshotTimeout, cancel)
+	progress.mu.Unlock()
+
+	b, err := ioutil.ReadAll(progress.downloadProgress)
+	if err != nil {
+		return err
+	}
+	snapshot, err := txdb.DecodeSnapshot(b)
+	if err != nil {
+		return err
+	}
+	// Delete the snapshot issuances because we don't have any commitment
+	// to them in the block. This means that Cores bootstrapping from a
+	// snapshot cannot guarantee uniqueness of issuances until the max
+	// issuance window has elapsed.
+	snapshot.PruneNonces(math.MaxUint64)
+
+	// Next, get the initial block.
+	initialBlock, err := getBlock(ctx, peer, 1, getBlockTimeout)
+	if err != nil {
+		return err
+	}
+	if initialBlock == nil {
+		// Something seriously funny is afoot.
+		return errors.New("could not get initial block from generator")
+	}
+
+	// Also get the corresponding block.
+	snapshotBlock, err := getBlock(ctx, peer, info.Height, getBlockTimeout)
+	if err != nil {
+		return err
+	}
+	if snapshotBlock == nil {
+		// Something seriously funny is still afoot.
+		return errors.New("generator provided snapshot but could not provide block")
+	}
+	if snapshotBlock.AssetsMerkleRoot != snapshot.Tree.RootHash() {
+		return errors.New("snapshot merkle root doesn't match block")
+	}
+
+	// Commit the snapshot, initial block and snapshot block.
+	err = s.SaveBlock(ctx, initialBlock)
+	if err != nil {
+		return errors.Wrap(err, "saving the initial block")
+	}
+	err = s.SaveBlock(ctx, snapshotBlock)
+	if err != nil {
+		return errors.Wrap(err, "saving bootstrap block")
+	}
+	err = s.SaveSnapshot(ctx, snapshotBlock.Height, snapshot)
+	return errors.Wrap(err, "saving bootstrap snaphot")
+}
+
+type progressReader struct {
+	reader io.Reader
+	read   uint64
+
+	timer           *time.Timer
+	progressTimeout time.Duration
+}
+
+func (r *progressReader) setTimeout(timeout time.Duration, cancel func()) {
+	r.progressTimeout = timeout
+	r.timer = time.AfterFunc(timeout, cancel)
+}
+
+func (r *progressReader) BytesRead() uint64 {
+	return atomic.LoadUint64(&r.read)
+}
+
+func (r *progressReader) Read(b []byte) (int, error) {
+	n, err := r.reader.Read(b)
+
+	atomic.AddUint64(&r.read, uint64(n))
+
+	// If there's a timeout on delay between reads, then reset the timer.
+	if r.timer != nil {
+		r.timer.Reset(r.progressTimeout)
+	}
+	return n, err
+}

--- a/core/fetch/fetch.go
+++ b/core/fetch/fetch.go
@@ -4,17 +4,12 @@ package fetch
 
 import (
 	"context"
-	"io"
-	"io/ioutil"
-	"math"
 	"math/rand"
 	"net"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"chain/core/rpc"
-	"chain/core/txdb"
 	"chain/errors"
 	"chain/log"
 	"chain/protocol"
@@ -28,9 +23,6 @@ var (
 	generatorHeight          uint64
 	generatorHeightFetchedAt time.Time
 	generatorLock            sync.Mutex
-
-	downloadingSnapshot   *Snapshot
-	downloadingSnapshotMu sync.Mutex
 )
 
 func GeneratorHeight() (uint64, time.Time) {
@@ -41,31 +33,10 @@ func GeneratorHeight() (uint64, time.Time) {
 	return h, t
 }
 
-func SnapshotProgress() *Snapshot {
-	downloadingSnapshotMu.Lock()
-	defer downloadingSnapshotMu.Unlock()
-	return downloadingSnapshot
-}
-
 // Init initializes the fetch package.
 func Init(ctx context.Context, peer *rpc.Client) {
 	// Fetch the generator height periodically.
 	go pollGeneratorHeight(ctx, peer)
-}
-
-// BootstrapSnapshot downloads and stores the most recent snapshot from the
-// provided peer. It's run when bootstrapping a new Core to an existing
-// network. It should be run before invoking Chain.Recover.
-func BootstrapSnapshot(ctx context.Context, c *protocol.Chain, store protocol.Store, peer *rpc.Client, health func(error)) {
-	const maxAttempts = 5
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		err := fetchSnapshot(ctx, peer, store, attempt)
-		health(err)
-		if err == nil {
-			break
-		}
-		logNetworkError(ctx, err)
-	}
 }
 
 // Fetch runs in a loop, fetching blocks from the configured
@@ -76,12 +47,6 @@ func BootstrapSnapshot(ctx context.Context, c *protocol.Chain, store protocol.St
 // After each attempt to fetch and apply a block, it calls health
 // to report either an error or nil to indicate success.
 func Fetch(ctx context.Context, c *protocol.Chain, peer *rpc.Client, health func(error), prevBlock *bc.Block, prevSnapshot *state.Snapshot) {
-	// If we downloaded a snapshot, now that we've recovered and successfully
-	// booted from the snapshot, mark it as done.
-	if sp := SnapshotProgress(); sp != nil {
-		sp.done()
-	}
-
 	var height uint64
 	if prevBlock != nil {
 		height = prevBlock.Height
@@ -265,139 +230,4 @@ func logNetworkError(ctx context.Context, err error) {
 	} else {
 		log.Error(ctx, err)
 	}
-}
-
-// Snapshot describes a snapshot being downloaded from a peer Core.
-type Snapshot struct {
-	Attempt int
-	Height  uint64
-	Size    uint64
-	progressReader
-
-	stopped   bool
-	stoppedMu sync.Mutex
-}
-
-func (s *Snapshot) InProgress() bool {
-	s.stoppedMu.Lock()
-	defer s.stoppedMu.Unlock()
-	return !s.stopped
-}
-
-func (s *Snapshot) done() {
-	s.stoppedMu.Lock()
-	defer s.stoppedMu.Unlock()
-	s.stopped = true
-}
-
-// fetchSnapshot fetches the latest snapshot from the generator and applies it
-// to the store. It should only be called on freshly configured cores--
-// cores that have been operating should replay all transactions so that
-// they can index them properly.
-func fetchSnapshot(ctx context.Context, peer *rpc.Client, s protocol.Store, attempt int) error {
-	const getBlockTimeout = 30 * time.Second
-	const readSnapshotTimeout = 30 * time.Second
-
-	info := &Snapshot{Attempt: attempt}
-	err := peer.Call(ctx, "/rpc/get-snapshot-info", nil, &info)
-	if err != nil {
-		return errors.Wrap(err, "getting snapshot info")
-	}
-	if info.Height == 0 {
-		return nil
-	}
-
-	downloadingSnapshotMu.Lock()
-	downloadingSnapshot = info
-	downloadingSnapshotMu.Unlock()
-
-	downloadCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	// Download the snapshot, recording our progress as we go.
-	body, err := peer.CallRaw(downloadCtx, "/rpc/get-snapshot", info.Height)
-	if err != nil {
-		return errors.Wrap(err, "getting snapshot")
-	}
-	defer body.Close()
-
-	// Wrap the response body reader in our progress reader.
-	info.progressReader.reader = body
-	info.progressReader.setTimeout(readSnapshotTimeout, cancel)
-	b, err := ioutil.ReadAll(&info.progressReader)
-	if err != nil {
-		return err
-	}
-	snapshot, err := txdb.DecodeSnapshot(b)
-	if err != nil {
-		return err
-	}
-	// Delete the snapshot nonces because we don't have any commitment
-	// to them in the block. This means that Cores bootstrapping from a
-	// snapshot cannot guarantee uniqueness of issuances until the max
-	// issuance window has elapsed.
-	snapshot.PruneNonces(math.MaxUint64)
-
-	// Next, get the initial block.
-	initialBlock, err := getBlock(ctx, peer, 1, getBlockTimeout)
-	if err != nil {
-		return err
-	}
-	if initialBlock == nil {
-		// Something seriously funny is afoot.
-		return errors.New("could not get initial block from generator")
-	}
-
-	// Also get the corresponding block.
-	snapshotBlock, err := getBlock(ctx, peer, info.Height, getBlockTimeout)
-	if err != nil {
-		return err
-	}
-	if snapshotBlock == nil {
-		// Something seriously funny is still afoot.
-		return errors.New("generator provided snapshot but could not provide block")
-	}
-	if snapshotBlock.AssetsMerkleRoot != snapshot.Tree.RootHash() {
-		return errors.New("snapshot merkle root doesn't match block")
-	}
-
-	// Commit the snapshot, initial block and snapshot block.
-	err = s.SaveBlock(ctx, initialBlock)
-	if err != nil {
-		return errors.Wrap(err, "saving the initial block")
-	}
-	err = s.SaveBlock(ctx, snapshotBlock)
-	if err != nil {
-		return errors.Wrap(err, "saving bootstrap block")
-	}
-	err = s.SaveSnapshot(ctx, snapshotBlock.Height, snapshot)
-	return errors.Wrap(err, "saving bootstrap snaphot")
-}
-
-type progressReader struct {
-	reader io.Reader
-	read   uint64
-
-	timer           *time.Timer
-	progressTimeout time.Duration
-}
-
-func (r *progressReader) setTimeout(timeout time.Duration, cancel func()) {
-	r.progressTimeout = timeout
-	r.timer = time.AfterFunc(timeout, cancel)
-}
-
-func (r *progressReader) BytesRead() uint64 {
-	return atomic.LoadUint64(&r.read)
-}
-
-func (r *progressReader) Read(b []byte) (int, error) {
-	n, err := r.reader.Read(b)
-
-	atomic.AddUint64(&r.read, uint64(n))
-
-	// If there's a timeout on delay between reads, then reset the timer.
-	if r.timer != nil {
-		r.timer.Reset(r.progressTimeout)
-	}
-	return n, err
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2864";
+	public final String Id = "main/rev2865";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2864"
+const ID string = "main/rev2865"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2864"
+export const rev_id = "main/rev2865"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2864".freeze
+	ID = "main/rev2865".freeze
 end


### PR DESCRIPTION
Refactor bootstrapping by snapshot to not rely on global
variables in core/fetch for reporting download progress.
Previously, as a proxy for detecting successful recovery
from the snapshot, there was an undocumented relationship
between fetch.BootstrapSnapshot and fetch.Fetch where
Fetch would mark the snapshot as completed:

```
// If we downloaded a snapshot, now that we've recovered and successfully		
// booted from the snapshot, mark it as done.		
if sp := SnapshotProgress(); sp != nil {		
	sp.done()		
}
```

Instead, return a progress type from BootstrapSnapshot
that can be stored on the core.API and used in /info calls.
Remove this value from the core.API after Chain.Recover
completes. This commit also reorganizes all bootstrapping
-specific code in core/fetch to a bootstrap.go file.

I tested this locally by connecting to testnet, observing
dashboard & curling http://localhost:1999/info. 