### PR TITLE
cmd/slashland: extend success timeout to 4 minutes

### DIFF
--- a/cmd/slashland/main.go
+++ b/cmd/slashland/main.go
@@ -327,7 +327,7 @@ func wrapMessage(msg string, limit int) string {
 func waitForSuccessfulStatus(req *landReq, repo, commitSHA string) bool {
 	start := time.Now()
 	for {
-		if time.Since(start) > 3*time.Minute {
+		if time.Since(start) > 4*time.Minute {
 			sayf("<@%s|%s> failed to land %s: timed out waiting for build status",
 				req.userID,
 				req.userName,

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2857";
+	public final String Id = "main/rev2858";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2857"
+const ID string = "main/rev2858"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2857"
+export const rev_id = "main/rev2858"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2857".freeze
+	ID = "main/rev2858".freeze
 end


### PR DESCRIPTION
Anecdotal evidence suggests that the current timeout of 3 minutes
is too slow, especially given that the new revid functionality
forces a fresh CI check for any PR.