### PR TITLE
sdk/node: fix alias typo

### DIFF
--- a/sdk/node/src/api/transactionFeeds.js
+++ b/sdk/node/src/api/transactionFeeds.js
@@ -50,7 +50,7 @@ class TransactionFeed {
    */
   constructor(feed, client) {
     this.id = feed['id']
-    this.alias = feed['aias']
+    this.alias = feed['alias']
     this.after = feed['after']
     this.filter = feed['filter']
 


### PR DESCRIPTION
Fixes a typo in the node SDK transactionFeeds.