### PR TITLE
cmd/cored: rename insecure_disable_https_redirect

### DIFF
--- a/bin/build-centos-rpm
+++ b/bin/build-centos-rpm
@@ -32,7 +32,7 @@ cleanup() {
 trap "cleanup" EXIT
 
 GOOS=linux GOARCH=amd64 go build\
-  -tags 'insecure_disable_https_redirect'\
+  -tags 'plain_http'\
   -ldflags "$ldflags"\
   -o $CHAIN/docker/centos-rpm/cored\
   chain/cmd/cored

--- a/bin/build-cored-release
+++ b/bin/build-cored-release
@@ -48,7 +48,7 @@ DATE=${DATE:-`date +%s`} # date can be set via envvar
 ldflags="-X main.buildTag=$releaseRef -X main.buildCommit=$commit -X main.buildDate=$DATE"
 
 go build\
-  -tags 'insecure_disable_https_redirect'\
+  -tags 'plain_http'\
   -ldflags "$ldflags"\
   -o $outputDir/cored\
   chain/cmd/cored

--- a/cmd/benchcore/main.go
+++ b/cmd/benchcore/main.go
@@ -333,7 +333,7 @@ func mustBuildCored() []byte {
 
 	date := time.Now().UTC().Format(time.RFC3339)
 	cmd := exec.Command("go", "build",
-		"-tags", "insecure_disable_https_redirect",
+		"-tags", "plain_http",
 		"-ldflags", "-X main.buildDate="+date,
 		"-o", "/dev/stdout",
 		"chain/cmd/cored",

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -72,7 +72,7 @@ var (
 	buildDate   = "?"
 
 	race          []interface{} // initialized in race.go
-	httpsRedirect = true        // initialized in insecure.go
+	httpsRedirect = true        // initialized in plain_http.go
 )
 
 func init() {

--- a/cmd/cored/plain_http.go
+++ b/cmd/cored/plain_http.go
@@ -1,4 +1,4 @@
-//+build insecure_disable_https_redirect
+//+build plain_http
 
 package main
 

--- a/cmd/deploy/main.go
+++ b/cmd/deploy/main.go
@@ -87,7 +87,7 @@ func mustBuild(filename string) []byte {
 	commit = bytes.TrimSpace(commit)
 	date := time.Now().UTC().Format(time.RFC3339)
 	cmd = exec.Command("go", "build",
-		"-tags", "insecure_disable_https_redirect",
+		"-tags", "plain_http",
 		"-ldflags", "-X main.buildTag=dev -X main.buildDate="+date+" -X main.buildCommit="+string(commit),
 		"-o", "/dev/stdout",
 		"chain/cmd/"+filename,

--- a/docker/ci/bin/setup-core
+++ b/docker/ci/bin/setup-core
@@ -20,8 +20,7 @@ waitForGenerator() {(
 )}
 
 PATH=$(go env GOPATH)/bin:$PATH:$CHAIN/bin
-go install -tags 'insecure_disable_https_redirect' chain/cmd/cored
-go install chain/cmd/corectl
+go install -tags 'plain_http' chain/cmd/{cored,corectl}
 corectl migrate
 corectl config-generator
 initlog=`mktemp`

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2874";
+	public final String Id = "main/rev2875";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2874"
+const ID string = "main/rev2875"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2874"
+export const rev_id = "main/rev2875"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2874".freeze
+	ID = "main/rev2875".freeze
 end


### PR DESCRIPTION
The `insecure_disable_https_redirect` build tag has been
renamed to `plain_http`. This commit is a part of the work
involving replacing the `dev` and `prod` build tags with more
granular options (started in #859).