### PR TITLE
core/fileutil: new package

### DIFF
--- a/core/fileutil/dir.go
+++ b/core/fileutil/dir.go
@@ -1,0 +1,12 @@
+//+build !windows,!darwin
+
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func DefaultDir() string {
+	return filepath.Join(os.Getenv("HOME"), ".cored")
+}

--- a/core/fileutil/dir.go
+++ b/core/fileutil/dir.go
@@ -7,6 +7,6 @@ import (
 	"path/filepath"
 )
 
-func DefaultDir() string {
-	return filepath.Join(os.Getenv("HOME"), ".cored")
+func defaultDir() string {
+	return filepath.Join(os.Getenv("HOME"), ".chaincore")
 }

--- a/core/fileutil/dir_darwin.go
+++ b/core/fileutil/dir_darwin.go
@@ -1,5 +1,3 @@
-//+build darwin
-
 package fileutil
 
 import (

--- a/core/fileutil/dir_darwin.go
+++ b/core/fileutil/dir_darwin.go
@@ -5,6 +5,6 @@ import (
 	"path/filepath"
 )
 
-func DefaultDir() string {
+func defaultDir() string {
 	return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Chain Core")
 }

--- a/core/fileutil/dir_darwin.go
+++ b/core/fileutil/dir_darwin.go
@@ -1,0 +1,12 @@
+//+build darwin
+
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func DefaultDir() string {
+	return filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Chain Core")
+}

--- a/core/fileutil/dir_windows.go
+++ b/core/fileutil/dir_windows.go
@@ -1,5 +1,3 @@
-//+build windows
-
 package fileutil
 
 import (

--- a/core/fileutil/dir_windows.go
+++ b/core/fileutil/dir_windows.go
@@ -1,0 +1,12 @@
+//+build windows
+
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func DefaultDir() string {
+	return filepath.Join(os.Getenv("LOCALAPPDATA"), "Chain")
+}

--- a/core/fileutil/dir_windows.go
+++ b/core/fileutil/dir_windows.go
@@ -5,6 +5,6 @@ import (
 	"path/filepath"
 )
 
-func DefaultDir() string {
-	return filepath.Join(os.Getenv("LOCALAPPDATA"), "Chain")
+func defaultDir() string {
+	return filepath.Join(os.Getenv("LOCALAPPDATA"), `Chain Core`)
 }

--- a/core/fileutil/doc.go
+++ b/core/fileutil/doc.go
@@ -1,0 +1,8 @@
+// Package fileutil contains OS-compatible utilities for writing Chain Core's
+// application data.
+package fileutil
+
+// DefaultDir returns the directory used to store Chain Core's application data.
+func DefaultDir() string {
+	return defaultDir()
+}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2829";
+	public final String Id = "main/rev2830";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2829"
+const ID string = "main/rev2830"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2829"
+export const rev_id = "main/rev2830"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2829".freeze
+	ID = "main/rev2830".freeze
 end


### PR DESCRIPTION
package `fileutil` contains OS-compatible utilities for writing Chain Core's application data