### PR TITLE
installer/mac: update 1.0-stable with most recent 1.0.x Mac installer

### DIFF
--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.0-stable/rev2496"
+const ID string = "1.0-stable/rev2497"

--- a/installer/mac/ChainCore/Base.lproj/Main.storyboard
+++ b/installer/mac/ChainCore/Base.lproj/Main.storyboard
@@ -23,7 +23,7 @@
                 </windowController>
                 <customObject id="irj-fp-CtB" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="731" y="-294"/>
+            <point key="canvasLocation" x="701" y="-302"/>
         </scene>
         <!--Window Controller-->
         <scene sceneID="dfz-VO-LQk">
@@ -182,16 +182,16 @@
         <!--View Controller-->
         <scene sceneID="qij-K2-cCG">
             <objects>
-                <customObject id="PPT-qH-eGw" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <userDefaultsController id="KVx-oV-dzR"/>
+                <customObject id="PPT-qH-eGw" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <viewController id="F90-nP-753" sceneMemberID="viewController">
                     <view key="view" id="yPx-aT-K8a">
-                        <rect key="frame" x="0.0" y="0.0" width="300" height="61"/>
+                        <rect key="frame" x="0.0" y="0.0" width="300" height="46"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </view>
                 </viewController>
             </objects>
-            <point key="canvasLocation" x="1236" y="-302"/>
+            <point key="canvasLocation" x="1275" y="-308"/>
         </scene>
         <!--Application-->
         <scene sceneID="JPo-4y-FX3">
@@ -216,11 +216,6 @@
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
-                                        <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW">
-                                            <connections>
-                                                <segue destination="0CQ-HC-63t" kind="show" id="PFZ-iz-T8N"/>
-                                            </connections>
-                                        </menuItem>
                                         <menuItem title="Check for Updates…" id="jgT-3h-PCr">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>

--- a/installer/mac/ChainCore/ChainCore.swift
+++ b/installer/mac/ChainCore/ChainCore.swift
@@ -129,7 +129,10 @@ class ChainCore: NSObject {
         task.environment = [
             "DATABASE_URL": databaseURL,
             "LISTEN":       ":\(port)",
-            "LOGFILE":      self.logURL.path
+            "LOGFILE":      self.logURL.path,
+
+            // FIXME: cored binaries built with bin/build-cored-release have trouble acquiring a default user for Postgres connections. This ensures the current user's login name is always available in the environment.
+            "USER":         NSUserName(),
         ]
         //task.standardOutput = Pipe()
         //task.standardError = Pipe()

--- a/installer/mac/tools/build_chain.sh
+++ b/installer/mac/tools/build_chain.sh
@@ -7,13 +7,9 @@ export CHAIN="${SOURCE_DIR}/../.."
 export GOPATH="${CHAIN}/../.."
 export PATH="${PATH}:/usr/local/go/bin"
 
-cd "${CHAIN}"
-go install -tags insecure_disable_https_redirect ./cmd/cored
-go install -tags insecure_disable_https_redirect ./cmd/corectl
+tempBuildPath=`mktemp -d`
+trap "rm -rf $tempBuildPath" EXIT
+"${CHAIN}/bin/build-cored-release" cmd.cored-1.0.2 $tempBuildPath
 
-cp -f "${GOPATH}/bin/cored" "${TARGET_DIR}/"
-cp -f "${GOPATH}/bin/corectl" "${TARGET_DIR}/"
-
-# `go build` is slower on repeated runs than `go install`
-# go build -o "${TARGET_DIR}/cored"   -tags insecure_disable_https_redirect "./cmd/cored"
-# go build -o "${TARGET_DIR}/corectl" -tags insecure_disable_https_redirect "./cmd/corectl"
+cp -f $tempBuildPath/cored "${TARGET_DIR}/"
+cp -f $tempBuildPath/corectl "${TARGET_DIR}/"

--- a/installer/mac/updates/updates.xml
+++ b/installer/mac/updates/updates.xml
@@ -15,11 +15,11 @@
             </ul>
           ]]>
         </description>
-        <pubDate>Fri, 02 Dec 2016 11:52:18 -0800</pubDate>
+        <pubDate>Mon, 05 Dec 2016 17:01:41 -0800</pubDate>
         <enclosure
         	url="https://download.chain.com/mac/Chain_Core_1.0.2.zip"
         	sparkle:version="1.0.2"
-        	length="53599377"
+        	length="53609347"
         	type="application/octet-stream"
         	sparkle:dsaSignature=""
         	/>


### PR DESCRIPTION
This commit ports the Mac app from tag installer.mac-1.0.2 to the
1.0-stable branch. This is part of a series of commits that will
ensure that the 1.0-stable branch contains the latest 1.0.x
changes for all packages.