### PR TITLE
core: fix processor dependencies

### DIFF
--- a/core/account/indexer_test.go
+++ b/core/account/indexer_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"chain/core/pin"
-	"chain/core/query"
 	"chain/crypto/ed25519/chainkd"
 	"chain/database/pg/pgtest"
 	"chain/protocol/bc"
@@ -42,18 +41,6 @@ func TestUsedExpiredAccountControlPrograms(t *testing.T) {
 		}},
 	}
 	err = m.indexAccountUTXOs(ctx, b)
-	if err != nil {
-		testutil.FatalErr(t, err)
-	}
-
-	// The expire control programs routine requires that the account
-	// and query tx processors to run first. Create fake pins indiciating
-	// that they've already run.
-	err = pins.CreatePin(ctx, PinName, 2)
-	if err != nil {
-		testutil.FatalErr(t, err)
-	}
-	err = pins.CreatePin(ctx, query.TxPinName, 2)
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}

--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -145,7 +145,7 @@ func (reg *Registry) indexAssets(ctx context.Context, b *bc.Block) error {
 		WITH new_assets AS (
 			INSERT INTO assets (id, vm_version, issuance_program, definition, created_at, initial_block_hash, first_block_height)
 			VALUES(unnest($1::bytea[]), unnest($2::bigint[]), unnest($3::bytea[]), unnest($4::bytea[]), $5, $6, $7)
-			ON CONFLICT (id) DO NOTHING
+			ON CONFLICT (id) DO UPDATE SET first_block_height = $7 WHERE assets.first_block_height > $7
 			RETURNING id
 		)
 		SELECT id FROM new_assets

--- a/core/query/index.go
+++ b/core/query/index.go
@@ -39,6 +39,7 @@ func (ind *Indexer) ProcessBlocks(ctx context.Context) {
 // saves all annotated transactions to the database.
 func (ind *Indexer) IndexTransactions(ctx context.Context, b *bc.Block) error {
 	<-ind.pinStore.PinWaiter("asset", b.Height)
+	<-ind.pinStore.PinWaiter(TxPinName, b.Height-1)
 
 	err := ind.insertBlock(ctx, b)
 	if err != nil {

--- a/core/query_test.go
+++ b/core/query_test.go
@@ -23,6 +23,10 @@ func TestQueryWithClockSkew(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = pinStore.CreatePin(ctx, query.TxPinName, 99)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	indexer := query.NewIndexer(db, c, pinStore)
 	api := &API{DB: db, Chain: c, Indexer: indexer}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,0 +1,4 @@
+
+public final class RevId {
+	public final String Id = "1.1-stable/rev2747";
+}

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,0 +1,3 @@
+package rev
+
+const ID string = "1.1-stable/rev2747"


### PR DESCRIPTION
Fix a few block processor dependencies that were incorrectly missing or
unnecessary. This is the 1.1-stable version of #783. Because main and
`1.1-stable` have diverged some, this PR is slightly different. Most
notably, because account_utxos are marked as spent in the account block
processor, the account block processor must also wait for block n-1 to
be indexed.

I had to move the account package's PinWaiter calls into closures for the
tests.