### PR TITLE
protocol/bc: move CalcMerkleRoot here

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2844";
+	public final String Id = "main/rev2845";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2844"
+const ID string = "main/rev2845"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2844"
+export const rev_id = "main/rev2845"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2844".freeze
+	ID = "main/rev2845".freeze
 end

--- a/protocol/bc/merkle.go
+++ b/protocol/bc/merkle.go
@@ -1,10 +1,9 @@
-package validation
+package bc
 
 import (
 	"math"
 
 	"chain/crypto/sha3pool"
-	"chain/protocol/bc"
 )
 
 var (
@@ -14,7 +13,7 @@ var (
 
 // CalcMerkleRoot creates a merkle tree from a slice of transactions
 // and returns the root hash of the tree.
-func CalcMerkleRoot(transactions []*bc.Tx) (root bc.Hash, err error) {
+func CalcMerkleRoot(transactions []*Tx) (root Hash, err error) {
 	switch {
 	case len(transactions) == 0:
 		sha3pool.Sum256(root[:], nil)

--- a/protocol/bc/merkle.go
+++ b/protocol/bc/merkle.go
@@ -13,7 +13,7 @@ var (
 
 // CalcMerkleRoot creates a merkle tree from a slice of transactions
 // and returns the root hash of the tree.
-func CalcMerkleRoot(transactions []*Tx) (root Hash, err error) {
+func MerkleRoot(transactions []*Tx) (root Hash, err error) {
 	switch {
 	case len(transactions) == 0:
 		sha3pool.Sum256(root[:], nil)
@@ -30,12 +30,12 @@ func CalcMerkleRoot(transactions []*Tx) (root Hash, err error) {
 
 	default:
 		k := prevPowerOfTwo(len(transactions))
-		left, err := CalcMerkleRoot(transactions[:k])
+		left, err := MerkleRoot(transactions[:k])
 		if err != nil {
 			return root, err
 		}
 
-		right, err := CalcMerkleRoot(transactions[k:])
+		right, err := MerkleRoot(transactions[k:])
 		if err != nil {
 			return root, err
 		}

--- a/protocol/bc/merkle.go
+++ b/protocol/bc/merkle.go
@@ -11,7 +11,7 @@ var (
 	interiorPrefix = []byte{0x01}
 )
 
-// CalcMerkleRoot creates a merkle tree from a slice of transactions
+// MerkleRoot creates a merkle tree from a slice of transactions
 // and returns the root hash of the tree.
 func MerkleRoot(transactions []*Tx) (root Hash, err error) {
 	switch {

--- a/protocol/bc/merkle_test.go
+++ b/protocol/bc/merkle_test.go
@@ -59,7 +59,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 				},
 			}))
 		}
-		got, err := CalcMerkleRoot(txs)
+		got, err := MerkleRoot(txs)
 		if err != nil {
 			t.Fatalf("unexpected error %s", err)
 		}
@@ -86,14 +86,14 @@ func TestDuplicateLeaves(t *testing.T) {
 
 	// first, get the root of an unbalanced tree
 	txns := []*Tx{txs[5], txs[4], txs[3], txs[2], txs[1], txs[0]}
-	root1, err := CalcMerkleRoot(txns)
+	root1, err := MerkleRoot(txns)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 
 	// now, get the root of a balanced tree that repeats leaves 0 and 1
 	txns = []*Tx{txs[5], txs[4], txs[3], txs[2], txs[1], txs[0], txs[1], txs[0]}
-	root2, err := CalcMerkleRoot(txns)
+	root2, err := MerkleRoot(txns)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
@@ -119,14 +119,14 @@ func TestAllDuplicateLeaves(t *testing.T) {
 
 	// first, get the root of an unbalanced tree
 	txs := []*Tx{tx6, tx5, tx4, tx3, tx2, tx1}
-	root1, err := CalcMerkleRoot(txs)
+	root1, err := MerkleRoot(txs)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 
 	// now, get the root of a balanced tree that repeats leaves 5 and 6
 	txs = []*Tx{tx6, tx5, tx6, tx5, tx4, tx3, tx2, tx1}
-	root2, err := CalcMerkleRoot(txs)
+	root2, err := MerkleRoot(txs)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}

--- a/protocol/bc/merkle_test.go
+++ b/protocol/bc/merkle_test.go
@@ -1,17 +1,15 @@
-package validation
+package bc
 
 import (
 	"bytes"
 	"testing"
 	"time"
-
-	"chain/protocol/bc"
 )
 
 func TestCalcMerkleRoot(t *testing.T) {
 	cases := []struct {
 		witnesses [][][]byte
-		want      bc.Hash
+		want      Hash
 	}{{
 		witnesses: [][][]byte{
 			[][]byte{
@@ -48,13 +46,13 @@ func TestCalcMerkleRoot(t *testing.T) {
 	}}
 
 	for _, c := range cases {
-		var txs []*bc.Tx
+		var txs []*Tx
 		for _, wit := range c.witnesses {
-			txs = append(txs, bc.NewTx(bc.TxData{
-				Inputs: []*bc.TxInput{
-					&bc.TxInput{
+			txs = append(txs, NewTx(TxData{
+				Inputs: []*TxInput{
+					&TxInput{
 						AssetVersion: 1,
-						TypedInput: &bc.SpendInput{
+						TypedInput: &SpendInput{
 							Arguments: wit,
 						},
 					},
@@ -73,28 +71,28 @@ func TestCalcMerkleRoot(t *testing.T) {
 }
 
 func TestDuplicateLeaves(t *testing.T) {
-	var initialBlockHash bc.Hash
+	var initialBlockHash Hash
 	trueProg := []byte{0x51}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyStringHash)
-	txs := make([]*bc.Tx, 6)
+	assetID := ComputeAssetID(trueProg, initialBlockHash, 1, EmptyStringHash)
+	txs := make([]*Tx, 6)
 	for i := uint64(0); i < 6; i++ {
 		now := []byte(time.Now().String())
-		txs[i] = bc.NewTx(bc.TxData{
+		txs[i] = NewTx(TxData{
 			Version: 1,
-			Inputs:  []*bc.TxInput{bc.NewIssuanceInput(now, i, nil, initialBlockHash, trueProg, nil, nil)},
-			Outputs: []*bc.TxOutput{bc.NewTxOutput(assetID, i, trueProg, nil)},
+			Inputs:  []*TxInput{NewIssuanceInput(now, i, nil, initialBlockHash, trueProg, nil, nil)},
+			Outputs: []*TxOutput{NewTxOutput(assetID, i, trueProg, nil)},
 		})
 	}
 
 	// first, get the root of an unbalanced tree
-	txns := []*bc.Tx{txs[5], txs[4], txs[3], txs[2], txs[1], txs[0]}
+	txns := []*Tx{txs[5], txs[4], txs[3], txs[2], txs[1], txs[0]}
 	root1, err := CalcMerkleRoot(txns)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 
 	// now, get the root of a balanced tree that repeats leaves 0 and 1
-	txns = []*bc.Tx{txs[5], txs[4], txs[3], txs[2], txs[1], txs[0], txs[1], txs[0]}
+	txns = []*Tx{txs[5], txs[4], txs[3], txs[2], txs[1], txs[0], txs[1], txs[0]}
 	root2, err := CalcMerkleRoot(txns)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
@@ -106,28 +104,28 @@ func TestDuplicateLeaves(t *testing.T) {
 }
 
 func TestAllDuplicateLeaves(t *testing.T) {
-	var initialBlockHash bc.Hash
+	var initialBlockHash Hash
 	trueProg := []byte{0x51}
-	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyStringHash)
+	assetID := ComputeAssetID(trueProg, initialBlockHash, 1, EmptyStringHash)
 	now := []byte(time.Now().String())
-	issuanceInp := bc.NewIssuanceInput(now, 1, nil, initialBlockHash, trueProg, nil, nil)
+	issuanceInp := NewIssuanceInput(now, 1, nil, initialBlockHash, trueProg, nil, nil)
 
-	tx := bc.NewTx(bc.TxData{
+	tx := NewTx(TxData{
 		Version: 1,
-		Inputs:  []*bc.TxInput{issuanceInp},
-		Outputs: []*bc.TxOutput{bc.NewTxOutput(assetID, 1, trueProg, nil)},
+		Inputs:  []*TxInput{issuanceInp},
+		Outputs: []*TxOutput{NewTxOutput(assetID, 1, trueProg, nil)},
 	})
 	tx1, tx2, tx3, tx4, tx5, tx6 := tx, tx, tx, tx, tx, tx
 
 	// first, get the root of an unbalanced tree
-	txs := []*bc.Tx{tx6, tx5, tx4, tx3, tx2, tx1}
+	txs := []*Tx{tx6, tx5, tx4, tx3, tx2, tx1}
 	root1, err := CalcMerkleRoot(txs)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}
 
 	// now, get the root of a balanced tree that repeats leaves 5 and 6
-	txs = []*bc.Tx{tx6, tx5, tx6, tx5, tx4, tx3, tx2, tx1}
+	txs = []*Tx{tx6, tx5, tx6, tx5, tx4, tx3, tx2, tx1}
 	root2, err := CalcMerkleRoot(txs)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
@@ -138,8 +136,8 @@ func TestAllDuplicateLeaves(t *testing.T) {
 	}
 }
 
-func mustParseHash(s string) bc.Hash {
-	h, err := bc.ParseHash(s)
+func mustParseHash(s string) Hash {
+	h, err := ParseHash(s)
 	if err != nil {
 		panic(err)
 	}

--- a/protocol/bc/merkle_test.go
+++ b/protocol/bc/merkle_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func TestCalcMerkleRoot(t *testing.T) {
+func TestMerkleRoot(t *testing.T) {
 	cases := []struct {
 		witnesses [][][]byte
 		want      Hash

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -82,7 +82,7 @@ func (c *Chain) GenerateBlock(ctx context.Context, prev *bc.Block, snapshot *sta
 			b.Transactions = append(b.Transactions, tx)
 		}
 	}
-	b.TransactionsMerkleRoot, err = validation.CalcMerkleRoot(b.Transactions)
+	b.TransactionsMerkleRoot, err = bc.CalcMerkleRoot(b.Transactions)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "calculating tx merkle root")
 	}
@@ -210,7 +210,7 @@ func NewInitialBlock(pubkeys []ed25519.PublicKey, nSigs int, timestamp time.Time
 		return nil, err
 	}
 
-	root, err := validation.CalcMerkleRoot([]*bc.Tx{}) // calculate the zero value of the tx merkle root
+	root, err := bc.CalcMerkleRoot([]*bc.Tx{}) // calculate the zero value of the tx merkle root
 	if err != nil {
 		return nil, errors.Wrap(err, "calculating zero value of tx merkle root")
 	}

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -82,7 +82,7 @@ func (c *Chain) GenerateBlock(ctx context.Context, prev *bc.Block, snapshot *sta
 			b.Transactions = append(b.Transactions, tx)
 		}
 	}
-	b.TransactionsMerkleRoot, err = bc.CalcMerkleRoot(b.Transactions)
+	b.TransactionsMerkleRoot, err = bc.MerkleRoot(b.Transactions)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "calculating tx merkle root")
 	}
@@ -210,7 +210,7 @@ func NewInitialBlock(pubkeys []ed25519.PublicKey, nSigs int, timestamp time.Time
 		return nil, err
 	}
 
-	root, err := bc.CalcMerkleRoot([]*bc.Tx{}) // calculate the zero value of the tx merkle root
+	root, err := bc.MerkleRoot([]*bc.Tx{}) // calculate the zero value of the tx merkle root
 	if err != nil {
 		return nil, errors.Wrap(err, "calculating zero value of tx merkle root")
 	}

--- a/protocol/recover_test.go
+++ b/protocol/recover_test.go
@@ -55,7 +55,7 @@ func TestRecoverSnapshotNoAdditionalBlocks(t *testing.T) {
 }
 
 func createEmptyBlock(block *bc.Block, snapshot *state.Snapshot) *bc.Block {
-	root, err := bc.CalcMerkleRoot(nil)
+	root, err := bc.MerkleRoot(nil)
 	if err != nil {
 		log.Fatalf("calculating empty merkle root: %s", err)
 	}

--- a/protocol/recover_test.go
+++ b/protocol/recover_test.go
@@ -9,7 +9,6 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/prottest/memstore"
 	"chain/protocol/state"
-	"chain/protocol/validation"
 	"chain/testutil"
 )
 
@@ -56,7 +55,7 @@ func TestRecoverSnapshotNoAdditionalBlocks(t *testing.T) {
 }
 
 func createEmptyBlock(block *bc.Block, snapshot *state.Snapshot) *bc.Block {
-	root, err := validation.CalcMerkleRoot(nil)
+	root, err := bc.CalcMerkleRoot(nil)
 	if err != nil {
 		log.Fatalf("calculating empty merkle root: %s", err)
 	}

--- a/protocol/validation/bench_test.go
+++ b/protocol/validation/bench_test.go
@@ -60,6 +60,6 @@ func BenchmarkCalcMerkleRoot(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		bc.CalcMerkleRoot(txs)
+		bc.MerkleRoot(txs)
 	}
 }

--- a/protocol/validation/bench_test.go
+++ b/protocol/validation/bench_test.go
@@ -60,6 +60,6 @@ func BenchmarkCalcMerkleRoot(b *testing.B) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		validation.CalcMerkleRoot(txs)
+		bc.CalcMerkleRoot(txs)
 	}
 }

--- a/protocol/validation/block.go
+++ b/protocol/validation/block.go
@@ -138,7 +138,7 @@ func validateBlockHeader(prev *bc.BlockHeader, block *bc.Block) error {
 		}
 	}
 
-	txMerkleRoot, err := CalcMerkleRoot(block.Transactions)
+	txMerkleRoot, err := bc.CalcMerkleRoot(block.Transactions)
 	if err != nil {
 		return errors.Wrap(err, "calculating tx merkle root")
 	}

--- a/protocol/validation/block.go
+++ b/protocol/validation/block.go
@@ -138,7 +138,7 @@ func validateBlockHeader(prev *bc.BlockHeader, block *bc.Block) error {
 		}
 	}
 
-	txMerkleRoot, err := bc.CalcMerkleRoot(block.Transactions)
+	txMerkleRoot, err := bc.MerkleRoot(block.Transactions)
 	if err != nil {
 		return errors.Wrap(err, "calculating tx merkle root")
 	}

--- a/protocol/validation/block_test.go
+++ b/protocol/validation/block_test.go
@@ -138,3 +138,11 @@ func TestValidateBlockHeader(t *testing.T) {
 		}
 	}
 }
+
+func mustParseHash(s string) bc.Hash {
+	h, err := bc.ParseHash(s)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}


### PR DESCRIPTION
This is part of "entries"-based validation, which moves much of the validation logic into the `protocol/bc` package.

Another carved-off piece of https://github.com/chain/chain/pull/788