### PR TITLE
protocol/bc: adjust exports and field names

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2845";
+	public final String Id = "main/rev2846";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2845"
+const ID string = "main/rev2846"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2845"
+export const rev_id = "main/rev2846"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2845".freeze
+	ID = "main/rev2846".freeze
 end

--- a/protocol/bc/blockheader.go
+++ b/protocol/bc/blockheader.go
@@ -3,7 +3,7 @@ package bc
 // BlockHeaderEntry contains the header information for a blockchain
 // block. It satisfies the Entry interface.
 type BlockHeaderEntry struct {
-	body struct {
+	Body struct {
 		Version              uint64
 		Height               uint64
 		PreviousBlockID      Hash
@@ -16,7 +16,7 @@ type BlockHeaderEntry struct {
 }
 
 func (BlockHeaderEntry) Type() string          { return "blockheader" }
-func (bh *BlockHeaderEntry) Body() interface{} { return bh.body }
+func (bh *BlockHeaderEntry) body() interface{} { return bh.Body }
 
 func (BlockHeaderEntry) Ordinal() int { return -1 }
 
@@ -24,12 +24,12 @@ func (BlockHeaderEntry) Ordinal() int { return -1 }
 // its body.
 func NewBlockHeaderEntry(version, height uint64, previousBlockID Hash, timestampMS uint64, transactionsRoot, assetsRoot Hash, nextConsensusProgram []byte) *BlockHeaderEntry {
 	bh := new(BlockHeaderEntry)
-	bh.body.Version = version
-	bh.body.Height = height
-	bh.body.PreviousBlockID = previousBlockID
-	bh.body.TimestampMS = timestampMS
-	bh.body.TransactionsRoot = transactionsRoot
-	bh.body.AssetsRoot = assetsRoot
-	bh.body.NextConsensusProgram = nextConsensusProgram
+	bh.Body.Version = version
+	bh.Body.Height = height
+	bh.Body.PreviousBlockID = previousBlockID
+	bh.Body.TimestampMS = timestampMS
+	bh.Body.TransactionsRoot = transactionsRoot
+	bh.Body.AssetsRoot = assetsRoot
+	bh.Body.NextConsensusProgram = nextConsensusProgram
 	return bh
 }

--- a/protocol/bc/entry.go
+++ b/protocol/bc/entry.go
@@ -20,7 +20,7 @@ type Entry interface {
 
 	// Body produces the entry's body, which is used as input to
 	// EntryID.
-	Body() interface{}
+	body() interface{}
 
 	// Ordinal reports the position of the TxInput or TxOutput within
 	// its transaction, when this entry was created from such an
@@ -54,7 +54,7 @@ func EntryID(e Entry) (hash Hash) {
 
 	bh := sha3pool.Get256()
 	defer sha3pool.Put256(bh)
-	err := writeForHash(bh, e.Body())
+	err := writeForHash(bh, e.body())
 	if err != nil {
 		panic(err)
 	}
@@ -87,10 +87,6 @@ func writeForHash(w io.Writer, c interface{}) error {
 	case string:
 		_, err := blockchain.WriteVarstr31(w, []byte(v))
 		return errors.Wrapf(err, "writing string (len %d) for hash", len(v))
-
-		// TODO: The rest of these are all aliases for [32]byte. Do we
-		// really need them all?
-
 	case Hash:
 		_, err := w.Write(v[:])
 		return errors.Wrap(err, "writing Hash for hash")

--- a/protocol/bc/map.go
+++ b/protocol/bc/map.go
@@ -27,7 +27,7 @@ func mapTx(tx *TxData) (headerID Hash, hdr *TxHeader, entryMap map[Hash]Entry, e
 	// available in case an issuance needs it for its anchor.
 
 	var firstSpend *Spend
-	muxSources := make([]valueSource, len(tx.Inputs))
+	muxSources := make([]ValueSource, len(tx.Inputs))
 
 	for i, inp := range tx.Inputs {
 		if oldSp, ok := inp.TypedInput.(*SpendInput); ok {
@@ -41,7 +41,7 @@ func mapTx(tx *TxData) (headerID Hash, hdr *TxHeader, entryMap map[Hash]Entry, e
 				err = errors.Wrapf(err, "adding spend entry for input %d", i)
 				return
 			}
-			muxSources[i] = valueSource{
+			muxSources[i] = ValueSource{
 				Ref:   id,
 				Value: oldSp.AssetAmount,
 			}
@@ -121,7 +121,7 @@ func mapTx(tx *TxData) (headerID Hash, hdr *TxHeader, entryMap map[Hash]Entry, e
 				return
 			}
 
-			muxSources[i] = valueSource{
+			muxSources[i] = ValueSource{
 				Ref:   issID,
 				Value: val,
 			}

--- a/protocol/bc/map_test.go
+++ b/protocol/bc/map_test.go
@@ -32,34 +32,34 @@ func TestMapTx(t *testing.T) {
 	if header.Body.MaxTimeMS != oldTx.MaxTime {
 		t.Errorf("header.Body.MaxTimeMS is %d, expected %d", header.Body.MaxTimeMS, oldTx.MaxTime)
 	}
-	if len(header.Body.Results) != len(oldOuts) {
-		t.Errorf("header.Body.Results contains %d item(s), expected %d", len(header.Body.Results), len(oldOuts))
+	if len(header.Body.ResultIDs) != len(oldOuts) {
+		t.Errorf("header.Body.ResultIDs contains %d item(s), expected %d", len(header.Body.ResultIDs), len(oldOuts))
 	}
 
 	for i, oldOut := range oldOuts {
-		if resultEntry, ok := entryMap[header.Body.Results[i]]; ok {
+		if resultEntry, ok := entryMap[header.Body.ResultIDs[i]]; ok {
 			if newOut, ok := resultEntry.(*Output); ok {
 				if newOut.Body.Source.Value != oldOut.AssetAmount {
-					t.Errorf("header.Body.Results[%d].(*output).Body.Source is %v, expected %v", i, newOut.Body.Source.Value, oldOut.AssetAmount)
+					t.Errorf("header.Body.ResultIDs[%d].(*output).Body.Source is %v, expected %v", i, newOut.Body.Source.Value, oldOut.AssetAmount)
 				}
 				if newOut.Body.ControlProgram.VMVersion != 1 {
-					t.Errorf("header.Body.Results[%d].(*output).Body.ControlProgram.VMVersion is %d, expected 1", i, newOut.Body.ControlProgram.VMVersion)
+					t.Errorf("header.Body.ResultIDs[%d].(*output).Body.ControlProgram.VMVersion is %d, expected 1", i, newOut.Body.ControlProgram.VMVersion)
 				}
 				if !bytes.Equal(newOut.Body.ControlProgram.Code, oldOut.ControlProgram) {
-					t.Errorf("header.Body.Results[%d].(*output).Body.ControlProgram.Code is %x, expected %x", i, newOut.Body.ControlProgram.Code, oldOut.ControlProgram)
+					t.Errorf("header.Body.ResultIDs[%d].(*output).Body.ControlProgram.Code is %x, expected %x", i, newOut.Body.ControlProgram.Code, oldOut.ControlProgram)
 				}
 				if newOut.Body.Data != hashData(oldOut.ReferenceData) {
 					want := hashData(oldOut.ReferenceData)
-					t.Errorf("header.Body.Results[%d].(*output).Body.Data is %x, expected %x", i, newOut.Body.Data[:], want[:])
+					t.Errorf("header.Body.ResultIDs[%d].(*output).Body.Data is %x, expected %x", i, newOut.Body.Data[:], want[:])
 				}
 				if (newOut.Body.ExtHash != Hash{}) {
-					t.Errorf("header.Body.Results[%d].(*output).Body.ExtHash is %x, expected zero", i, newOut.Body.ExtHash[:])
+					t.Errorf("header.Body.ResultIDs[%d].(*output).Body.ExtHash is %x, expected zero", i, newOut.Body.ExtHash[:])
 				}
 			} else {
-				t.Errorf("header.Body.Results[%d] has type %s, expected output1", i, resultEntry.Type())
+				t.Errorf("header.Body.ResultIDs[%d] has type %s, expected output1", i, resultEntry.Type())
 			}
 		} else {
-			t.Errorf("entryMap contains nothing for header.Body.Results[%d] (%x)", i, header.Body.Results[i][:])
+			t.Errorf("entryMap contains nothing for header.Body.ResultIDs[%d] (%x)", i, header.Body.ResultIDs[i][:])
 		}
 	}
 }

--- a/protocol/bc/map_test.go
+++ b/protocol/bc/map_test.go
@@ -23,43 +23,43 @@ func TestMapTx(t *testing.T) {
 
 	t.Log(spew.Sdump(entryMap))
 
-	if header.body.Version != 1 {
-		t.Errorf("header.body.Version is %d, expected 1", header.body.Version)
+	if header.Body.Version != 1 {
+		t.Errorf("header.Body.Version is %d, expected 1", header.Body.Version)
 	}
-	if header.body.MinTimeMS != oldTx.MinTime {
-		t.Errorf("header.body.MinTimeMS is %d, expected %d", header.body.MinTimeMS, oldTx.MinTime)
+	if header.Body.MinTimeMS != oldTx.MinTime {
+		t.Errorf("header.Body.MinTimeMS is %d, expected %d", header.Body.MinTimeMS, oldTx.MinTime)
 	}
-	if header.body.MaxTimeMS != oldTx.MaxTime {
-		t.Errorf("header.body.MaxTimeMS is %d, expected %d", header.body.MaxTimeMS, oldTx.MaxTime)
+	if header.Body.MaxTimeMS != oldTx.MaxTime {
+		t.Errorf("header.Body.MaxTimeMS is %d, expected %d", header.Body.MaxTimeMS, oldTx.MaxTime)
 	}
-	if len(header.body.Results) != len(oldOuts) {
-		t.Errorf("header.body.Results contains %d item(s), expected %d", len(header.body.Results), len(oldOuts))
+	if len(header.Body.Results) != len(oldOuts) {
+		t.Errorf("header.Body.Results contains %d item(s), expected %d", len(header.Body.Results), len(oldOuts))
 	}
 
 	for i, oldOut := range oldOuts {
-		if resultEntry, ok := entryMap[header.body.Results[i]]; ok {
+		if resultEntry, ok := entryMap[header.Body.Results[i]]; ok {
 			if newOut, ok := resultEntry.(*Output); ok {
-				if newOut.body.Source.Value != oldOut.AssetAmount {
-					t.Errorf("header.body.Results[%d].(*output).body.Source is %v, expected %v", i, newOut.body.Source.Value, oldOut.AssetAmount)
+				if newOut.Body.Source.Value != oldOut.AssetAmount {
+					t.Errorf("header.Body.Results[%d].(*output).Body.Source is %v, expected %v", i, newOut.Body.Source.Value, oldOut.AssetAmount)
 				}
-				if newOut.body.ControlProgram.VMVersion != 1 {
-					t.Errorf("header.body.Results[%d].(*output).body.ControlProgram.VMVersion is %d, expected 1", i, newOut.body.ControlProgram.VMVersion)
+				if newOut.Body.ControlProgram.VMVersion != 1 {
+					t.Errorf("header.Body.Results[%d].(*output).Body.ControlProgram.VMVersion is %d, expected 1", i, newOut.Body.ControlProgram.VMVersion)
 				}
-				if !bytes.Equal(newOut.body.ControlProgram.Code, oldOut.ControlProgram) {
-					t.Errorf("header.body.Results[%d].(*output).body.ControlProgram.Code is %x, expected %x", i, newOut.body.ControlProgram.Code, oldOut.ControlProgram)
+				if !bytes.Equal(newOut.Body.ControlProgram.Code, oldOut.ControlProgram) {
+					t.Errorf("header.Body.Results[%d].(*output).Body.ControlProgram.Code is %x, expected %x", i, newOut.Body.ControlProgram.Code, oldOut.ControlProgram)
 				}
-				if newOut.body.Data != hashData(oldOut.ReferenceData) {
+				if newOut.Body.Data != hashData(oldOut.ReferenceData) {
 					want := hashData(oldOut.ReferenceData)
-					t.Errorf("header.body.Results[%d].(*output).body.Data is %x, expected %x", i, newOut.body.Data[:], want[:])
+					t.Errorf("header.Body.Results[%d].(*output).Body.Data is %x, expected %x", i, newOut.Body.Data[:], want[:])
 				}
-				if (newOut.body.ExtHash != Hash{}) {
-					t.Errorf("header.body.Results[%d].(*output).body.ExtHash is %x, expected zero", i, newOut.body.ExtHash[:])
+				if (newOut.Body.ExtHash != Hash{}) {
+					t.Errorf("header.Body.Results[%d].(*output).Body.ExtHash is %x, expected zero", i, newOut.Body.ExtHash[:])
 				}
 			} else {
-				t.Errorf("header.body.Results[%d] has type %s, expected output1", i, resultEntry.Type())
+				t.Errorf("header.Body.Results[%d] has type %s, expected output1", i, resultEntry.Type())
 			}
 		} else {
-			t.Errorf("entryMap contains nothing for header.body.Results[%d] (%x)", i, header.body.Results[i][:])
+			t.Errorf("entryMap contains nothing for header.Body.Results[%d] (%x)", i, header.Body.Results[i][:])
 		}
 	}
 }

--- a/protocol/bc/mux.go
+++ b/protocol/bc/mux.go
@@ -4,19 +4,19 @@ package bc
 // making it available to one or more destination entries. It
 // satisfies the Entry interface.
 type Mux struct {
-	body struct {
+	Body struct {
 		Sources []valueSource
 		Program Program
 		ExtHash Hash
 	}
 
 	// Sources contains (pointers to) the manifested entries for each
-	// body.Sources[i].Ref.
+	// Body.Sources[i].Ref.
 	Sources []Entry // each entry is *issuance, *spend, or *mux
 }
 
 func (Mux) Type() string         { return "mux1" }
-func (m *Mux) Body() interface{} { return m.body }
+func (m *Mux) body() interface{} { return m.Body }
 
 func (Mux) Ordinal() int { return -1 }
 
@@ -24,7 +24,7 @@ func (Mux) Ordinal() int { return -1 }
 // with addSource or addSourceID.
 func NewMux(program Program) *Mux {
 	m := new(Mux)
-	m.body.Program = program
+	m.Body.Program = program
 	return m
 }
 
@@ -39,6 +39,6 @@ func (m *Mux) addSourceID(sourceID Hash, value AssetAmount, position uint64) {
 		Value:    value,
 		Position: position,
 	}
-	m.body.Sources = append(m.body.Sources, src)
+	m.Body.Sources = append(m.Body.Sources, src)
 	m.Sources = append(m.Sources, nil)
 }

--- a/protocol/bc/mux.go
+++ b/protocol/bc/mux.go
@@ -5,7 +5,7 @@ package bc
 // satisfies the Entry interface.
 type Mux struct {
 	Body struct {
-		Sources []valueSource
+		Sources []ValueSource
 		Program Program
 		ExtHash Hash
 	}
@@ -34,7 +34,7 @@ func (m *Mux) addSource(e Entry, value AssetAmount, position uint64) {
 }
 
 func (m *Mux) addSourceID(sourceID Hash, value AssetAmount, position uint64) {
-	src := valueSource{
+	src := ValueSource{
 		Ref:      sourceID,
 		Value:    value,
 		Position: position,

--- a/protocol/bc/nonce.go
+++ b/protocol/bc/nonce.go
@@ -4,27 +4,27 @@ package bc
 // otherwise-identical issuances (when used as those issuances'
 // "anchors"). It satisfies the Entry interface.
 type Nonce struct {
-	body struct {
+	Body struct {
 		Program   Program
 		TimeRange Hash
 		ExtHash   Hash
 	}
 
 	// TimeRange contains (a pointer to) the manifested entry
-	// corresponding to body.TimeRange.
+	// corresponding to Body.TimeRange.
 	TimeRange *TimeRange
 }
 
 func (Nonce) Type() string         { return "nonce1" }
-func (n *Nonce) Body() interface{} { return n.body }
+func (n *Nonce) body() interface{} { return n.Body }
 
 func (Nonce) Ordinal() int { return -1 }
 
 // NewNonce creates a new Nonce.
 func NewNonce(p Program, tr *TimeRange) *Nonce {
 	n := new(Nonce)
-	n.body.Program = p
-	n.body.TimeRange = EntryID(tr)
+	n.Body.Program = p
+	n.Body.TimeRange = EntryID(tr)
 	n.TimeRange = tr
 	return n
 }

--- a/protocol/bc/nonce.go
+++ b/protocol/bc/nonce.go
@@ -5,13 +5,13 @@ package bc
 // "anchors"). It satisfies the Entry interface.
 type Nonce struct {
 	Body struct {
-		Program   Program
-		TimeRange Hash
-		ExtHash   Hash
+		Program     Program
+		TimeRangeID Hash
+		ExtHash     Hash
 	}
 
 	// TimeRange contains (a pointer to) the manifested entry
-	// corresponding to Body.TimeRange.
+	// corresponding to Body.TimeRangeID.
 	TimeRange *TimeRange
 }
 
@@ -24,7 +24,7 @@ func (Nonce) Ordinal() int { return -1 }
 func NewNonce(p Program, tr *TimeRange) *Nonce {
 	n := new(Nonce)
 	n.Body.Program = p
-	n.Body.TimeRange = EntryID(tr)
+	n.Body.TimeRangeID = EntryID(tr)
 	n.TimeRange = tr
 	return n
 }

--- a/protocol/bc/output.go
+++ b/protocol/bc/output.go
@@ -6,7 +6,7 @@ package bc
 //
 // (Not to be confused with the deprecated type TxOutput.)
 type Output struct {
-	body struct {
+	Body struct {
 		Source         valueSource
 		ControlProgram Program
 		Data           Hash
@@ -15,12 +15,12 @@ type Output struct {
 	ordinal int
 
 	// Source contains (a pointer to) the manifested entry corresponding
-	// to body.Source.
+	// to Body.Source.
 	Source Entry // *issuance, *spend, or *mux
 }
 
 func (Output) Type() string         { return "output1" }
-func (o *Output) Body() interface{} { return o.body }
+func (o *Output) body() interface{} { return o.Body }
 
 func (o Output) Ordinal() int { return o.ordinal }
 
@@ -28,8 +28,8 @@ func (o Output) Ordinal() int { return o.ordinal }
 // set with setSource or setSourceID.
 func NewOutput(controlProgram Program, data Hash, ordinal int) *Output {
 	out := new(Output)
-	out.body.ControlProgram = controlProgram
-	out.body.Data = data
+	out.Body.ControlProgram = controlProgram
+	out.Body.Data = data
 	out.ordinal = ordinal
 	return out
 }
@@ -43,7 +43,7 @@ func (o *Output) setSource(e Entry, value AssetAmount, position uint64) {
 }
 
 func (o *Output) setSourceID(sourceID Hash, value AssetAmount, position uint64) {
-	o.body.Source = valueSource{
+	o.Body.Source = valueSource{
 		Ref:      sourceID,
 		Value:    value,
 		Position: position,

--- a/protocol/bc/output.go
+++ b/protocol/bc/output.go
@@ -7,7 +7,7 @@ package bc
 // (Not to be confused with the deprecated type TxOutput.)
 type Output struct {
 	Body struct {
-		Source         valueSource
+		Source         ValueSource
 		ControlProgram Program
 		Data           Hash
 		ExtHash        Hash
@@ -43,7 +43,7 @@ func (o *Output) setSource(e Entry, value AssetAmount, position uint64) {
 }
 
 func (o *Output) setSourceID(sourceID Hash, value AssetAmount, position uint64) {
-	o.Body.Source = valueSource{
+	o.Body.Source = ValueSource{
 		Ref:      sourceID,
 		Value:    value,
 		Position: position,

--- a/protocol/bc/retirement.go
+++ b/protocol/bc/retirement.go
@@ -4,7 +4,7 @@ package bc
 // blockchain. The value it contains can never be obtained by later
 // entries. Retirement satisfies the Entry interface.
 type Retirement struct {
-	body struct {
+	Body struct {
 		Source  valueSource
 		Data    Hash
 		ExtHash Hash
@@ -12,12 +12,12 @@ type Retirement struct {
 	ordinal int
 
 	// Source contains (a pointer to) the manifested entry corresponding
-	// to body.Source.
+	// to Body.Source.
 	Source Entry // *issuance, *spend, or *mux
 }
 
 func (Retirement) Type() string         { return "retirement1" }
-func (r *Retirement) Body() interface{} { return r.body }
+func (r *Retirement) body() interface{} { return r.Body }
 
 func (r Retirement) Ordinal() int { return r.ordinal }
 
@@ -25,7 +25,7 @@ func (r Retirement) Ordinal() int { return r.ordinal }
 // should be set with setSource or setSourceID.
 func NewRetirement(data Hash, ordinal int) *Retirement {
 	r := new(Retirement)
-	r.body.Data = data
+	r.Body.Data = data
 	r.ordinal = ordinal
 	return r
 }
@@ -36,7 +36,7 @@ func (r *Retirement) setSource(e Entry, value AssetAmount, position uint64) {
 }
 
 func (r *Retirement) setSourceID(sourceID Hash, value AssetAmount, position uint64) {
-	r.body.Source = valueSource{
+	r.Body.Source = valueSource{
 		Ref:      sourceID,
 		Value:    value,
 		Position: position,

--- a/protocol/bc/retirement.go
+++ b/protocol/bc/retirement.go
@@ -5,7 +5,7 @@ package bc
 // entries. Retirement satisfies the Entry interface.
 type Retirement struct {
 	Body struct {
-		Source  valueSource
+		Source  ValueSource
 		Data    Hash
 		ExtHash Hash
 	}
@@ -36,7 +36,7 @@ func (r *Retirement) setSource(e Entry, value AssetAmount, position uint64) {
 }
 
 func (r *Retirement) setSourceID(sourceID Hash, value AssetAmount, position uint64) {
-	r.Body.Source = valueSource{
+	r.Body.Source = ValueSource{
 		Ref:      sourceID,
 		Value:    value,
 		Position: position,

--- a/protocol/bc/timerange.go
+++ b/protocol/bc/timerange.go
@@ -2,21 +2,21 @@ package bc
 
 // TimeRange denotes a time range. It satisfies the Entry interface.
 type TimeRange struct {
-	body struct {
+	Body struct {
 		MinTimeMS, MaxTimeMS uint64
 		ExtHash              Hash
 	}
 }
 
 func (TimeRange) Type() string          { return "timerange1" }
-func (tr *TimeRange) Body() interface{} { return tr.body }
+func (tr *TimeRange) body() interface{} { return tr.Body }
 
 func (TimeRange) Ordinal() int { return -1 }
 
 // NewTimeRange creates a new TimeRange.
 func NewTimeRange(minTimeMS, maxTimeMS uint64) *TimeRange {
 	tr := new(TimeRange)
-	tr.body.MinTimeMS = minTimeMS
-	tr.body.MaxTimeMS = maxTimeMS
+	tr.Body.MinTimeMS = minTimeMS
+	tr.Body.MaxTimeMS = maxTimeMS
 	return tr
 }

--- a/protocol/bc/txheader.go
+++ b/protocol/bc/txheader.go
@@ -7,14 +7,14 @@ package bc
 type TxHeader struct {
 	Body struct {
 		Version              uint64
-		Results              []Hash
+		ResultIDs            []Hash
 		Data                 Hash
 		MinTimeMS, MaxTimeMS uint64
 		ExtHash              Hash
 	}
 
 	// Results contains (pointers to) the manifested entries for the
-	// items in Body.Results.
+	// items in Body.ResultIDs.
 	Results []Entry // each entry is *output or *retirement
 }
 
@@ -33,7 +33,7 @@ func NewTxHeader(version uint64, results []Entry, data Hash, minTimeMS, maxTimeM
 
 	h.Results = results
 	for _, r := range results {
-		h.Body.Results = append(h.Body.Results, EntryID(r))
+		h.Body.ResultIDs = append(h.Body.ResultIDs, EntryID(r))
 	}
 
 	return h

--- a/protocol/bc/txheader.go
+++ b/protocol/bc/txheader.go
@@ -5,7 +5,7 @@ package bc
 // of the TxHeader is the ID of the transaction. TxHeader satisfies
 // the Entry interface.
 type TxHeader struct {
-	body struct {
+	Body struct {
 		Version              uint64
 		Results              []Hash
 		Data                 Hash
@@ -14,26 +14,26 @@ type TxHeader struct {
 	}
 
 	// Results contains (pointers to) the manifested entries for the
-	// items in body.Results.
+	// items in Body.Results.
 	Results []Entry // each entry is *output or *retirement
 }
 
 func (TxHeader) Type() string         { return "txheader" }
-func (h *TxHeader) Body() interface{} { return h.body }
+func (h *TxHeader) body() interface{} { return h.Body }
 
 func (TxHeader) Ordinal() int { return -1 }
 
 // NewTxHeader creates an new TxHeader.
 func NewTxHeader(version uint64, results []Entry, data Hash, minTimeMS, maxTimeMS uint64) *TxHeader {
 	h := new(TxHeader)
-	h.body.Version = version
-	h.body.Data = data
-	h.body.MinTimeMS = minTimeMS
-	h.body.MaxTimeMS = maxTimeMS
+	h.Body.Version = version
+	h.Body.Data = data
+	h.Body.MinTimeMS = minTimeMS
+	h.Body.MaxTimeMS = maxTimeMS
 
 	h.Results = results
 	for _, r := range results {
-		h.body.Results = append(h.body.Results, EntryID(r))
+		h.Body.Results = append(h.Body.Results, EntryID(r))
 	}
 
 	return h

--- a/protocol/bc/txissuance.go
+++ b/protocol/bc/txissuance.go
@@ -6,15 +6,15 @@ package bc
 // (Not to be confused with the deprecated type IssuanceInput.)
 type Issuance struct {
 	Body struct {
-		Anchor  Hash
-		Value   AssetAmount
-		Data    Hash
-		ExtHash Hash
+		AnchorID Hash
+		Value    AssetAmount
+		Data     Hash
+		ExtHash  Hash
 	}
 	ordinal int
 
 	// Anchor is a pointer to the manifested entry corresponding to
-	// Body.Anchor.
+	// Body.AnchorID.
 	Anchor Entry // *nonce or *spend
 }
 
@@ -26,7 +26,7 @@ func (iss Issuance) Ordinal() int { return iss.ordinal }
 // NewIssuance creates a new Issuance.
 func NewIssuance(anchor Entry, value AssetAmount, data Hash, ordinal int) *Issuance {
 	iss := new(Issuance)
-	iss.Body.Anchor = EntryID(anchor)
+	iss.Body.AnchorID = EntryID(anchor)
 	iss.Anchor = anchor
 	iss.Body.Value = value
 	iss.Body.Data = data

--- a/protocol/bc/txissuance.go
+++ b/protocol/bc/txissuance.go
@@ -5,7 +5,7 @@ package bc
 //
 // (Not to be confused with the deprecated type IssuanceInput.)
 type Issuance struct {
-	body struct {
+	Body struct {
 		Anchor  Hash
 		Value   AssetAmount
 		Data    Hash
@@ -14,22 +14,22 @@ type Issuance struct {
 	ordinal int
 
 	// Anchor is a pointer to the manifested entry corresponding to
-	// body.Anchor.
+	// Body.Anchor.
 	Anchor Entry // *nonce or *spend
 }
 
 func (Issuance) Type() string           { return "issuance1" }
-func (iss *Issuance) Body() interface{} { return iss.body }
+func (iss *Issuance) body() interface{} { return iss.Body }
 
 func (iss Issuance) Ordinal() int { return iss.ordinal }
 
 // NewIssuance creates a new Issuance.
 func NewIssuance(anchor Entry, value AssetAmount, data Hash, ordinal int) *Issuance {
 	iss := new(Issuance)
-	iss.body.Anchor = EntryID(anchor)
+	iss.Body.Anchor = EntryID(anchor)
 	iss.Anchor = anchor
-	iss.body.Value = value
-	iss.body.Data = data
+	iss.Body.Value = value
+	iss.Body.Data = data
 	iss.ordinal = ordinal
 	return iss
 }

--- a/protocol/bc/txspend.go
+++ b/protocol/bc/txspend.go
@@ -5,7 +5,7 @@ package bc
 //
 // (Not to be confused with the deprecated type SpendInput.)
 type Spend struct {
-	body struct {
+	Body struct {
 		SpentOutput Hash // the hash of an output entry
 		Data        Hash
 		ExtHash     Hash
@@ -13,20 +13,20 @@ type Spend struct {
 	ordinal int
 
 	// SpentOutput contains (a pointer to) the manifested entry
-	// corresponding to body.SpentOutput.
+	// corresponding to Body.SpentOutput.
 	SpentOutput *Output
 }
 
 func (Spend) Type() string         { return "spend1" }
-func (s *Spend) Body() interface{} { return s.body }
+func (s *Spend) body() interface{} { return s.Body }
 
 func (s Spend) Ordinal() int { return s.ordinal }
 
 // NewSpend creates a new Spend.
 func NewSpend(out *Output, data Hash, ordinal int) *Spend {
 	s := new(Spend)
-	s.body.SpentOutput = EntryID(out)
-	s.body.Data = data
+	s.Body.SpentOutput = EntryID(out)
+	s.Body.Data = data
 	s.ordinal = ordinal
 	s.SpentOutput = out
 	return s

--- a/protocol/bc/txspend.go
+++ b/protocol/bc/txspend.go
@@ -6,14 +6,14 @@ package bc
 // (Not to be confused with the deprecated type SpendInput.)
 type Spend struct {
 	Body struct {
-		SpentOutput Hash // the hash of an output entry
-		Data        Hash
-		ExtHash     Hash
+		SpentOutputID Hash // the hash of an output entry
+		Data          Hash
+		ExtHash       Hash
 	}
 	ordinal int
 
 	// SpentOutput contains (a pointer to) the manifested entry
-	// corresponding to Body.SpentOutput.
+	// corresponding to Body.SpentOutputID.
 	SpentOutput *Output
 }
 
@@ -25,7 +25,7 @@ func (s Spend) Ordinal() int { return s.ordinal }
 // NewSpend creates a new Spend.
 func NewSpend(out *Output, data Hash, ordinal int) *Spend {
 	s := new(Spend)
-	s.Body.SpentOutput = EntryID(out)
+	s.Body.SpentOutputID = EntryID(out)
 	s.Body.Data = data
 	s.ordinal = ordinal
 	s.SpentOutput = out

--- a/protocol/bc/txtransaction.go
+++ b/protocol/bc/txtransaction.go
@@ -39,8 +39,8 @@ func ComputeTxHashes(oldTx *TxData) (hashes *TxHashes, err error) {
 	hashes.ID = txid
 
 	// Results
-	hashes.Results = make([]ResultInfo, len(header.Body.Results))
-	for i, resultHash := range header.Body.Results {
+	hashes.Results = make([]ResultInfo, len(header.Body.ResultIDs))
+	for i, resultHash := range header.Body.ResultIDs {
 		hashes.Results[i].ID = resultHash
 		entry := entries[resultHash]
 		if out, ok := entry.(*Output); ok {
@@ -57,7 +57,7 @@ func ComputeTxHashes(oldTx *TxData) (hashes *TxHashes, err error) {
 		switch ent := ent.(type) {
 		case *Nonce:
 			// TODO: check time range is within network-defined limits
-			trID := ent.Body.TimeRange
+			trID := ent.Body.TimeRangeID
 			trEntry, ok := entries[trID]
 			if !ok {
 				return nil, fmt.Errorf("nonce entry refers to nonexistent timerange entry")
@@ -77,7 +77,7 @@ func ComputeTxHashes(oldTx *TxData) (hashes *TxHashes, err error) {
 
 		case *Spend:
 			hashes.SigHashes[ent.Ordinal()] = makeSigHash(entryID, hashes.ID)
-			hashes.SpentOutputIDs[ent.Ordinal()] = ent.Body.SpentOutput
+			hashes.SpentOutputIDs[ent.Ordinal()] = ent.Body.SpentOutputID
 		}
 	}
 

--- a/protocol/bc/txtransaction.go
+++ b/protocol/bc/txtransaction.go
@@ -39,14 +39,14 @@ func ComputeTxHashes(oldTx *TxData) (hashes *TxHashes, err error) {
 	hashes.ID = txid
 
 	// Results
-	hashes.Results = make([]ResultInfo, len(header.body.Results))
-	for i, resultHash := range header.body.Results {
+	hashes.Results = make([]ResultInfo, len(header.Body.Results))
+	for i, resultHash := range header.Body.Results {
 		hashes.Results[i].ID = resultHash
 		entry := entries[resultHash]
 		if out, ok := entry.(*Output); ok {
-			hashes.Results[i].SourceID = out.body.Source.Ref
-			hashes.Results[i].SourcePos = out.body.Source.Position
-			hashes.Results[i].RefDataHash = out.body.Data
+			hashes.Results[i].SourceID = out.Body.Source.Ref
+			hashes.Results[i].SourcePos = out.Body.Source.Position
+			hashes.Results[i].RefDataHash = out.Body.Data
 		}
 	}
 
@@ -57,7 +57,7 @@ func ComputeTxHashes(oldTx *TxData) (hashes *TxHashes, err error) {
 		switch ent := ent.(type) {
 		case *Nonce:
 			// TODO: check time range is within network-defined limits
-			trID := ent.body.TimeRange
+			trID := ent.Body.TimeRange
 			trEntry, ok := entries[trID]
 			if !ok {
 				return nil, fmt.Errorf("nonce entry refers to nonexistent timerange entry")
@@ -69,7 +69,7 @@ func ComputeTxHashes(oldTx *TxData) (hashes *TxHashes, err error) {
 			iss := struct {
 				ID           Hash
 				ExpirationMS uint64
-			}{entryID, tr.body.MaxTimeMS}
+			}{entryID, tr.Body.MaxTimeMS}
 			hashes.Issuances = append(hashes.Issuances, iss)
 
 		case *Issuance:
@@ -77,7 +77,7 @@ func ComputeTxHashes(oldTx *TxData) (hashes *TxHashes, err error) {
 
 		case *Spend:
 			hashes.SigHashes[ent.Ordinal()] = makeSigHash(entryID, hashes.ID)
-			hashes.SpentOutputIDs[ent.Ordinal()] = ent.body.SpentOutput
+			hashes.SpentOutputIDs[ent.Ordinal()] = ent.Body.SpentOutput
 		}
 	}
 

--- a/protocol/bc/value.go
+++ b/protocol/bc/value.go
@@ -1,6 +1,6 @@
 package bc
 
-type valueSource struct {
+type ValueSource struct {
 	Ref      Hash
 	Value    AssetAmount
 	Position uint64 // what int do we actually want?

--- a/protocol/vm/crypto.go
+++ b/protocol/vm/crypto.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"chain/crypto/ed25519"
-	"chain/errors"
 	"chain/math/checked"
 )
 

--- a/protocol/vm/crypto.go
+++ b/protocol/vm/crypto.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"chain/crypto/ed25519"
+	"chain/errors"
 	"chain/math/checked"
 )
 


### PR DESCRIPTION
The `Body` field of each entry type is now exported, and the `body` method of the `Entry` interface is not. Also, some entry fields that hold the IDs of other entries have been renamed fooID. These changes will allow better access to entry data during "entries"-based validation, coming soon.

A carved-off piece of https://github.com/chain/chain/pull/788