### PR TITLE
all: clean up

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -69,9 +69,6 @@ var (
 
 	race          []interface{} // initialized in race.go
 	httpsRedirect = true        // initialized in insecure.go
-
-	blockPeriod              = time.Second
-	expireReservationsPeriod = time.Second
 )
 
 func init() {
@@ -318,13 +315,6 @@ func initializeLocalSigner(ctx context.Context, conf *config.Config, db pg.DB, c
 	return s, nil
 }
 
-// remoteSigner defines the address and public key of another Core
-// that may sign blocks produced by this generator.
-type remoteSigner struct {
-	Client *rpc.Client
-	Key    ed25519.PublicKey
-}
-
 // remoteHSM is a client wrapper for an hsm that is used as a blocksigner.Signer
 type remoteHSM struct {
 	Client *rpc.Client
@@ -359,6 +349,13 @@ func remoteSignerInfo(ctx context.Context, processID, buildTag, blockchainID str
 		a = append(a, &remoteSigner{Client: client, Key: ed25519.PublicKey(signer.Pubkey)})
 	}
 	return a
+}
+
+// remoteSigner defines the address and public key of another Core
+// that may sign blocks produced by this generator.
+type remoteSigner struct {
+	Client *rpc.Client
+	Key    ed25519.PublicKey
 }
 
 func (s *remoteSigner) SignBlock(ctx context.Context, b *bc.Block) (signature []byte, err error) {

--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -296,7 +296,7 @@ func writeCode(w io.Writer, path, snippet string) {
 func readSnippet(path, snippet string) (string, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("Unable to read source file: %s", path)
+		return "", fmt.Errorf("unable to read source file: %s: %s", path, err)
 	}
 
 	src := string(b)

--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -296,7 +296,7 @@ func writeCode(w io.Writer, path, snippet string) {
 func readSnippet(path, snippet string) (string, error) {
 	b, err := ioutil.ReadFile(path)
 	if err != nil {
-		return "", fmt.Errorf("Unable to read source file: %s\n", path)
+		return "", fmt.Errorf("Unable to read source file: %s", path)
 	}
 
 	src := string(b)

--- a/cmd/slashland/main.go
+++ b/cmd/slashland/main.go
@@ -159,7 +159,7 @@ func land(req *landReq) {
 		)
 		return
 	}
-	if prState.Mergeable != nil && *prState.Mergeable == false {
+	if prState.Mergeable != nil && !*prState.Mergeable {
 		sayf("<@%s|%s> failed to land %s: branch has conflicts",
 			req.userID,
 			req.userName,

--- a/cmd/vet/testdata/logparity.go
+++ b/cmd/vet/testdata/logparity.go
@@ -4,7 +4,7 @@ package testdata
 
 import "chain/log"
 
-// This function never executes, but it serves as a simple test for the program.
+// PrintkvTests never executes, but it serves as a simple test for the program.
 // Test with (cd ..; go test).
 func PrintkvTests() {
 	log.Printkv(nil, "k", "v")            // ok

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -22,6 +22,7 @@ import (
 	"chain/core/txdb"
 	"chain/database/pg"
 	"chain/database/pg/pgtest"
+	"chain/errors"
 	"chain/protocol"
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
@@ -228,7 +229,7 @@ func generateBlock(ctx context.Context, t testing.TB, db pg.DB, timestamp time.T
 
 	c, err := protocol.NewChain(ctx, b1.Hash(), store, nil)
 	if err != nil {
-		return err
+		return errors.Wrap(err)
 	}
 	pinStore := pin.NewStore(db)
 	coretest.CreatePins(ctx, t, pinStore)

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -227,6 +227,9 @@ func generateBlock(ctx context.Context, t testing.TB, db pg.DB, timestamp time.T
 	}
 
 	c, err := protocol.NewChain(ctx, b1.Hash(), store, nil)
+	if err != nil {
+		return err
+	}
 	pinStore := pin.NewStore(db)
 	coretest.CreatePins(ctx, t, pinStore)
 	indexer := query.NewIndexer(db, c, pinStore)

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -70,7 +70,7 @@ type Action interface {
 	Build(context.Context, *TemplateBuilder) error
 }
 
-// Reciever encapsulates information about where to send assets.
+// Receiver encapsulates information about where to send assets.
 type Receiver struct {
 	ControlProgram chainjson.HexBytes `json:"control_program"`
 	ExpiresAt      time.Time          `json:"expires_at"`

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2830";
+	public final String Id = "main/rev2831";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2830"
+const ID string = "main/rev2831"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2830"
+export const rev_id = "main/rev2831"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2830".freeze
+	ID = "main/rev2831".freeze
 end

--- a/protocol/bc/txtransaction.go
+++ b/protocol/bc/txtransaction.go
@@ -22,7 +22,7 @@ func ComputeOutputID(sc *SpendCommitment) (h Hash, err error) {
 	return h, nil
 }
 
-// TxHashes returns all hashes needed for validation and state updates.
+// ComputeTxHashes returns all hashes needed for validation and state updates.
 func ComputeTxHashes(oldTx *TxData) (hashes *TxHashes, err error) {
 	defer func() {
 		if r, ok := recover().(error); ok {
@@ -74,12 +74,12 @@ func ComputeTxHashes(oldTx *TxData) (hashes *TxHashes, err error) {
 
 		case *Issuance:
 			vmc := newVMContext(entryID, hashes.ID, header.body.Data, ent.body.Data)
-			vmc.NonceID = (*Hash)(&ent.body.Anchor)
+			vmc.NonceID = &ent.body.Anchor
 			hashes.VMContexts[ent.Ordinal()] = vmc
 
 		case *Spend:
 			vmc := newVMContext(entryID, hashes.ID, header.body.Data, ent.body.Data)
-			vmc.OutputID = (*Hash)(&ent.body.SpentOutput)
+			vmc.OutputID = &ent.body.SpentOutput
 			hashes.VMContexts[ent.Ordinal()] = vmc
 			hashes.SpentOutputIDs[ent.Ordinal()] = ent.body.SpentOutput
 		}


### PR DESCRIPTION
Clean up some small items found manually and by linters:

* blockPeriod, expireReservationsPeriod are no longer used in cmd/cored/main.go
* move remoteSigner struct definition to be beside its method declarations
* don't include newline in error message in md2html
* simplify boolean check in slashland
* tweak a few function comments to be in "[FunctionName] ..." format
* fix misspelling of "Receiver" in a comment
* check unchecked error value in TestRecovery
* avoid a couple of unnecessary conversions to *bc.Hash in ComputeTxHashes