### PR TITLE
protocol/bc: make MapBlock correctly transform nil

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2860";
+	public final String Id = "main/rev2861";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2860"
+const ID string = "main/rev2861"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2860"
+export const rev_id = "main/rev2861"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2860".freeze
+	ID = "main/rev2861".freeze
 end

--- a/protocol/bc/map.go
+++ b/protocol/bc/map.go
@@ -212,6 +212,9 @@ func mapBlockHeader(old *BlockHeader) (bhID Hash, bh *BlockHeaderEntry) {
 }
 
 func MapBlock(old *Block) *BlockEntries {
+	if old == nil {
+		return nil // if old is nil, so should new be
+	}
 	b := new(BlockEntries)
 	b.ID, b.BlockHeaderEntry = mapBlockHeader(&old.BlockHeader)
 	for _, oldTx := range old.Transactions {

--- a/protocol/block.go
+++ b/protocol/block.go
@@ -114,11 +114,7 @@ func (c *Chain) ValidateBlock(block, prev *bc.Block) error {
 }
 
 func validateBlock(block, prev *bc.Block, initialBlockHash bc.Hash, validateTx func(*bc.TxEntries) error, runProg bool) error {
-	var prevEntries *bc.BlockEntries
-	if prev != nil {
-		prevEntries = bc.MapBlock(prev)
-	}
-	err := validation.ValidateBlock(bc.MapBlock(block), prevEntries, initialBlockHash, validateTx, runProg)
+	err := validation.ValidateBlock(bc.MapBlock(block), bc.MapBlock(prev), initialBlockHash, validateTx, runProg)
 	if err != nil {
 		return errors.Sub(ErrBadBlock, err)
 	}


### PR DESCRIPTION
The BlockEntries equivalent of a nil Block is nil. This
change makes MapBlock cover its entire domain -- it's
valid for all values of *Block, including nil.