### PR TITLE
installer/mac: tick version to 1.1.2

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "1.1-stable/rev2753";
+	public final String Id = "1.1-stable/rev2754";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.1-stable/rev2753"
+const ID string = "1.1-stable/rev2754"

--- a/installer/mac/CHANGELOG.md
+++ b/installer/mac/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Chain Core Mac Installer changelog
 
+## 1.1.2 (March 28, 2017)
+
+* Updated to Chain Core [1.1.4](https://github.com/chain/chain/blob/1.1-stable/CHANGELOG.md#1.1.4),
+which brings improved support for Macs running Yosemite.
+
 ## 1.1.1 (March 8, 2017)
 
 * Updated to Chain Core [1.1.3](https://github.com/chain/chain/blob/1.1-stable/CHANGELOG.md#1.1.3)

--- a/installer/mac/Chain Core.xcodeproj/project.pbxproj
+++ b/installer/mac/Chain Core.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 		83FB57281D1B05F000A903A3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_VERSION = 1.1.1;
+				APP_VERSION = 1.1.2;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -463,7 +463,7 @@
 		83FB57291D1B05F000A903A3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_VERSION = 1.1.1;
+				APP_VERSION = 1.1.2;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/installer/mac/tools/build_chain.sh
+++ b/installer/mac/tools/build_chain.sh
@@ -9,7 +9,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 tempBuildPath=`mktemp -d`
 trap "rm -rf $tempBuildPath" EXIT
-"${CHAIN}/bin/build-cored-release" chain-core-server-1.1.3 $tempBuildPath
+"${CHAIN}/bin/build-cored-release" chain-core-server-1.1.4 $tempBuildPath
 
 cp -f $tempBuildPath/cored "${TARGET_DIR}/"
 cp -f $tempBuildPath/corectl "${TARGET_DIR}/"

--- a/installer/mac/updates/updates.xml
+++ b/installer/mac/updates/updates.xml
@@ -6,15 +6,15 @@
     <description>Most recent changes with links to updates.</description>
     <language>en</language>
       <item>
-        <title>Chain Core Developer Edition 1.1.1</title>
+        <title>Chain Core Developer Edition 1.1.2</title>
         <description>
           <![CDATA[
             <p><b>NOTE:</b> This update will create a fresh blockchain if you were previously
               using versions 1.0.x or 1.1.0; please backup any blockchain data you wish to preserve.
             </p>
             <ul>
-              <li>Update the Chain Core server package to version 1.1.3</li>
-              <li>Improved startup detection of other Chain Cores</li>
+              <li>Update the Chain Core server package to version 1.1.4</li>
+              <li>Improved OS X Yosemite support</li>
             </ul>
           ]]>
         </description>

--- a/installer/mac/updates/updates.xml
+++ b/installer/mac/updates/updates.xml
@@ -14,7 +14,7 @@
             </p>
             <ul>
               <li>Update the Chain Core server package to version 1.1.4</li>
-              <li>Improved OS X Yosemite support</li>
+              <li>Improved Safari 8 and legacy mac support</li>
             </ul>
           ]]>
         </description>

--- a/installer/mac/updates/updates.xml
+++ b/installer/mac/updates/updates.xml
@@ -18,11 +18,11 @@
             </ul>
           ]]>
         </description>
-        <pubDate>Wed, 08 Mar 2017 17:02:30 -0800</pubDate>
+        <pubDate>Thu, 30 Mar 2017 12:28:15 -0700</pubDate>
         <enclosure
-        	url="https://download.chain.com/mac/Chain_Core_1.1.1.zip"
-        	sparkle:version="1.1.1"
-        	length="54200125"
+        	url="https://download.chain.com/mac/Chain_Core_1.1.2.zip"
+        	sparkle:version="1.1.2"
+        	length="54279963"
         	type="application/octet-stream"
         	sparkle:dsaSignature=""
         	/>


### PR DESCRIPTION
Update to Chain Core 1.1.4, which brings improved support for Macs running Yosemite.