### PR TITLE
core/pin: add unit tests

### DIFF
--- a/core/pin/pin_test.go
+++ b/core/pin/pin_test.go
@@ -6,7 +6,62 @@ import (
 	"time"
 
 	"chain/database/pg/pgtest"
+	"chain/protocol/bc"
+	"chain/protocol/prottest"
+	"chain/testutil"
 )
+
+func TestCreatePin(t *testing.T) {
+	db := pgtest.NewTx(t)
+	ctx := context.Background()
+	store := NewStore(db)
+
+	err := store.CreatePin(ctx, "example", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h := store.Height("example"); h != 100 {
+		t.Errorf("pin height got %d, want %d", h, 100)
+	}
+
+	// Try to create the pin again but with a higher height.
+	// The pin should be unchanged.
+	err = store.CreatePin(ctx, "example", 20000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h := store.Height("example"); h != 100 {
+		t.Errorf("pin height got %d, want %d", h, 100)
+	}
+}
+
+func TestListenPin(t *testing.T) {
+	dbURL, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create two stores. One will update the pin, the other will listen to it.
+	activeStore, passiveStore := NewStore(db), NewStore(db)
+	err := activeStore.CreatePin(ctx, "example", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = passiveStore.LoadAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Track updates to the pin height in the passive store.
+	passiveStore.Listen(ctx, "example", dbURL)
+
+	// Mark the pin as having completed block 2.
+	pin := <-activeStore.pin("example")
+	pin.complete(ctx, 2)
+
+	// Wait for the passive store to recognize that block 2 has
+	// been processed.
+	<-passiveStore.PinWaiter("example", 2)
+}
 
 func TestWaitForPin(t *testing.T) {
 	dbtx := pgtest.NewTx(t)
@@ -35,5 +90,39 @@ func TestWaitForPin(t *testing.T) {
 	err = <-ch
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestProcessBlocks(t *testing.T) {
+	db := pgtest.NewTx(t)
+	ctx := context.Background()
+	store := NewStore(db)
+	c := prottest.NewChain(t)
+
+	err := store.CreatePin(ctx, "example", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var blockHeights []uint64
+	go store.ProcessBlocks(ctx, c, "example", func(ctx context.Context, b *bc.Block) error {
+		// Wait for previous blocks to be processed.
+		<-store.PinWaiter("example", b.Height-1)
+
+		blockHeights = append(blockHeights, b.Height)
+		return nil
+	})
+
+	// Make a handful of empty blocks, forcing the processor to process them.
+	prottest.MakeBlock(t, c, nil)
+	prottest.MakeBlock(t, c, nil)
+	prottest.MakeBlock(t, c, nil)
+
+	// Wait for the block processor to finish processing.
+	<-store.AllWaiter(4)
+
+	want := []uint64{1, 2, 3, 4}
+	if !testutil.DeepEqual(blockHeights, want) {
+		t.Errorf("processed block heights, got %#v want %#v", blockHeights, want)
 	}
 }

--- a/core/pin/pin_test.go
+++ b/core/pin/pin_test.go
@@ -95,9 +95,10 @@ func TestWaitForPin(t *testing.T) {
 
 func TestProcessBlocks(t *testing.T) {
 	db := pgtest.NewTx(t)
-	ctx := context.Background()
 	store := NewStore(db)
 	c := prottest.NewChain(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	err := store.CreatePin(ctx, "example", 0)
 	if err != nil {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2832";
+	public final String Id = "main/rev2833";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2832"
+const ID string = "main/rev2833"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2832"
+export const rev_id = "main/rev2833"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2832".freeze
+	ID = "main/rev2833".freeze
 end


### PR DESCRIPTION
Improve the test coverage of the pin package. This brings statement
coverage from 27.9% to 82.1%.