### PR TITLE
sdk/ruby: update 1.0-stable to most recent 1.0.x Ruby SDK

### DIFF
--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.0-stable/rev2494"
+const ID string = "1.0-stable/rev2495"

--- a/sdk/ruby/CHANGELOG.md
+++ b/sdk/ruby/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Chain Ruby SDK
 
+## 1.0.3 (March 2, 2017)
+
+* Relax minimum Ruby version requirement from 2.1 to 2.0. While the Ruby SDK is now compatible with Ruby 2.0, we strongly recommend using Ruby 2.1 or greater, since Ruby 2.0 has reached end-of-life and is no longer receiving critical security updates.
+
+## 1.0.2 (February 21, 2017)
+
+* Syntax compatibility update
+
+## 1.0.1 (January 24, 2017)
+
+* Set minimum Ruby version requirement to 2.1
+* Enhanced transaction feed API support
+* Fixed issue reading attributers with array getter syntax (@donce in [#422](https://github.com/chain/chain/pull/422))
+
 ## 1.0.0 (November 17, 2016)
 
 * Initial release

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -4,12 +4,14 @@
 
 ### Get the gem
 
-The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core. Ruby 2 is required.
+The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). Make sure to use the most recent version whose major and minor components (`major.minor.x`) match your version of Chain Core.
+
+Ruby 2.0 or greater is required. We strongly recommend upgrading to Ruby 2.1 or greater, as [Ruby 2.0 has reached end-of-life](https://www.ruby-lang.org/en/downloads/branches/) and will no longer receive security updates and bugfixes.
 
 For most applications, you can simply add the following to your `Gemfile`:
 
 ```
-gem 'chain-sdk', '~> 1.0.0', require: 'chain'
+gem 'chain-sdk', '~> 1.0.3', require: 'chain'
 ```
 
 ### In your code

--- a/sdk/ruby/chain-sdk.gemspec
+++ b/sdk/ruby/chain-sdk.gemspec
@@ -4,10 +4,11 @@ Gem::Specification.new do |s|
   s.name = 'chain-sdk'
   s.version = Chain::VERSION
   s.authors = ['Chain Engineering']
-  s.description = 'The Official Ruby SDK for the Chain Core Developer Edition'
-  s.summary = 'The Official Ruby SDK for the Chain Core Developer Edition'
+  s.description = 'The Official Ruby SDK for Chain Core'
+  s.summary = 'The Official Ruby SDK for Chain Core'
   s.licenses = ['Apache-2.0']
   s.homepage = 'https://github.com/chain/chain/tree/main/sdk/ruby'
+  s.required_ruby_version = '~> 2.0'
 
   s.files = ['README.md', 'LICENSE']
   s.files += Dir['lib/**/*.rb']

--- a/sdk/ruby/lib/chain/access_token.rb
+++ b/sdk/ruby/lib/chain/access_token.rb
@@ -27,12 +27,15 @@ module Chain
 
     class ClientModule < Chain::ClientModule
 
+      # Create client/network access token.
+      # @param [Hash] opts
+      # @option params [String] :type Type specifiying the type of access token to be created.
+      #                                   You must specify either 'client' or 'network'.
+      # @option params [String] :id ID specifying the ID of newly created access token.
+      #                                   You must specify a unique ID for access token.
       # @return [AccessToken]
-      def create(type:, id:)
-        AccessToken.new(client.conn.request(
-          'create-access-token',
-          {type: type, id: id}
-        ))
+      def create(opts = {})
+        AccessToken.new(client.conn.request('create-access-token', opts))
       end
 
       # @param [Hash] opts

--- a/sdk/ruby/lib/chain/response_object.rb
+++ b/sdk/ruby/lib/chain/response_object.rb
@@ -25,7 +25,7 @@ module Chain
       attrib_name = attrib_name.to_sym
       raise KeyError.new("key not found: #{attrib_name}") unless self.class.attrib_opts.key?(attrib_name)
 
-      instance_variable_get "@{attrib_name}"
+      instance_variable_get "@#{attrib_name}"
     end
 
     def []=(attrib_name, value)

--- a/sdk/ruby/lib/chain/version.rb
+++ b/sdk/ruby/lib/chain/version.rb
@@ -1,3 +1,3 @@
 module Chain
-  VERSION = '1.0.0'
+  VERSION = '1.0.3'
 end

--- a/sdk/ruby/spec/integration/integration_spec.rb
+++ b/sdk/ruby/spec/integration/integration_spec.rb
@@ -84,7 +84,7 @@ context 'Chain SDK integration test' do
       chain.assets.create(alias: :unobtanium)
     }.to raise_error(Chain::APIError)
 
-    # Batch account creation
+    # Batch asset creation
 
     asset_batch = chain.assets.create_batch([
       {alias: :bronze, root_xpubs: [chain.mock_hsm.keys.create.xpub], quorum: 1}, # success


### PR DESCRIPTION
This commit ports the Ruby SDK from tag sdk-ruby-1.0.3 to the
1.0-stable branch. This is part of a series of commits that will
ensure that the 1.0-stable branch contains the latest 1.0.x
changes for all packages.