### PR TITLE
wercker.yml: disable flaky dashboard linting in CI

### DIFF
--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.0-stable/rev2498"
+const ID string = "1.0-stable/rev2499"

--- a/wercker.yml
+++ b/wercker.yml
@@ -28,12 +28,6 @@ cored:
         name: check for tk and xxx
         code: |
           check-tk-xxx
-    - inz/npm-install@1.1.5:
-      cwd: $CHAIN/dashboard/
-    - script:
-        name: dashboard tests
-        code: |
-          dashboard-tests
 
 java:
   steps:


### PR DESCRIPTION
This is a backport of #363, which disabled flaky eslint checks
in CI. This is useful for all branches, pending a more formal
fix.