### PR TITLE
docs/internal: document point release standards

### DIFF
--- a/docs/internal/package-tags-branches.md
+++ b/docs/internal/package-tags-branches.md
@@ -19,6 +19,14 @@ Version branches act as the merge base for point release updates across all pack
 
 Updates to the version branches should be as conservative as possible. We should ensure that the tip of each version branch maintains cross-compatibility across packages, per our [versioning scheme](../core/reference/versioning.md).
 
+The standards for including a bug fix in a point release of Chain Core Server are:
+
+- the bug has no workaround
+- the bug is likely to be hit (e.g. >1% probability)
+- the bug compromises important functionality (i.e. not cosmetic, not minor)
+
+If a bug meets all three of those standards, it is a good candidate to fix in a point release. Different products might decide to apply different standards for their point releases.
+
 <sup>1</sup> Version 1.0 predates this scheme, so there is no `1.0-stable` branch. To make updates to 1.0, please use the 1.0 package-specific release tags.
 
 ## Release tags

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2834";
+	public final String Id = "main/rev2835";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2834"
+const ID string = "main/rev2835"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2834"
+export const rev_id = "main/rev2835"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2834".freeze
+	ID = "main/rev2835".freeze
 end


### PR DESCRIPTION
This change attempts to codify the standards we use to
include changes in a point release. It'll help to have
them written down. We can refine them over time if we
think it's necessary.