### PR TITLE
protocol/vm: test stack underflow; fix 2 bugs

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2866";
+	public final String Id = "main/rev2867";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2866"
+const ID string = "main/rev2867"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2866"
+export const rev_id = "main/rev2867"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2866".freeze
+	ID = "main/rev2867".freeze
 end

--- a/protocol/vm/bitwise_test.go
+++ b/protocol/vm/bitwise_test.go
@@ -237,13 +237,6 @@ func TestBitwiseOps(t *testing.T) {
 		cases = append(cases, testStruct{
 			op: op,
 			startVM: &virtualMachine{
-				runLimit:  50000,
-				dataStack: [][]byte{},
-			},
-			wantErr: ErrDataStackUnderflow,
-		}, testStruct{
-			op: op,
-			startVM: &virtualMachine{
 				runLimit:  0,
 				dataStack: [][]byte{{0xff}, {0xff}},
 			},
@@ -255,18 +248,6 @@ func TestBitwiseOps(t *testing.T) {
 				dataStack: [][]byte{{0xff}, {0xff}},
 			},
 			wantErr: ErrRunLimitExceeded,
-		})
-	}
-
-	twoops := []Op{OP_AND, OP_OR, OP_XOR, OP_EQUAL, OP_EQUALVERIFY}
-	for _, op := range twoops {
-		cases = append(cases, testStruct{
-			op: op,
-			startVM: &virtualMachine{
-				runLimit:  50000,
-				dataStack: [][]byte{{0xff}},
-			},
-			wantErr: ErrDataStackUnderflow,
 		})
 	}
 

--- a/protocol/vm/control_test.go
+++ b/protocol/vm/control_test.go
@@ -117,13 +117,6 @@ func TestControlOps(t *testing.T) {
 		},
 		wantErr: ErrVerifyFailed,
 	}, {
-		op: OP_VERIFY,
-		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
 		startVM: &virtualMachine{runLimit: 50000},
 		op:      OP_FAIL,
 		wantErr: ErrReturn,
@@ -160,26 +153,6 @@ func TestControlOps(t *testing.T) {
 			deferredCost: -49952,
 			dataStack:    [][]byte{{}},
 		},
-	}, {
-		op: OP_CHECKPREDICATE,
-		startVM: &virtualMachine{
-			runLimit: 50000,
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKPREDICATE,
-		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{}},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKPREDICATE,
-		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{}, {}},
-		},
-		wantErr: ErrDataStackUnderflow,
 	}, {
 		op: OP_CHECKPREDICATE,
 		startVM: &virtualMachine{

--- a/protocol/vm/crypto.go
+++ b/protocol/vm/crypto.go
@@ -48,19 +48,19 @@ func opCheckSig(vm *virtualMachine) error {
 	if err != nil {
 		return err
 	}
-	if len(pubkeyBytes) != ed25519.PublicKeySize {
-		return vm.pushBool(false, true)
-	}
 	msg, err := vm.pop(true)
+	if err != nil {
+		return err
+	}
+	sig, err := vm.pop(true)
 	if err != nil {
 		return err
 	}
 	if len(msg) != 32 {
 		return ErrBadValue
 	}
-	sig, err := vm.pop(true)
-	if err != nil {
-		return err
+	if len(pubkeyBytes) != ed25519.PublicKeySize {
+		return vm.pushBool(false, true)
 	}
 	return vm.pushBool(ed25519.Verify(ed25519.PublicKey(pubkeyBytes), msg, sig), true)
 }

--- a/protocol/vm/crypto_test.go
+++ b/protocol/vm/crypto_test.go
@@ -219,32 +219,6 @@ func TestCryptoOps(t *testing.T) {
 	}, {
 		op: OP_CHECKSIG,
 		startVM: &VirtualMachine{
-			RunLimit:  50000,
-			DataStack: [][]byte{},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKSIG,
-		startVM: &VirtualMachine{
-			RunLimit: 50000,
-			DataStack: [][]byte{
-				mustDecodeHex("ab3220d065dc875c6a5b4ecc39809b5f24eb0a605e9eef5190457edbf1e3b866"),
-			},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKSIG,
-		startVM: &VirtualMachine{
-			RunLimit: 50000,
-			DataStack: [][]byte{
-				mustDecodeHex("916f0027a575074ce72a331777c3478d6513f786a591bd892da1a577bf2335f9"),
-				mustDecodeHex("ab3220d065dc875c6a5b4ecc39809b5f24eb0a605e9eef5190457edbf1e3b866"),
-			},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKSIG,
-		startVM: &VirtualMachine{
 			RunLimit: 50000,
 			DataStack: [][]byte{
 				mustDecodeHex("af5abdf4bbb34f4a089efc298234f84fd909def662a8df03b4d7d40372728851" +
@@ -456,13 +430,6 @@ func TestCryptoOps(t *testing.T) {
 				DataStack: [][]byte{{1}},
 			},
 			wantErr: ErrRunLimitExceeded,
-		}, testStruct{
-			op: op,
-			startVM: &VirtualMachine{
-				RunLimit:  50000,
-				DataStack: [][]byte{},
-			},
-			wantErr: ErrDataStackUnderflow,
 		})
 	}
 

--- a/protocol/vm/introspection_test.go
+++ b/protocol/vm/introspection_test.go
@@ -272,57 +272,6 @@ func TestIntrospectionOps(t *testing.T) {
 	}, {
 		op: OP_CHECKOUTPUT,
 		startVM: &VirtualMachine{
-			Context: context0,
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKOUTPUT,
-		startVM: &VirtualMachine{
-			DataStack: [][]byte{
-				[]byte("controlprog"),
-			},
-			Context: context0,
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKOUTPUT,
-		startVM: &VirtualMachine{
-			DataStack: [][]byte{
-				append([]byte{2}, make([]byte, 31)...),
-				{1},
-				[]byte("controlprog"),
-			},
-			Context: context0,
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKOUTPUT,
-		startVM: &VirtualMachine{
-			DataStack: [][]byte{
-				{7},
-				append([]byte{2}, make([]byte, 31)...),
-				{1},
-				[]byte("controlprog"),
-			},
-			Context: context0,
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKOUTPUT,
-		startVM: &VirtualMachine{
-			DataStack: [][]byte{
-				mustDecodeHex("1f2a05f881ed9fa0c9068a84823677409f863891a2196eb55dbfbb677a566374"),
-				{7},
-				append([]byte{2}, make([]byte, 31)...),
-				{1},
-				[]byte("controlprog"),
-			},
-			Context: context0,
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CHECKOUTPUT,
-		startVM: &VirtualMachine{
 			DataStack: [][]byte{
 				{4},
 				mustDecodeHex("1f2a05f881ed9fa0c9068a84823677409f863891a2196eb55dbfbb677a566374"),

--- a/protocol/vm/numeric_test.go
+++ b/protocol/vm/numeric_test.go
@@ -446,13 +446,6 @@ func TestNumericOps(t *testing.T) {
 			deferredCost: -18,
 			dataStack:    [][]byte{{1}},
 		},
-	}, {
-		op: OP_WITHIN,
-		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{1}, {2}},
-		},
-		wantErr: ErrDataStackUnderflow,
 	}}
 
 	numops := []Op{
@@ -461,34 +454,15 @@ func TestNumericOps(t *testing.T) {
 		OP_BOOLOR, OP_NUMEQUAL, OP_NUMEQUALVERIFY, OP_NUMNOTEQUAL, OP_LESSTHAN,
 		OP_LESSTHANOREQUAL, OP_GREATERTHAN, OP_GREATERTHANOREQUAL, OP_MIN, OP_MAX, OP_WITHIN,
 	}
-	twopop := numops[8:]
 
 	for _, op := range numops {
 		cases = append(cases, testStruct{
-			op: op,
-			startVM: &virtualMachine{
-				runLimit:  50000,
-				dataStack: [][]byte{},
-			},
-			wantErr: ErrDataStackUnderflow,
-		}, testStruct{
 			op: op,
 			startVM: &virtualMachine{
 				runLimit:  0,
 				dataStack: [][]byte{{2}, {2}, {2}},
 			},
 			wantErr: ErrRunLimitExceeded,
-		})
-	}
-
-	for _, op := range twopop {
-		cases = append(cases, testStruct{
-			op: op,
-			startVM: &virtualMachine{
-				runLimit:  50000,
-				dataStack: [][]byte{{2}},
-			},
-			wantErr: ErrDataStackUnderflow,
 		})
 	}
 

--- a/protocol/vm/splice_test.go
+++ b/protocol/vm/splice_test.go
@@ -27,13 +27,6 @@ func TestSpliceOps(t *testing.T) {
 	}, {
 		op: OP_CAT,
 		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{[]byte("world")},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CAT,
-		startVM: &virtualMachine{
 			runLimit:  4,
 			dataStack: [][]byte{[]byte("hello"), []byte("world")},
 		},
@@ -73,20 +66,6 @@ func TestSpliceOps(t *testing.T) {
 	}, {
 		op: OP_SUBSTR,
 		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{5}},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_SUBSTR,
-		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{3}, {5}},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_SUBSTR,
-		startVM: &virtualMachine{
 			runLimit:  4,
 			dataStack: [][]byte{[]byte("helloworld"), {3}, {5}},
 		},
@@ -116,13 +95,6 @@ func TestSpliceOps(t *testing.T) {
 			dataStack: [][]byte{[]byte("helloworld"), {11}},
 		},
 		wantErr: ErrBadValue,
-	}, {
-		op: OP_LEFT,
-		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{5}},
-		},
-		wantErr: ErrDataStackUnderflow,
 	}, {
 		op: OP_LEFT,
 		startVM: &virtualMachine{
@@ -158,13 +130,6 @@ func TestSpliceOps(t *testing.T) {
 	}, {
 		op: OP_RIGHT,
 		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{5}},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_RIGHT,
-		startVM: &virtualMachine{
 			runLimit:  4,
 			dataStack: [][]byte{[]byte("helloworld"), {5}},
 		},
@@ -194,13 +159,6 @@ func TestSpliceOps(t *testing.T) {
 	}, {
 		op: OP_CATPUSHDATA,
 		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{0xab, 0xcd}},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_CATPUSHDATA,
-		startVM: &virtualMachine{
 			runLimit:  4,
 			dataStack: [][]byte{{0xff}, {0xab, 0xcd}},
 		},
@@ -213,10 +171,6 @@ func TestSpliceOps(t *testing.T) {
 			op:      op,
 			startVM: &virtualMachine{runLimit: 0},
 			wantErr: ErrRunLimitExceeded,
-		}, testStruct{
-			op:      op,
-			startVM: &virtualMachine{runLimit: 50000, dataStack: [][]byte{}},
-			wantErr: ErrDataStackUnderflow,
 		})
 	}
 

--- a/protocol/vm/stack_test.go
+++ b/protocol/vm/stack_test.go
@@ -196,13 +196,6 @@ func TestStackOps(t *testing.T) {
 			dataStack: [][]byte{{1}},
 		},
 	}, {
-		op: OP_NIP,
-		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{1}},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
 		op: OP_OVER,
 		startVM: &virtualMachine{
 			runLimit:  50000,
@@ -232,13 +225,6 @@ func TestStackOps(t *testing.T) {
 	}, {
 		op: OP_PICK,
 		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{3}, {2}, {1}, {3}},
-		},
-		wantErr: ErrDataStackUnderflow,
-	}, {
-		op: OP_PICK,
-		startVM: &virtualMachine{
 			runLimit:  2,
 			dataStack: [][]byte{{0xff, 0xff}, {2}, {1}, {2}},
 		},
@@ -253,13 +239,6 @@ func TestStackOps(t *testing.T) {
 			runLimit:  50007,
 			dataStack: [][]byte{{2}, {1}, {3}},
 		},
-	}, {
-		op: OP_ROLL,
-		startVM: &virtualMachine{
-			runLimit:  50000,
-			dataStack: [][]byte{{3}, {2}, {1}, {3}},
-		},
-		wantErr: ErrDataStackUnderflow,
 	}, {
 		op: OP_ROT,
 		startVM: &virtualMachine{
@@ -310,13 +289,6 @@ func TestStackOps(t *testing.T) {
 			wantErr: ErrRunLimitExceeded,
 		})
 	}
-	for _, op := range stackops[2:] {
-		cases = append(cases, testStruct{
-			op:      op,
-			startVM: &virtualMachine{runLimit: 50000, dataStack: [][]byte{}},
-			wantErr: ErrDataStackUnderflow,
-		})
-	}
 
 	for i, c := range cases {
 		err := ops[c.op].fn(c.startVM)
@@ -357,7 +329,7 @@ func TestStackUnderflow(t *testing.T) {
 		{1, opSha256},
 		{1, opSha3},
 		{3, opCheckSig},
-		{3, opCheckMultiSig}, // TODO(kr): special; check data-dependent # of pops
+		{3, opCheckMultiSig}, // special, see also TestCryptoOps
 
 		// introspection
 		{6, opCheckOutput},
@@ -395,10 +367,12 @@ func TestStackUnderflow(t *testing.T) {
 		{2, opCat},
 		{3, opSubstr},
 		{2, opLeft},
+		{2, opRight},
 		{1, opSize},
 		{2, opCatpushdata},
 
 		// stack
+		{1, opToAltStack},
 		{2, op2Drop},
 		{2, op2Dup},
 		{3, op3Dup},

--- a/protocol/vm/stack_test.go
+++ b/protocol/vm/stack_test.go
@@ -1,6 +1,10 @@
 package vm
 
 import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"chain/testutil"
@@ -329,4 +333,117 @@ func TestStackOps(t *testing.T) {
 			t.Errorf("case %d, op %s: unexpected vm result\n\tgot:  %+v\n\twant: %+v\n", i, ops[c.op].name, c.startVM, c.wantVM)
 		}
 	}
+}
+
+func TestStackUnderflow(t *testing.T) {
+	cases := []struct {
+		narg int // number of stack items required
+		op   func(*virtualMachine) error
+	}{
+		// bitwise
+		{1, opInvert},
+		{2, opAnd},
+		{2, opOr},
+		{2, opXor},
+		{2, opEqual},
+		{2, opEqualVerify},
+
+		// control
+		{1, opVerify},
+		{3, opCheckPredicate},
+		{1, opJumpIf},
+
+		// crypto
+		{1, opSha256},
+		{1, opSha3},
+		{3, opCheckSig},
+		{3, opCheckMultiSig}, // TODO(kr): special; check data-dependent # of pops
+
+		// introspection
+		{6, opCheckOutput},
+
+		// numeric
+		{1, op1Add},
+		{1, op1Sub},
+		{1, op2Mul},
+		{1, op2Div},
+		{1, opNegate},
+		{1, opAbs},
+		{1, opNot},
+		{1, op0NotEqual},
+		{2, opAdd},
+		{2, opSub},
+		{2, opMul},
+		{2, opDiv},
+		{2, opMod},
+		{2, opLshift},
+		{2, opRshift},
+		{2, opBoolAnd},
+		{2, opBoolOr},
+		{2, opNumEqual},
+		{2, opNumEqualVerify},
+		{2, opNumNotEqual},
+		{2, opLessThan},
+		{2, opGreaterThan},
+		{2, opLessThanOrEqual},
+		{2, opGreaterThanOrEqual},
+		{2, opMin},
+		{2, opMax},
+		{3, opWithin},
+
+		// splice
+		{2, opCat},
+		{3, opSubstr},
+		{2, opLeft},
+		{1, opSize},
+		{2, opCatpushdata},
+
+		// stack
+		{2, op2Drop},
+		{2, op2Dup},
+		{3, op3Dup},
+		{4, op2Over},
+		{6, op2Rot},
+		{4, op2Swap},
+		{1, opIfDup},
+		{1, opDrop},
+		{1, opDup},
+		{2, opNip},
+		{2, opOver},
+		{2, opPick}, // TODO(kr): special; check data-dependent # of pops
+		{2, opRoll}, // TODO(kr): special; check data-dependent # of pops
+		{3, opRot},
+		{2, opSwap},
+		{2, opTuck},
+	}
+
+	for _, test := range cases {
+		t.Run(funcName(test.op), func(t *testing.T) {
+
+			for i := 0; i < test.narg; i++ {
+				t.Run(fmt.Sprintf("%d args", i), func(t *testing.T) {
+
+					vm := &virtualMachine{
+						runLimit:  50000,
+						dataStack: make([][]byte, i),
+					}
+					err := test.op(vm)
+					if err != ErrDataStackUnderflow {
+						t.Errorf("err = %v, want ErrStackUnderflow", err)
+					}
+
+				})
+			}
+
+		})
+	}
+}
+
+func funcName(f interface{}) string {
+	v := reflect.ValueOf(f)
+	if v.Kind() != reflect.Func {
+		return ""
+	}
+	s := runtime.FuncForPC(v.Pointer()).Name()
+	return s[strings.LastIndex(s, ".")+1:]
 }


### PR DESCRIPTION
This change adds unit tests for stack underflow
conditions in all operations. It uncovered two spec
deviation bugs in CHECKSIG. These are now fixed.

This increases stmt coverage from 95% to 95.3%.