### PR TITLE
core: remove deprecated /rpc/get-blocks endpoint

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -147,7 +147,6 @@ func (a *API) buildHandler() {
 	m.Handle(networkRPCPrefix+"submit", needConfig(func(ctx context.Context, tx *bc.Tx) error {
 		return a.submitter.Submit(ctx, tx)
 	}))
-	m.Handle(networkRPCPrefix+"get-blocks", needConfig(a.getBlocksRPC)) // DEPRECATED: use get-block instead
 	m.Handle(networkRPCPrefix+"get-block", needConfig(a.getBlockRPC))
 	m.Handle(networkRPCPrefix+"get-snapshot-info", needConfig(a.getSnapshotInfoRPC))
 	m.Handle(networkRPCPrefix+"get-snapshot", http.HandlerFunc(a.getSnapshotRPC))

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -16,7 +16,6 @@ var (
 
 	latencyRange = map[string]time.Duration{
 		networkRPCPrefix + "get-block":         20 * time.Second,
-		networkRPCPrefix + "get-blocks":        20 * time.Second,
 		networkRPCPrefix + "signer/sign-block": 5 * time.Second,
 		networkRPCPrefix + "get-snapshot":      30 * time.Second,
 		// the rest have a default range

--- a/core/rpc.go
+++ b/core/rpc.go
@@ -29,16 +29,6 @@ func (a *API) getBlockRPC(ctx context.Context, height uint64) (chainjson.HexByte
 	return rawBlock, nil
 }
 
-// getBlocksRPC -- DEPRECATED: use getBlock instead
-func (a *API) getBlocksRPC(ctx context.Context, afterHeight uint64) ([]chainjson.HexBytes, error) {
-	block, err := a.getBlockRPC(ctx, afterHeight+1)
-	if err != nil {
-		return nil, err
-	}
-
-	return []chainjson.HexBytes{block}, nil
-}
-
 type snapshotInfoResp struct {
 	Height       uint64  `json:"height"`
 	Size         uint64  `json:"size"`

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2839";
+	public final String Id = "main/rev2840";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2839"
+const ID string = "main/rev2840"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2839"
+export const rev_id = "main/rev2840"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2839".freeze
+	ID = "main/rev2840".freeze
 end


### PR DESCRIPTION
The /rpc/get-blocks RPC endpoint was replaced with the /rpc/get-block
endpoint shortly before the 1.0.0 release.

See 0a590e07e9484872d2ee7a5b28d5b8b3a582764f.