### PR TITLE
docs/internal: revise tagging doc

### DIFF
--- a/docs/internal/package-tags-branches.md
+++ b/docs/internal/package-tags-branches.md
@@ -13,9 +13,9 @@
 
 ## Version branches
 
-Every major/minor version pair will have its own branch named `<major>-<minor>-stable`, e.g. `1.1-stable`.<sup>1</sup>
+Every major/minor version pair will have its own branch named `<major>-<minor>-stable`, e.g. `1.1-stable`.
 
-Version branches act as the merge base for point release updates across all packages, and should start with the commit corresponding to `chain-core-server-<major>.<minor>.0`.
+Version branches act as the merge base for point release updates across all packages, and should start with the commit corresponding to `chain-core-server-<major>.<minor>.0`.<sup>1</sup>
 
 Updates to the version branches should be as conservative as possible. We should ensure that the tip of each version branch maintains cross-compatibility across packages, per our [versioning scheme](../core/reference/versioning.md).
 
@@ -27,7 +27,7 @@ The standards for including a bug fix in a point release of Chain Core Server ar
 
 If a bug meets all three of those standards, it is a good candidate to fix in a point release. Different products might decide to apply different standards for their point releases.
 
-<sup>1</sup> Version 1.0 predates this scheme, so there is no `1.0-stable` branch. To make updates to 1.0, please use the 1.0 package-specific release tags.
+<sup>1</sup> Most package releases in 1.0.x predate this scheme. While the `1.0-stable` reflects the state-of-the-art in 1.0.x, it is not the merge base for older releases for that version family.
 
 ## Release tags
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2859";
+	public final String Id = "main/rev2860";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2859"
+const ID string = "main/rev2860"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2859"
+export const rev_id = "main/rev2860"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2859".freeze
+	ID = "main/rev2860".freeze
 end


### PR DESCRIPTION
Adjust language to reflect that 1.0-stable should be considered usable
for future releases (if any) on 1.0.x.