### PR TITLE
core/leader: encapsulate state

### DIFF
--- a/core/api_test.go
+++ b/core/api_test.go
@@ -366,7 +366,7 @@ func toTxTemplate(ctx context.Context, inp map[string]interface{}) (*txbuilder.T
 
 type alwaysLeader struct{}
 
-func (al alwaysLeader) Address(_ context.Context) (string, error) {
+func (al alwaysLeader) Address(context.Context) (string, error) {
 	return ":1999", nil
 }
 

--- a/core/api_test.go
+++ b/core/api_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"sync"
 	"testing"
 	"time"
 
@@ -219,14 +218,7 @@ func TestTransfer(t *testing.T) {
 	go api.accounts.ProcessBlocks(ctx)
 	api.indexer.RegisterAnnotator(api.accounts.AnnotateTxs)
 	api.indexer.RegisterAnnotator(api.assets.AnnotateTxs)
-
-	// TODO(jackson): Replace this with a mock leader.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go leader.Run(db, ":1999", func(ctx context.Context) {
-		wg.Done()
-	})
-	wg.Wait()
+	api.leader = alwaysLeader{}
 
 	assetAlias := "some-asset"
 	account1Alias := "first-account"
@@ -370,4 +362,14 @@ func toTxTemplate(ctx context.Context, inp map[string]interface{}) (*txbuilder.T
 	tpl := new(txbuilder.Template)
 	err = json.Unmarshal(jsonInp, tpl)
 	return tpl, err
+}
+
+type alwaysLeader struct{}
+
+func (al alwaysLeader) Address(_ context.Context) (string, error) {
+	return ":1999", nil
+}
+
+func (al alwaysLeader) State() leader.ProcessState {
+	return leader.Leading
 }

--- a/core/core.go
+++ b/core/core.go
@@ -51,7 +51,7 @@ func (a *API) info(ctx context.Context) (map[string]interface{}, error) {
 		}, nil
 	}
 	// If we're not the leader, forward to the leader.
-	if leader.State() == leader.Following {
+	if a.leader.State() == leader.Following {
 		var resp map[string]interface{}
 		err := a.forwardToLeader(ctx, "/info", nil, &resp)
 		return resp, err
@@ -88,7 +88,7 @@ func (a *API) leaderInfo(ctx context.Context) (map[string]interface{}, error) {
 	}
 
 	m := map[string]interface{}{
-		"state":                             leader.State().String(),
+		"state":                             a.leader.State().String(),
 		"is_configured":                     true,
 		"configured_at":                     a.config.ConfiguredAt,
 		"is_signer":                         a.config.IsSigner,

--- a/core/leader/leader.go
+++ b/core/leader/leader.go
@@ -52,14 +52,11 @@ type Leader struct {
 // Address retrieves a routable address of the current
 // Core leader.
 func (l *Leader) Address(ctx context.Context) (string, error) {
-	const q = `SELECT address FROM leader`
-
 	var addr string
-	err := l.db.QueryRow(ctx, q).Scan(&addr)
+	err := l.db.QueryRow(ctx, `SELECT address FROM leader`).Scan(&addr)
 	if err != nil {
 		return "", errors.Wrap(err, "could not fetch leader address")
 	}
-
 	return addr, nil
 }
 

--- a/core/leader/leader.go
+++ b/core/leader/leader.go
@@ -110,8 +110,6 @@ func Run(ctx context.Context, db pg.DB, addr string, lead func(context.Context))
 				cancel()
 			}
 		}
-		// If leadershipChanges was closed because ctx was cancelled,
-		// cancel leadCtx too on the way out.
 		cancel()
 	}()
 	return l

--- a/core/leader/leader.go
+++ b/core/leader/leader.go
@@ -132,7 +132,7 @@ func leadershipChanges(ctx context.Context, l *Leader) chan bool {
 
 		for {
 			for !tryForLeadership(ctx, l) {
-				// Wait for a tick of the ticker, or the context
+				// Wait for a tick of the ticker or the context
 				// to be cancelled.
 				select {
 				case <-ctx.Done():
@@ -144,7 +144,7 @@ func leadershipChanges(ctx context.Context, l *Leader) chan bool {
 			ch <- true // elected leader
 
 			for maintainLeadership(ctx, l) {
-				// Wait for a tick of the ticker, or the context
+				// Wait for a tick of the ticker or the context
 				// to be cancelled.
 				select {
 				case <-ctx.Done():

--- a/core/leader/leader.go
+++ b/core/leader/leader.go
@@ -99,8 +99,8 @@ func Run(db pg.DB, addr string, lead func(context.Context)) *Leader {
 	log.Printf(ctx, "Using leaderKey: %q", l.key)
 
 	go func() {
+		cancel := func() {}
 		var leadCtx context.Context
-		var cancel func()
 		for leader := range leadershipChanges(ctx, l) {
 			if leader {
 				log.Printf(ctx, "I am the core leader")
@@ -114,6 +114,7 @@ func Run(db pg.DB, addr string, lead func(context.Context)) *Leader {
 				cancel()
 			}
 		}
+		cancel()
 	}()
 	return l
 }

--- a/core/leader/leader_test.go
+++ b/core/leader/leader_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 func TestFailover(t *testing.T) {
+	ctx := context.Background()
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+
 	var l1, l2 *Leader
 	var wg1, wg2 sync.WaitGroup
 	wg1.Add(1)
 	wg2.Add(1)
-
-	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
-	ctx := context.Background()
 	ctx1, cancel1 := context.WithCancel(ctx)
 	ctx2, cancel2 := context.WithCancel(ctx)
 	defer cancel1()

--- a/core/leader/leader_test.go
+++ b/core/leader/leader_test.go
@@ -12,7 +12,6 @@ func TestFailover(t *testing.T) {
 	ctx := context.Background()
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
 
-	var l1, l2 *Leader
 	var wg1, wg2 sync.WaitGroup
 	wg1.Add(1)
 	wg2.Add(1)
@@ -23,13 +22,7 @@ func TestFailover(t *testing.T) {
 
 	// Start up the first leader process. It should immediately become
 	// leader.
-	l1 = Run(ctx1, db, ":1999", func(_ context.Context) {
-		// Since the lead func hasn't completed yet, the leader
-		// state should still be 'recovering'.
-		if s := l1.State(); s != Recovering {
-			t.Errorf("for first process state, got %s want %s", s, Recovering)
-		}
-
+	l1 := Run(ctx1, db, ":1999", func(_ context.Context) {
 		t.Log("first process is now leader")
 		wg1.Done()
 	})
@@ -49,13 +42,7 @@ func TestFailover(t *testing.T) {
 	}
 
 	// Start up the second leader process. It should be following.
-	l2 = Run(ctx2, db, ":2000", func(_ context.Context) {
-		// When this process takes over leadership, it should be
-		// 'recovering'.
-		if s := l2.State(); s != Recovering {
-			t.Errorf("for second process state, got %s want %s", s, Recovering)
-		}
-
+	l2 := Run(ctx2, db, ":2000", func(_ context.Context) {
 		t.Log("second process is now leader")
 		wg2.Done()
 	})

--- a/core/leader/leader_test.go
+++ b/core/leader/leader_test.go
@@ -1,10 +1,11 @@
 package leader
 
 import (
-	"chain/database/pg/pgtest"
 	"context"
 	"sync"
 	"testing"
+
+	"chain/database/pg/pgtest"
 )
 
 func TestFailover(t *testing.T) {

--- a/core/leader/leader_test.go
+++ b/core/leader/leader_test.go
@@ -67,7 +67,7 @@ func TestFailover(t *testing.T) {
 	// second process to take over leadership.
 	cancel1()
 	wg2.Wait()
-	if s := l1.State(); s != Leading {
+	if s := l2.State(); s != Leading {
 		t.Errorf("the second process state, got %s want %s", s, Leading)
 	}
 	addr, err = l2.Address(ctx)

--- a/core/leader/leader_test.go
+++ b/core/leader/leader_test.go
@@ -1,0 +1,79 @@
+package leader
+
+import (
+	"chain/database/pg/pgtest"
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestFailover(t *testing.T) {
+	var l1, l2 *Leader
+	var wg1, wg2 sync.WaitGroup
+	wg1.Add(1)
+	wg2.Add(1)
+
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	ctx := context.Background()
+	ctx1, cancel1 := context.WithCancel(ctx)
+	ctx2, cancel2 := context.WithCancel(ctx)
+	defer cancel1()
+	defer cancel2()
+
+	// Start up the first leader process. It should immediately become
+	// leader.
+	l1 = Run(ctx1, db, ":1999", func(_ context.Context) {
+		// Since the lead func hasn't completed yet, the leader
+		// state should still be 'recovering'.
+		if s := l1.State(); s != Recovering {
+			t.Errorf("for first process state, got %s want %s", s, Recovering)
+		}
+
+		t.Log("first process is now leader")
+		wg1.Done()
+	})
+
+	// Wait for the first process lead func to complete. The first process
+	// should be then be 'leading'.
+	wg1.Wait()
+	if s := l1.State(); s != Leading {
+		t.Errorf("the first process state, got %s want %s", s, Leading)
+	}
+	addr, err := l1.Address(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != l1.address {
+		t.Errorf("leader Address() got %s, want %s", addr, l1.address)
+	}
+
+	// Start up the second leader process. It should be following.
+	l2 = Run(ctx2, db, ":2000", func(_ context.Context) {
+		// When this process takes over leadership, it should be
+		// 'recovering'.
+		if s := l2.State(); s != Recovering {
+			t.Errorf("for second process state, got %s want %s", s, Recovering)
+		}
+
+		t.Log("second process is now leader")
+		wg2.Done()
+	})
+	if s := l2.State(); s != Following {
+		t.Errorf("for second process state, got %s want %s", s, Following)
+	}
+
+	// Kill the first process by cancelling its context. Then wait for the
+	// second process to take over leadership.
+	cancel1()
+	wg2.Wait()
+	if s := l1.State(); s != Leading {
+		t.Errorf("the second process state, got %s want %s", s, Leading)
+	}
+	addr, err = l2.Address(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if addr != l2.address {
+		t.Errorf("leader Address() got %s, want %s", addr, l2.address)
+	}
+}

--- a/core/leader/leader_test.go
+++ b/core/leader/leader_test.go
@@ -22,7 +22,7 @@ func TestFailover(t *testing.T) {
 
 	// Start up the first leader process. It should immediately become
 	// leader.
-	l1 := Run(ctx1, db, ":1999", func(_ context.Context) {
+	l1 := Run(ctx1, db, ":1999", func(context.Context) {
 		t.Log("first process is now leader")
 		wg1.Done()
 	})
@@ -42,7 +42,7 @@ func TestFailover(t *testing.T) {
 	}
 
 	// Start up the second leader process. It should be following.
-	l2 := Run(ctx2, db, ":2000", func(_ context.Context) {
+	l2 := Run(ctx2, db, ":2000", func(context.Context) {
 		t.Log("second process is now leader")
 		wg2.Done()
 	})

--- a/core/run.go
+++ b/core/run.go
@@ -179,7 +179,7 @@ func Run(
 
 	// When this cored becomes leader, run a.lead to perform
 	// leader-only Core duties.
-	go leader.Run(db, routableAddress, a.lead)
+	a.leader = leader.Run(db, routableAddress, a.lead)
 
 	// Construct the complete http.Handler once.
 	a.buildHandler()

--- a/core/run.go
+++ b/core/run.go
@@ -179,7 +179,7 @@ func Run(
 
 	// When this cored becomes leader, run a.lead to perform
 	// leader-only Core duties.
-	a.leader = leader.Run(db, routableAddress, a.lead)
+	a.leader = leader.Run(ctx, db, routableAddress, a.lead)
 
 	// Construct the complete http.Handler once.
 	a.buildHandler()

--- a/core/transact.go
+++ b/core/transact.go
@@ -98,7 +98,7 @@ func (a *API) build(ctx context.Context, buildReqs []*buildRequest) (interface{}
 	// If we're not the leader, we don't have access to the current
 	// reservations. Forward the build call to the leader process.
 	// TODO(jackson): Distribute reservations across cored processes.
-	if leader.State() != leader.Leading {
+	if a.leader.State() != leader.Leading {
 		var resp interface{}
 		err := a.forwardToLeader(ctx, "/build-transaction", buildReqs, &resp)
 		return resp, err
@@ -289,7 +289,7 @@ type submitArg struct {
 
 // POST /submit-transaction
 func (a *API) submit(ctx context.Context, x submitArg) (interface{}, error) {
-	if leader.State() != leader.Leading {
+	if a.leader.State() != leader.Leading {
 		var resp json.RawMessage
 		err := a.forwardToLeader(ctx, "/submit-transaction", x, &resp)
 		return resp, err

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2828";
+	public final String Id = "main/rev2829";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2828"
+const ID string = "main/rev2829"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2828"
+export const rev_id = "main/rev2829"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2828".freeze
+	ID = "main/rev2829".freeze
 end


### PR DESCRIPTION
Encapsulate all of the core/leader state into a struct instead of
using package-level global variables. Also, add a test for leader
failover since it's now possible to unit test.