### PR TITLE
errors: define new WrappedError interface

### DIFF
--- a/protocol/vm/vm.go
+++ b/protocol/vm/vm.go
@@ -275,6 +275,7 @@ func stackCost(stack [][]byte) int64 {
 	return result
 }
 
+// Error satisfies the errors.WrappedError interface.
 type Error struct {
 	Err  error
 	Prog []byte
@@ -293,6 +294,10 @@ func (e Error) Error() string {
 	}
 
 	return fmt.Sprintf("%s [prog %x = %s; args %s]", e.Err.Error(), e.Prog, dis, strings.Join(args, " "))
+}
+
+func (e Error) Wrapped() error {
+	return e.Err
 }
 
 func wrapErr(err error, vm *virtualMachine, args [][]byte) error {


### PR DESCRIPTION
The existing `wrapperError` type satisfies the new `WrappedError` interface, which is now also satisfied by `vm.Error`. This will allow finer-grained unit testing of the "entries"-based validation logic to follow.

A carved-off piece of https://github.com/chain/chain/pull/788