### PR TITLE
core: unexport API.HealthSetter

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -72,8 +72,6 @@ type API struct {
 	generator       *generator.Generator
 	remoteGenerator *rpc.Client
 	indexTxs        bool
-	genhealth       func(error)
-	fetchhealth     func(error)
 
 	healthMu     sync.Mutex
 	healthErrors map[string]interface{}

--- a/core/health.go
+++ b/core/health.go
@@ -1,9 +1,9 @@
 package core
 
-// HealthSetter returns a function that, when called,
+// healthSetter returns a function that, when called,
 // sets the named health status in the map returned by "/health".
 // The returned function is safe to call concurrently with ServeHTTP.
-func (a *API) HealthSetter(name string) func(error) {
+func (a *API) healthSetter(name string) func(error) {
 	return func(err error) { a.setHealth(name, err) }
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2836";
+	public final String Id = "main/rev2837";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2836"
+const ID string = "main/rev2837"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2836"
+export const rev_id = "main/rev2837"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2836".freeze
+	ID = "main/rev2837".freeze
 end


### PR DESCRIPTION
Unexport API.HealthSetter. Now that the leader run function is in the
core package, HealthSetter doesn't need to be exported.