### PR TITLE
dashboard: replace Map with object in flash message state

### DIFF
--- a/dashboard/src/features/app/reducers.js
+++ b/dashboard/src/features/app/reducers.js
@@ -4,82 +4,84 @@ import { combineReducers } from 'redux'
 import uuid from 'uuid'
 
 const flash = (message, title, type) => ({ message, title, type, displayed: false })
-const success = (message, title) => flash(message, title, 'success')
-const error = (message, title) => flash(message, title, 'danger')
+const newFlash = (state, f) => ({...state, [uuid.v4()]: f})
+const newSuccess = (state, message, title) => ({...state, [uuid.v4()]: flash(message, title, 'success')})
+const newError = (state, message, title) => ({...state, [uuid.v4()]: flash(message, title, 'danger')})
 
-export const flashMessages = (state = new Map(), action) => {
+export const flashMessages = (state = {}, action) => {
   switch (action.type) {
     case '@@router/LOCATION_CHANGE': {
       if (action.payload.state && action.payload.state.preserveFlash) {
         return state
       } else {
-        state.forEach((item, key) => {
+        Object.keys(state).forEach(key => {
+          const item = state[key]
           if (item.displayed) {
-            state.delete(key)
+            delete state[key]
           }
         })
-        return new Map(state)
+        return {...state}
       }
     }
 
     case 'CREATED_ACCOUNT': {
-      return new Map(state).set(uuid.v4(), success(<p>
-        Created account. <Link to='accounts/create'>Create another?</Link>
-      </p>))
+      return newSuccess(state, <p>
+          Created account. <Link to='accounts/create'>Create another?</Link>
+        </p>)
     }
 
     case 'CREATED_ASSET': {
-      return new Map(state).set(uuid.v4(), success(<p>
+      return newSuccess(state, <p>
         Created asset. <Link to='assets/create'>Create another?</Link>
-      </p>))
+      </p>)
     }
 
     case 'CREATED_TRANSACTION': {
-      return new Map(state).set(uuid.v4(), success(<p>
+      return newSuccess(state, <p>
         Submitted transaction. <Link to='transactions/create'>Create another?</Link>
-      </p>))
+      </p>)
     }
 
     case 'CREATED_MOCKHSM': {
-      return new Map(state).set(uuid.v4(), success(<p>
+      return newSuccess(state, <p>
         Created key. <Link to='mockhsms/create'>Create another?</Link>
-      </p>))
+      </p>)
     }
 
     case 'CREATED_TRANSACTIONFEED': {
-      return new Map(state).set(uuid.v4(), success(<p>
+      return newSuccess(state, <p>
         Created transaction feed. <Link to='transaction-feeds/create'>Create another?</Link>
-      </p>))
+      </p>)
     }
 
     case 'DELETE_CLIENT_ACCESS_TOKEN':
     case 'DELETE_NETWORK_ACCESS_TOKEN':
     case 'DELETE_TRANSACTIONFEED': {
-      return new Map(state).set(uuid.v4(), flash(action.message, null, 'info'))
+      return newFlash(state, flash(action.message, null, 'info'))
     }
 
     case 'DISMISS_FLASH': {
-      state.delete(action.param)
-      return new Map(state)
+      delete state[action.param]
+      return {...state}
     }
 
     case 'DISPLAYED_FLASH': {
-      const existing = state.get(action.param)
+      const existing = state[action.param]
       if (existing && !existing.displayed) {
-        const newState = new Map(state)
+        const newState = {...state}
         existing.displayed = true
-        newState.set(action.param, existing)
+        newState[action.param] = existing
         return newState
       }
       return state
     }
 
     case 'ERROR': {
-      return new Map(state).set(uuid.v4(), error(action.payload.message))
+      return newError(state, action.payload.message)
     }
 
     case 'USER_LOG_IN': {
-      return new Map()
+      return {}
     }
 
     default: {

--- a/dashboard/src/features/shared/components/Flash/Flash.jsx
+++ b/dashboard/src/features/shared/components/Flash/Flash.jsx
@@ -3,7 +3,8 @@ import styles from './Flash.scss'
 
 class Flash extends React.Component {
   componentWillReceiveProps(nextProps) {
-    nextProps.messages.forEach((item, key) => {
+    Object.keys(nextProps.messages).forEach(key => {
+      const item = nextProps.messages[key]
       if (!item.displayed) {
         this.props.markFlashDisplayed(key)
       }
@@ -16,7 +17,12 @@ class Flash extends React.Component {
     }
 
     const messages = []
-    this.props.messages.forEach((item, key) => {
+    // Flash messages are stored in an objecty key with a random UUID. If
+    // multiple messages are displayed, we rely on the browser maintaining
+    // object inerstion order of keys to display messages in the order they
+    // were created.
+    Object.keys(this.props.messages).forEach(key => {
+      const item = this.props.messages[key]
       messages.push(
         <div className={`${styles.alert} ${styles[item.type]} ${styles.main}`} key={key}>
           <div className={styles.content}>

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2848";
+	public final String Id = "main/rev2849";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2848"
+const ID string = "main/rev2849"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2848"
+export const rev_id = "main/rev2849"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2848".freeze
+	ID = "main/rev2849".freeze
 end


### PR DESCRIPTION
Safari 8 and earlier does not natively support the `Map` object. Rather
than adding a polyfill, this replaces the single use of a `Map` as a
data structure with a plain JavaScript object.

Port of #798 from `1.1-stable`