### PR TITLE
cmd/cored: configure root CA pool

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -4,11 +4,13 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"expvar"
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -51,6 +53,7 @@ var (
 	// config vars
 	tlsCrt        = env.String("TLSCRT", "")
 	tlsKey        = env.String("TLSKEY", "")
+	rootCAs       = env.String("ROOT_CA_CERTS", "") // file path
 	listenAddr    = env.String("LISTEN", ":1999")
 	dbURL         = env.String("DATABASE_URL", "postgres:///core?sslmode=disable")
 	splunkAddr    = os.Getenv("SPLUNKADDR")
@@ -183,6 +186,12 @@ func runServer() {
 			}
 		}
 	}()
+
+	if *rootCAs != "" {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+			RootCAs: loadRootCAs(*rootCAs),
+		}
+	}
 
 	sql.EnableQueryLogging(*logQueries)
 	db, err := sql.Open("hapg", *dbURL)
@@ -424,4 +433,18 @@ func (w *errlog) Write(p []byte) (int, error) {
 		w.t = time.Now()
 	}
 	return len(p), nil // report success for the MultiWriter
+}
+
+// loadRootCAs reads a list of PEM-encoded X.509 certificates from name
+func loadRootCAs(name string) *x509.CertPool {
+	pem, err := ioutil.ReadFile(name)
+	if err != nil {
+		chainlog.Fatal(context.Background(), chainlog.KeyError, err)
+	}
+	pool := x509.NewCertPool()
+	ok := pool.AppendCertsFromPEM(pem)
+	if !ok {
+		chainlog.Fatal(context.Background(), chainlog.KeyError, "no certs found in "+name)
+	}
+	return pool
 }

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -439,12 +439,12 @@ func (w *errlog) Write(p []byte) (int, error) {
 func loadRootCAs(name string) *x509.CertPool {
 	pem, err := ioutil.ReadFile(name)
 	if err != nil {
-		chainlog.Fatal(context.Background(), chainlog.KeyError, err)
+		chainlog.Fatalkv(context.Background(), chainlog.KeyError, err)
 	}
 	pool := x509.NewCertPool()
 	ok := pool.AppendCertsFromPEM(pem)
 	if !ok {
-		chainlog.Fatal(context.Background(), chainlog.KeyError, "no certs found in "+name)
+		chainlog.Fatalkv(context.Background(), chainlog.KeyError, "no certs found in "+name)
 	}
 	return pool
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2872";
+	public final String Id = "main/rev2873";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2872"
+const ID string = "main/rev2873"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2872"
+export const rev_id = "main/rev2873"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2872".freeze
+	ID = "main/rev2873".freeze
 end


### PR DESCRIPTION
By default, package crypto/tls uses the operating
system's set of global root CAs. This is unsuitable for
a typical production deployment, where the opeator will
run its own CA and provision its own certs.

This change provides a new environment variable:

ROOT_CA_CERTS=certs.pem
This variable holds a filename of a file containing a list
of PEM-encoded root X.509 certificates.

This is a back port of a change made in #684 with
updates to the logging call sites.