### PR TITLE
cmd/slashland: fix logic to avoid empty commits

### DIFF
--- a/cmd/slashland/main.go
+++ b/cmd/slashland/main.go
@@ -297,7 +297,7 @@ func commitRevIDs(landdir, baseBranch string) error {
 		return nil
 	}
 
-	cmd := dirCmd(landdir, "git", "commit", "-m", "auto rev id")
+	cmd = dirCmd(landdir, "git", "commit", "-m", "auto rev id")
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2867";
+	public final String Id = "main/rev2868";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2867"
+const ID string = "main/rev2868"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2867"
+export const rev_id = "main/rev2868"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2867".freeze
+	ID = "main/rev2868".freeze
 end


### PR DESCRIPTION
Running 'git commit' (without --allow-empty) will fail
when the file contents haven't changed, regardless of
the files' time stamps. We want to detect this situation
ahead of time and skip committing when the tree is
clean.

Unfortunately, diff-index, which is what we use to check
for a clean tree, *does* consider timestamps when
computing the diff; fortunately, running 'git add' fixes
this and causes the behavior of diff-index to match what
commit looks for in its "nothing to commit" error
message.

So now we explicitly add the files before checking to
see if the tree is clean.

This also gives us enough confidence to remove the
--allow-empty check on commit. It would be preferable
for chainbot simply to fail, alerting us that there's a
problem, rather than producing an empty commit and
continuing.

Fixes #830.