### PR TITLE
protocol/validation: remove import of chain/protocol/vm

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2843";
+	public final String Id = "main/rev2844";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2843"
+const ID string = "main/rev2844"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2843"
+export const rev_id = "main/rev2844"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2843".freeze
+	ID = "main/rev2844".freeze
 end

--- a/protocol/validation/merkle_test.go
+++ b/protocol/validation/merkle_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"chain/protocol/bc"
-	"chain/protocol/vm"
 )
 
 func TestCalcMerkleRoot(t *testing.T) {
@@ -16,7 +15,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 	}{{
 		witnesses: [][][]byte{
 			[][]byte{
-				vm.Int64Bytes(1),
+				{1, 0, 0, 0, 0, 0, 0, 0},
 				[]byte("00000"),
 			},
 		},
@@ -24,11 +23,11 @@ func TestCalcMerkleRoot(t *testing.T) {
 	}, {
 		witnesses: [][][]byte{
 			[][]byte{
-				vm.Int64Bytes(1),
+				{1, 0, 0, 0, 0, 0, 0, 0},
 				[]byte("000000"),
 			},
 			[][]byte{
-				vm.Int64Bytes(1),
+				{1, 0, 0, 0, 0, 0, 0, 0},
 				[]byte("111111"),
 			},
 		},
@@ -36,11 +35,11 @@ func TestCalcMerkleRoot(t *testing.T) {
 	}, {
 		witnesses: [][][]byte{
 			[][]byte{
-				vm.Int64Bytes(1),
+				{1, 0, 0, 0, 0, 0, 0, 0},
 				[]byte("000000"),
 			},
 			[][]byte{
-				vm.Int64Bytes(2),
+				{2, 0, 0, 0, 0, 0, 0, 0},
 				[]byte("111111"),
 				[]byte("222222"),
 			},
@@ -75,7 +74,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 
 func TestDuplicateLeaves(t *testing.T) {
 	var initialBlockHash bc.Hash
-	trueProg := []byte{byte(vm.OP_TRUE)}
+	trueProg := []byte{0x51}
 	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyStringHash)
 	txs := make([]*bc.Tx, 6)
 	for i := uint64(0); i < 6; i++ {
@@ -108,7 +107,7 @@ func TestDuplicateLeaves(t *testing.T) {
 
 func TestAllDuplicateLeaves(t *testing.T) {
 	var initialBlockHash bc.Hash
-	trueProg := []byte{byte(vm.OP_TRUE)}
+	trueProg := []byte{0x51}
 	assetID := bc.ComputeAssetID(trueProg, initialBlockHash, 1, bc.EmptyStringHash)
 	now := []byte(time.Now().String())
 	issuanceInp := bc.NewIssuanceInput(now, 1, nil, initialBlockHash, trueProg, nil, nil)

--- a/protocol/validation/merkle_test.go
+++ b/protocol/validation/merkle_test.go
@@ -15,7 +15,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 	}{{
 		witnesses: [][][]byte{
 			[][]byte{
-				{1, 0, 0, 0, 0, 0, 0, 0},
+				{1},
 				[]byte("00000"),
 			},
 		},
@@ -23,11 +23,11 @@ func TestCalcMerkleRoot(t *testing.T) {
 	}, {
 		witnesses: [][][]byte{
 			[][]byte{
-				{1, 0, 0, 0, 0, 0, 0, 0},
+				{1},
 				[]byte("000000"),
 			},
 			[][]byte{
-				{1, 0, 0, 0, 0, 0, 0, 0},
+				{1},
 				[]byte("111111"),
 			},
 		},
@@ -35,11 +35,11 @@ func TestCalcMerkleRoot(t *testing.T) {
 	}, {
 		witnesses: [][][]byte{
 			[][]byte{
-				{1, 0, 0, 0, 0, 0, 0, 0},
+				{1},
 				[]byte("000000"),
 			},
 			[][]byte{
-				{2, 0, 0, 0, 0, 0, 0, 0},
+				{2},
 				[]byte("111111"),
 				[]byte("222222"),
 			},


### PR DESCRIPTION
We were importing chain/protocol/vm for some constant values that don't affect the meaning of the tests in merkle_test.go. It's useful to remove edges in the dependency graph where possible so that future refactoring is less unnecessarily constrained.