### PR TITLE
bin/builder-docker-de: update 1.0-stable to most recent 1.0.x Docker build

### DIFF
--- a/bin/build-docker-de
+++ b/bin/build-docker-de
@@ -7,8 +7,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-imageVersion=${IMAGE_VERSION:-1.0.0}
-coredVersion=${CORED_VERSION:-cmd.cored-1.0.1}
+imageVersion=${IMAGE_VERSION:-1.0.1}
+coredVersion=${CORED_VERSION:-cmd.cored-1.0.2}
 
 GOOS=linux GOARCH=amd64 bin/build-cored-release "$coredVersion" $CHAIN/docker/de/
 docker build --tag chaincore/developer $CHAIN/docker/de/

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.0-stable/rev2497"
+const ID string = "1.0-stable/rev2498"


### PR DESCRIPTION
This commit ports the Docker build tool from tag docker.de-1.0.1 to the
1.0-stable branch. This is part of a series of commits that will
ensure that the 1.0-stable branch contains the latest 1.0.x
changes for all packages.