### PR TITLE
protocol: rename Chain.CommitBlock to CommitAppliedBlock

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -184,7 +184,7 @@ func Configure(ctx context.Context, db pg.DB, c *Config) error {
 			return err
 		}
 
-		err = chain.CommitBlock(ctx, block, state.Empty())
+		err = chain.CommitAppliedBlock(ctx, block, state.Empty())
 		if err != nil {
 			return err
 		}

--- a/core/fetch/fetch.go
+++ b/core/fetch/fetch.go
@@ -170,7 +170,7 @@ func applyBlock(ctx context.Context, c *protocol.Chain, prevSnap *state.Snapshot
 	if err != nil {
 		return prevSnap, prev, err
 	}
-	err = c.CommitBlock(ctx, block, snap)
+	err = c.CommitAppliedBlock(ctx, block, snap)
 	if err != nil {
 		return prevSnap, prev, err
 	}

--- a/core/generator/block.go
+++ b/core/generator/block.go
@@ -69,7 +69,7 @@ func (g *Generator) commitBlock(ctx context.Context, b *bc.Block, s *state.Snaps
 		return errors.Wrap(err, "sign")
 	}
 
-	err = g.chain.CommitBlock(ctx, b, s)
+	err = g.chain.CommitAppliedBlock(ctx, b, s)
 	if err != nil {
 		return errors.Wrap(err, "commit")
 	}

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -262,7 +262,7 @@ func generateBlock(ctx context.Context, t testing.TB, db pg.DB, timestamp time.T
 	if len(b.Transactions) == 0 {
 		return nil
 	}
-	err = c.CommitBlock(ctx, b, s)
+	err = c.CommitAppliedBlock(ctx, b, s)
 	if err != nil {
 		return err
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2870";
+	public final String Id = "main/rev2871";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2870"
+const ID string = "main/rev2871"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2870"
+export const rev_id = "main/rev2871"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2870".freeze
+	ID = "main/rev2871".freeze
 end

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -151,7 +151,7 @@ func (c *Chain) ApplyValidBlock(block *bc.Block) (*state.Snapshot, error) {
 // are triggered.
 //
 // TODO(bobg): rename to CommitAppliedBlock for clarity (deferred from https://github.com/chain/chain/pull/788)
-func (c *Chain) CommitBlock(ctx context.Context, block *bc.Block, snapshot *state.Snapshot) error {
+func (c *Chain) CommitAppliedBlock(ctx context.Context, block *bc.Block, snapshot *state.Snapshot) error {
 	// SaveBlock is the linearization point. Once the block is committed
 	// to persistent storage, the block has been applied and everything
 	// else can be derived from that block.

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -229,7 +229,7 @@ func newTestChain(tb testing.TB, ts time.Time) (c *Chain, b1 *bc.Block) {
 	}
 	// TODO(tessr): consider adding MaxIssuanceWindow to NewChain
 	c.MaxIssuanceWindow = 48 * time.Hour
-	err = c.CommitBlock(ctx, b1, state.Empty())
+	err = c.CommitAppliedBlock(ctx, b1, state.Empty())
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
@@ -254,7 +254,7 @@ func makeEmptyBlock(tb testing.TB, c *Chain) {
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
-	err = c.CommitBlock(ctx, nextBlock, nextState)
+	err = c.CommitAppliedBlock(ctx, nextBlock, nextState)
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}

--- a/protocol/prottest/block.go
+++ b/protocol/prottest/block.go
@@ -45,7 +45,7 @@ func NewChainWithStorage(tb testing.TB, store protocol.Store, outputIDs ...bc.Ha
 		s.Tree.Insert(outputID[:])
 	}
 
-	err = c.CommitBlock(ctx, b1, s)
+	err = c.CommitAppliedBlock(ctx, b1, s)
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
@@ -77,7 +77,7 @@ func MakeBlock(tb testing.TB, c *protocol.Chain, txs []*bc.Tx) *bc.Block {
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
-	err = c.CommitBlock(ctx, nextBlock, nextState)
+	err = c.CommitAppliedBlock(ctx, nextBlock, nextState)
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}

--- a/protocol/recover.go
+++ b/protocol/recover.go
@@ -61,7 +61,7 @@ func (c *Chain) Recover(ctx context.Context) (*bc.Block, *state.Snapshot, error)
 		// been too, but make sure just in case. Also "finalize" the last
 		// block (notifying other processes of the latest block height)
 		// and maybe persist the snapshot.
-		err = c.CommitBlock(ctx, b, snapshot)
+		err = c.CommitAppliedBlock(ctx, b, snapshot)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "committing block")
 		}

--- a/protocol/recover_test.go
+++ b/protocol/recover_test.go
@@ -22,7 +22,7 @@ func TestRecoverSnapshotNoAdditionalBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = c1.CommitBlock(context.Background(), b, state.Empty())
+	err = c1.CommitAppliedBlock(context.Background(), b, state.Empty())
 	if err != nil {
 		testutil.FatalErr(t, err)
 	}


### PR DESCRIPTION
The intent here is to clarify the sequence of events: validate, apply, commit. It's part of a larger simplification of the validation API, most of which happened in (and leading up to) https://github.com/chain/chain/pull/788.