### PR TITLE
installer/windows: update 1.0-stable to most recent 1.0.x windows installer

### DIFF
--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.0-stable/rev2495"
+const ID string = "1.0-stable/rev2496"

--- a/installer/windows/CHANGELOG.md
+++ b/installer/windows/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Chain Core Windows Installer changelog
 
+## 1.0.2 (February 22, 2017)
+
+* Resolve issue running Chain Core on non-English systems
+
 ## 1.0.1 (December 2, 2016)
 
 * Updated to Chain Core [1.0.2](../../cmd/cored/CHANGELOG.md#1.0.2)

--- a/installer/windows/ChainMgr/ChainMgr.go
+++ b/installer/windows/ChainMgr/ChainMgr.go
@@ -188,16 +188,14 @@ func rewriteConfig() error {
 func blockUntilReady(pglog *log.Logger) {
 	// TODO(tessr): add a timeout or something so we can't block indefinitely
 	for {
-		out, err := exec.Command(pg+"pg_isready.exe", "-p", pgPort, "-d", "postgres").Output()
-		if err != nil {
-			pglog.Printf("out: %s; err: %s", out, err)
-		}
+		err := exec.Command(pg+"pg_isready.exe", "-p", pgPort, "-d", "postgres").Run()
 
-		if strings.Contains(string(out), "accepting") {
+		if err != nil {
+			pglog.Printf("still waiting for postgres ready status: %s", err)
+		} else {
 			return
 		}
 
-		pglog.Printf("still waiting for postgres ready status: %s", out)
 		time.Sleep(500 * time.Millisecond)
 	}
 }

--- a/installer/windows/ChainPackage/ChainCoreInstaller.wxs
+++ b/installer/windows/ChainPackage/ChainCoreInstaller.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
      xmlns:http="http://schemas.microsoft.com/wix/HttpExtension"
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="*" Name="Chain Core Package" Language="1033" Version="1.0.1" Manufacturer="Chain Inc." UpgradeCode="eaa938af-2d6c-4912-b33d-1a09a6b1e81c">
+  <Product Id="*" Name="Chain Core Package" Language="1033" Version="1.0.2" Manufacturer="Chain Inc." UpgradeCode="eaa938af-2d6c-4912-b33d-1a09a6b1e81c">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />


### PR DESCRIPTION
This commit ports the Windows installer from tag installer.windows-1.0.2 to the
1.0-stable branch. This is part of a series of commits that will
ensure that the 1.0-stable branch contains the latest 1.0.x
changes for all packages.