### PR TITLE
cmd/md2html: support version prefix in doc generation

### DIFF
--- a/cmd/md2html/doc.go
+++ b/cmd/md2html/doc.go
@@ -11,7 +11,7 @@ of the converted markdown.
 
 Usage
 
-	md2html [destination]
+	md2html build [-prefix <major>.<minor>] [destination]
 
 
 	destination - address or directory
@@ -30,12 +30,12 @@ Example
 
 Start a server in the current directory:
 
-	$ md2html
+	$ md2html serve [-prefix <major>.<minor>]
 
 Copy all files --and convert .md to HTML-- in the current directory and
 write them to ~/site:
 
-	$ md2html ~/site
+	$ md2html serve ~/site
 
 Code Interpolation
 

--- a/cmd/md2html/doc.go
+++ b/cmd/md2html/doc.go
@@ -5,13 +5,13 @@ For each markdown file in the current directory, md2html will convert
 the markdown to html and write the resulting html to a file of
 the same name in the destination directory.
 
-If there is a file named layout.html which contains `{{Body}}`
+If there is a file named layout.html which contains `{{.Body}}`
 in the current directory, md2html use that data to wrap the html output
 of the converted markdown.
 
 Usage
 
-	md2html build [-prefix <major>.<minor>] [destination]
+	md2html [-prefix <major>.<minor>] build DEST_PATH
 
 
 	destination - address or directory
@@ -30,12 +30,7 @@ Example
 
 Start a server in the current directory:
 
-	$ md2html serve [-prefix <major>.<minor>]
-
-Copy all files --and convert .md to HTML-- in the current directory and
-write them to ~/site:
-
-	$ md2html serve ~/site
+	$ md2html [-prefix <major>.<minor>] serve [port]
 
 Code Interpolation
 

--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -90,7 +90,6 @@ func serve(args []string) {
 			fmt.Fprintln(os.Stderr, "usage: md2html [-prefix X.Y] serve PORT")
 			fmt.Fprintln(os.Stderr)
 			os.Exit(1)
-
 		}
 		addr = args[0]
 	}

--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -74,7 +74,7 @@ func help(w io.Writer) {
 	fmt.Fprintln(w, "usage: md2html [-prefix PREFIX] [command] [command-arguments]")
 	fmt.Fprintln(w, "\nFlags:")
 	fmt.Fprintln(w, "\t-prefix   specify version prefix of docs (e.g. '1.1')")
-	fmt.Fprintln(w, "\nThe commands are:\n")
+	fmt.Fprint(w, "\nThe commands are:\n\n")
 	for name := range commands {
 		fmt.Fprintln(w, "\t", name)
 	}
@@ -85,7 +85,7 @@ func serve(args []string) {
 	addr := "8080"
 	if len(args) >= 1 {
 		if _, err := strconv.Atoi(args[0]); err != nil {
-			fmt.Fprintln(os.Stderr, "You must specify a numeric port for serving content\n")
+			fmt.Fprint(os.Stderr, "You must specify a numeric port for serving content\n\n")
 			fmt.Fprintln(os.Stderr, "usage: md2html [-prefix X.Y] serve PORT")
 			fmt.Fprintln(os.Stderr)
 			os.Exit(1)
@@ -145,7 +145,7 @@ func serve(args []string) {
 
 func convert(args []string) {
 	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "You must specify an destination path for built docs\n")
+		fmt.Fprint(os.Stderr, "You must specify an destination path for built docs\n\n")
 		fmt.Fprintln(os.Stderr, "usage: md2html [-prefix X.Y] build DEST_PATH")
 		fmt.Fprintln(os.Stderr)
 		os.Exit(1)

--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/russross/blackfriday"
 	"io"
 	"io/ioutil"
 	"log"
@@ -18,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/russross/blackfriday"
 )
 
 var extToLang = map[string]string{

--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -35,7 +35,7 @@ var commands = map[string]*command{
 	"build": {convert},
 }
 
-var version = ""
+var version = "x.y"
 
 func main() {
 	if len(os.Args) < 2 {

--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -99,6 +99,11 @@ func serve(args []string) {
 	fmt.Printf("serving at: http://localhost%s\n", addr)
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		path := "." + r.URL.Path
+
+		if version != "" {
+			path = strings.Replace(path, version+"/", "", 1)
+		}
+
 		if filepath.Ext(path) != "" {
 			http.ServeFile(w, r, path)
 			return

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=/docs/core/get-started/introduction">
+    <meta http-equiv="refresh" content="0; url=/docs/{{.VersionPath}}core/get-started/introduction">
   </head>
 </html>

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -29,35 +29,35 @@
         <li>
           <a class="toggle" href="javascript:void(0);">Get Started</a>
           <ul class="inner">
-            <li><a href="/docs/core/get-started/introduction">Introduction</a></li>
-            <li><a href="/docs/core/get-started/install" title="Install Chain Core">Install</a></li>
-            <li><a href="/docs/core/get-started/sdk" title="Download SDK">SDK</a></li>
-            <li><a href="/docs/core/get-started/configure" title="Configure Chain Core">Configure</a></li>
-            <li><a href="/docs/core/get-started/five-minute-guide">5-Minute Guide</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/introduction">Introduction</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/install" title="Install Chain Core">Install</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/sdk" title="Download SDK">SDK</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/configure" title="Configure Chain Core">Configure</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/five-minute-guide">5-Minute Guide</a></li>
           </ul>
         </li>
         <li>
           <a class="toggle" href="javascript:void(0);">Build Applications</a>
           <ul class="inner">
-            <li><a href="/docs/core/build-applications/keys">Keys</a></li>
-            <li><a href="/docs/core/build-applications/assets">Assets</a></li>
-            <li><a href="/docs/core/build-applications/accounts">Accounts</a></li>
-            <li><a href="/docs/core/build-applications/transaction-basics">Transaction Basics</a></li>
-            <li><a href="/docs/core/build-applications/unspent-outputs">Unspent Outputs</a></li>
-            <li><a href="/docs/core/build-applications/control-programs">Control Programs</a></li>
-            <li><a href="/docs/core/build-applications/queries">Queries</a></li>
-            <li><a href="/docs/core/build-applications/multiparty-trades">Multiparty Trades</a></li>
-            <li><a href="/docs/core/build-applications/real-time-transaction-processing">Real-time Processing</a></li>
-            <li><a href="/docs/core/build-applications/batch-operations">Batch Operations</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/keys">Keys</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/assets">Assets</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/accounts">Accounts</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/transaction-basics">Transaction Basics</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/unspent-outputs">Unspent Outputs</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/control-programs">Control Programs</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/queries">Queries</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/multiparty-trades">Multiparty Trades</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/real-time-transaction-processing">Real-time Processing</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/batch-operations">Batch Operations</a></li>
           </ul>
         </li>
         <li>
           <a class="toggle" href="javascript:void(0);">Learn More</a>
           <ul class="inner">
-            <li><a href="/docs/core/learn-more/global-vs-local-data">Global vs Local Data</a></li>
-            <li><a href="/docs/core/learn-more/authentication" title="Authentication">Authentication</a></li>
-            <li><a href="/docs/core/learn-more/blockchain-operators">Blockchain Operators</a></li>
-            <li><a href="/docs/core/learn-more/blockchain-participants">Blockchain Participants</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/learn-more/global-vs-local-data">Global vs Local Data</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/learn-more/authentication" title="Authentication">Authentication</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/learn-more/blockchain-operators">Blockchain Operators</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/learn-more/blockchain-participants">Blockchain Participants</a></li>
           </ul>
         </li>
         <li>
@@ -66,9 +66,9 @@
             <li><a href="/docs/java/javadoc/index.html" target="_blank" class="skip-next-up">Java SDK</a></li>
             <li><a href="/docs/node/doc/index.html" target="_blank" class="skip-next-up">Node SDK</a></li>
             <li><a href="/docs/ruby/doc/index.html" target="_blank" class="skip-next-up">Ruby SDK</a></li>
-            <li><a href="/docs/core/reference/versioning">Versioning</a></li>
-            <li><a href="/docs/core/reference/api-objects">API Objects</a></li>
-            <li><a href="/docs/core/reference/license" class="skip-next-up">License</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/reference/versioning">Versioning</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/reference/api-objects">API Objects</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/reference/license" class="skip-next-up">License</a></li>
           </ul>
         </li>
 
@@ -97,8 +97,8 @@
     </div>
   </div>
   <div id="doc-wrapper" tabindex="0">
-    <article id="doc-content" class="{{Filename}}">
-      {{Body}}
+    <article id="doc-content" class="{{.Filename}}">
+      {{.Body}}
 
       <footer>
         <div id="up-next" style="display:none">

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -76,20 +76,20 @@
         <li>
           <a class="toggle" href="javascript:void(0);">Papers</a>
           <ul class="inner">
-            <li><a href="/docs/protocol/papers/whitepaper">Whitepaper</a></li>
-            <li><a href="/docs/protocol/papers/federated-consensus">Federated Consensus</a></li>
-            <li><a href="/docs/protocol/papers/blockchain-programs">Blockchain Programs</a></li>
-            <li><a href="/docs/protocol/papers/blockchain-extensibility">Blockchain Extensibility</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/papers/whitepaper">Whitepaper</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/papers/federated-consensus">Federated Consensus</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/papers/blockchain-programs">Blockchain Programs</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/papers/blockchain-extensibility">Blockchain Extensibility</a></li>
           </ul>
         </li>
         <li>
           <a class="toggle" href="javascript:void(0);">Specifications</a>
           <ul class="inner">
-            <li><a href="/docs/protocol/specifications/data" title="Data Model Specification">Data Model</a></li>
-            <li><a href="/docs/protocol/specifications/validation" title="Validation Specification">Validation</a></li>
-            <li><a href="/docs/protocol/specifications/consensus"  title="Consensus Specification">Consensus</a></li>
-            <li><a href="/docs/protocol/specifications/vm1" title="Virtual Machine Specification">Virtual Machine</a></li>
-            <li><a href="/docs/protocol/specifications/chainkd" title="Chain Key Derivation Specification">ChainKD</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/data" title="Data Model Specification">Data Model</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/validation" title="Validation Specification">Validation</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/consensus"  title="Consensus Specification">Consensus</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/vm1" title="Virtual Machine Specification">Virtual Machine</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/chainkd" title="Chain Key Derivation Specification">ChainKD</a></li>
           </ul>
         </li>
       </ul>

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2868";
+	public final String Id = "main/rev2869";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2868"
+const ID string = "main/rev2869"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2868"
+export const rev_id = "main/rev2869"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2868".freeze
+	ID = "main/rev2869".freeze
 end


### PR DESCRIPTION
Adds command line option for specifying a version prefix for all docs, using
`text/template` for substituting values in HTML.