### PR TITLE
sdk/node: fix alias typo

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "1.1-stable/rev2751";
+	public final String Id = "1.1-stable/rev2752";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.1-stable/rev2751"
+const ID string = "1.1-stable/rev2752"

--- a/sdk/node/src/api/transactionFeeds.js
+++ b/sdk/node/src/api/transactionFeeds.js
@@ -50,7 +50,7 @@ class TransactionFeed {
    */
   constructor(feed, client) {
     this.id = feed['id']
-    this.alias = feed['aias']
+    this.alias = feed['alias']
     this.after = feed['after']
     this.filter = feed['filter']
 


### PR DESCRIPTION
Fixes a typo in the node SDK transactionFeeds.

This is a backport of #815 (608a760) to the 1.1-stable branch.