### PR TITLE
core: fix processor dependencies

### DIFF
--- a/core/account/indexer.go
+++ b/core/account/indexer.go
@@ -103,7 +103,6 @@ func (m *Manager) ProcessBlocks(ctx context.Context) {
 	}
 	go m.pinStore.ProcessBlocks(ctx, m.chain, ExpirePinName, func(ctx context.Context, b *bc.Block) error {
 		<-m.pinStore.PinWaiter(PinName, b.Height)
-		<-m.pinStore.PinWaiter(query.TxPinName, b.Height)
 		return m.expireControlPrograms(ctx, b)
 	})
 	go m.pinStore.ProcessBlocks(ctx, m.chain, DeleteSpentsPinName, func(ctx context.Context, b *bc.Block) error {

--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -143,7 +143,7 @@ func (reg *Registry) indexAssets(ctx context.Context, b *bc.Block) error {
 		WITH new_assets AS (
 			INSERT INTO assets (id, vm_version, issuance_program, definition, created_at, initial_block_hash, first_block_height)
 			VALUES(unnest($1::bytea[]), unnest($2::bigint[]), unnest($3::bytea[]), unnest($4::bytea[]), $5, $6, $7)
-			ON CONFLICT (id) DO NOTHING
+			ON CONFLICT (id) DO UPDATE SET first_block_height = $7 WHERE assets.first_block_height > $7
 			RETURNING id
 		)
 		SELECT id FROM new_assets

--- a/core/query/index.go
+++ b/core/query/index.go
@@ -60,6 +60,7 @@ func (ind *Indexer) ProcessBlocks(ctx context.Context) {
 func (ind *Indexer) IndexTransactions(ctx context.Context, b *bc.Block) error {
 	<-ind.pinStore.PinWaiter("asset", b.Height)
 	<-ind.pinStore.PinWaiter("account", b.Height)
+	<-ind.pinStore.PinWaiter(TxPinName, b.Height-1)
 
 	err := ind.insertBlock(ctx, b)
 	if err != nil {

--- a/core/query_test.go
+++ b/core/query_test.go
@@ -28,6 +28,10 @@ func TestQueryWithClockSkew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = pinStore.CreatePin(ctx, query.TxPinName, 99)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	indexer := query.NewIndexer(db, c, pinStore)
 	api := &API{db: db, chain: c, indexer: indexer}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2833";
+	public final String Id = "main/rev2834";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2833"
+const ID string = "main/rev2834"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2833"
+export const rev_id = "main/rev2834"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2833".freeze
+	ID = "main/rev2834".freeze
 end


### PR DESCRIPTION
Fix a few block processor dependencies that were incorrectly missing or
unnecessary.

expire ACPs processor

The expire account control programs processor used to have a dependency
on the query package's transaction annotator and indexer. However, we no
longer use the account control programs for annotation. We only use the
account_utxo table. Instead, we just need to make sure that the account
indexer has successfully added the utxos to the account_utxo table
before we delete the control programs.

asset processor

A block processor can be run on multiple blocks at once. Previously, if
two consecutive blocks both contained transactions issuing a previously
unknown asset, there was a race condition for which value would be
recorded in the first_block_height column. We can fix this by always
updating with the lower block height.

annotated tx query processor

The query block processor is responsible for marking annotated outputs
as spent on every spend. Since a block processor can be run on multiple
blocks in parallel, the query block processor had a race condition. For
example, an output k can be created in block n-1 and spent in block n.
If the block processor processes block n first and then block n-1, the
processor would create the annotated output and never mark it as spent.
This would permanently corrupt balance queries. If we instead wait for
block n-1 to be processed by the query processor, we ensure that the
output has been created by the time we try to mark it as spent.


I tested this change locally against testnet, creating a few transactions
through the java SDK.