### PR TITLE
core: add unit tests for waitForTxInBlock

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2852";
+	public final String Id = "main/rev2853";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2852"
+const ID string = "main/rev2853"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2852"
+export const rev_id = "main/rev2853"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2852".freeze
+	ID = "main/rev2853".freeze
 end


### PR DESCRIPTION
Add unit tests for `waitForTxInBlock` to verify that the correct
block height is returned when a tx is confirmed and that the tx is
re-submitted for every block that does not contain the unconfirmed tx.