### PR TITLE
cmd/md2html: parse all text content as templates

### DIFF
--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -151,7 +151,11 @@ func convert(args []string) {
 	dest := args[0]
 
 	fmt.Printf("Converting markdown to: %s\n", dest)
-	convertErr := filepath.Walk(".", func(path string, f os.FileInfo, err error) error {
+	convertErr := filepath.Walk(".", func(p string, f os.FileInfo, err error) error {
+		if strings.HasPrefix(path.Base(p), ".") {
+			return nil
+		}
+
 		if err != nil {
 			return err
 		}
@@ -161,7 +165,7 @@ func convert(args []string) {
 		}
 
 		var (
-			destFile = filepath.Join(dest, path)
+			destFile = filepath.Join(dest, p)
 			output   []byte
 		)
 
@@ -173,7 +177,7 @@ func convert(args []string) {
 			destFile = strings.TrimSuffix(destFile, ".html")
 		}
 
-		output, err = renderFile(path)
+		output, err = renderFile(p)
 		if err != nil {
 			return err
 		}
@@ -193,11 +197,12 @@ func convert(args []string) {
 			return err
 		}
 
-		fmt.Printf("converted: %s\n", path)
+		fmt.Printf("converted: %s\n", p)
 		return nil
 	})
 
 	if convertErr != nil {
+		fmt.Println(convertErr)
 		os.Exit(1)
 	}
 }

--- a/cmd/md2html/main.go
+++ b/cmd/md2html/main.go
@@ -219,16 +219,16 @@ func renderFile(p string) ([]byte, error) {
 		return nil, err
 	}
 
-	skipExtensions := make(map[string]bool)
-	for _, v := range []string{".ttf", ".otf", ".woff", ".eot", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".mov"} {
-		skipExtensions[v] = true
+	templateExtensions := make(map[string]bool)
+	for _, v := range []string{".md", ".html", ".js", ".css"} {
+		templateExtensions[v] = true
 	}
 
 	if strings.HasSuffix(p, ".md") {
 		content, err = renderMarkdown(p, content)
 	} else if strings.HasSuffix(p, ".partial.html") {
 		content, err = renderLayout(p, content)
-	} else if !skipExtensions[filepath.Ext(p)] {
+	} else if templateExtensions[filepath.Ext(p)] {
 		content, err = renderTemplate(p, []byte{}, content)
 	}
 

--- a/docs/core/get-started/install.partial.html
+++ b/docs/core/get-started/install.partial.html
@@ -36,7 +36,7 @@
           <p>
             <a href="https://download.chain.com/mac/Chain_Core_Latest.zip" onclick="track('download-app','mac')" class="downloadBtn btn success">
               Download App
-              <img src="/docs/images/download-icon.png" class="btn-icon icon-download">
+              <img src="/docs/{{.VersionPath}}images/download-icon.png" class="btn-icon icon-download">
             </a>
           </p>
 
@@ -50,7 +50,7 @@
           <p>
             <a href="https://download.chain.com/windows/Chain_Core_Latest.exe" onclick="track('download-app','windows')" class="downloadBtn btn success">
               Download Installer
-              <img src="/docs/images/download-icon.png" class="btn-icon icon-download">
+              <img src="/docs/{{.VersionPath}}images/download-icon.png" class="btn-icon icon-download">
             </a>
           </p>
 
@@ -82,7 +82,7 @@
             requests.
           <p><strong>If you are running the latest version of Docker on Windows 10, you can skip this step.</strong></p>
           <p>
-            <video src="/docs/images/vitualbox-config.mov" controls width=100%></video>
+            <video src="/docs/{{.VersionPath}}images/vitualbox-config.mov" controls width=100%></video>
           </p>
 
         </div>
@@ -111,7 +111,7 @@
 
 <div id="downloadModal" class="modal md-modal md-effect-1">
   <div class="modal-content">
-    <span class="close"><img src="/docs/images/close.png" class="close-icon"> </span>
+    <span class="close"><img src="/docs/{{.VersionPath}}images/close.png" class="close-icon"> </span>
     <div class="form-container">
       <div class="modal-title ">Stay up to date with Chain Core</div>
       <p class="modal-subtitle">We're constantly developing new features and we want you to be the first to try them. Enter your email

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -3,7 +3,7 @@
 
 @font-face {
     font-family: 'Nitti-Normal';
-    src: url('/docs/{{.VersionPath}}{{.VersionPath}}fonts/Nitti-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/Nitti-Normal.otf')  format('opentype'),
+    src: url('/docs/{{.VersionPath}}fonts/Nitti-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/Nitti-Normal.otf')  format('opentype'),
     url('/docs/{{.VersionPath}}fonts/Nitti-Normal.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/Nitti-Normal.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/Nitti-Normal.svg#Nitti-Normal') format('svg');
     font-weight: normal;
     font-style: normal;

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -3,40 +3,40 @@
 
 @font-face {
     font-family: 'Nitti-Normal';
-    src: url('/docs/fonts/Nitti-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/Nitti-Normal.otf')  format('opentype'),
-    url('/docs/fonts/Nitti-Normal.woff') format('woff'), url('/docs/fonts/Nitti-Normal.ttf')  format('truetype'), url('/docs/fonts/Nitti-Normal.svg#Nitti-Normal') format('svg');
+    src: url('/docs/{{.VersionPath}}{{.VersionPath}}fonts/Nitti-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/Nitti-Normal.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/Nitti-Normal.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/Nitti-Normal.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/Nitti-Normal.svg#Nitti-Normal') format('svg');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Nitti-Medium';
-    src: url('/docs/fonts/Nitti-Medium.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/Nitti-Medium.otf')  format('opentype'),
-    url('/docs/fonts/Nitti-Medium.woff') format('woff'), url('/docs/fonts/Nitti-Medium.ttf')  format('truetype'), url('/docs/fonts/Nitti-Medium.svg#Nitti-Medium') format('svg');
+    src: url('/docs/{{.VersionPath}}fonts/Nitti-Medium.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/Nitti-Medium.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/Nitti-Medium.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/Nitti-Medium.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/Nitti-Medium.svg#Nitti-Medium') format('svg');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'NittiGrotesk-Normal';
-    src: url('/docs/fonts/NittiGrotesk-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/NittiGrotesk-Normal.otf')  format('opentype'),
-    url('/docs/fonts/NittiGrotesk-Normal.woff') format('woff'), url('/docs/fonts/NittiGrotesk-Normal.ttf')  format('truetype'), url('/docs/fonts/NittiGrotesk-Normal.svg#NittiGrotesk-Normal') format('svg');
+    src: url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.svg#NittiGrotesk-Normal') format('svg');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'NittiGrotesk-Medium';
-    src: url('/docs/fonts/NittiGrotesk-Medium.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/NittiGrotesk-Medium.otf')  format('opentype'),
-    url('/docs/fonts/NittiGrotesk-Medium.woff') format('woff'), url('/docs/fonts/NittiGrotesk-Medium.ttf')  format('truetype'), url('/docs/fonts/NittiGrotesk-Medium.svg#NittiGrotesk-Medium') format('svg');
+    src: url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.svg#NittiGrotesk-Medium') format('svg');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'NittiGrotesk-Bold';
-    src: url('/docs/fonts/NittiGrotesk-Bold.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/NittiGrotesk-Bold.otf')  format('opentype'),
-    url('/docs/fonts/NittiGrotesk-Bold.woff') format('woff'), url('/docs/fonts/NittiGrotesk-Bold.ttf')  format('truetype'), url('/docs/fonts/NittiGrotesk-Bold.svg#NittiGrotesk-Bold') format('svg');
+    src: url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.svg#NittiGrotesk-Bold') format('svg');
     font-weight: normal;
     font-style: normal;
 }

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -63,15 +63,9 @@
         <li>
           <a class="toggle" href="javascript:void(0);">Reference</a>
           <ul class="inner">
-<<<<<<< Updated upstream
-            <li><a href="/docs/java/javadoc/index.html" target="_blank" class="skip-next-up">Java SDK</a></li>
-            <li><a href="/docs/node/doc/index.html" target="_blank" class="skip-next-up">Node SDK</a></li>
-            <li><a href="/docs/ruby/doc/index.html" target="_blank" class="skip-next-up">Ruby SDK</a></li>
-=======
             <li><a href="/docs/{{.VersionPath}}java/javadoc/index.html" target="_blank" class="skip-next-up">Java SDK</a></li>
             <li><a href="/docs/{{.VersionPath}}node/doc/index.html" target="_blank" class="skip-next-up">Node SDK</a></li>
             <li><a href="/docs/{{.VersionPath}}ruby/doc/index.html" target="_blank" class="skip-next-up">Ruby SDK</a></li>
->>>>>>> Stashed changes
             <li><a href="/docs/{{.VersionPath}}core/reference/versioning">Versioning</a></li>
             <li><a href="/docs/{{.VersionPath}}core/reference/api-objects">API Objects</a></li>
             <li><a href="/docs/{{.VersionPath}}core/reference/license" class="skip-next-up">License</a></li>

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/docs/{{.VersionPath}}css/style.css">
   <link rel="stylesheet" href="/docs/{{.VersionPath}}css/prettify.css">
   <script src="/docs/{{.VersionPath}}js/jquery.min.js"></script>
-  <script src="/docs{{.VersionPath}}js/layout.js"></script>
+  <script src="/docs/{{.VersionPath}}js/layout.js"></script>
   <script src="/docs/{{.VersionPath}}js/init.js"></script>
   <script src="/docs/{{.VersionPath}}js/codeSelector.js"></script>
   <meta name="viewport" content="width=1060">

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -5,12 +5,12 @@
   <meta name="description" content="">
   <meta name="viewport" content ="width=device-width,initial-scale=1,user-scalable=yes" />
   <title>Chain Documentation</title>
-  <link rel="stylesheet" href="/docs/css/style.css">
-  <link rel="stylesheet" href="/docs/css/prettify.css">
-  <script src="/docs/js/jquery.min.js"></script>
-  <script src="/docs/js/layout.js"></script>
-  <script src="/docs/js/init.js"></script>
-  <script src="/docs/js/codeSelector.js"></script>
+  <link rel="stylesheet" href="/docs/{{.VersionPath}}css/style.css">
+  <link rel="stylesheet" href="/docs/{{.VersionPath}}css/prettify.css">
+  <script src="/docs/{{.VersionPath}}js/jquery.min.js"></script>
+  <script src="/docs{{.VersionPath}}js/layout.js"></script>
+  <script src="/docs/{{.VersionPath}}js/init.js"></script>
+  <script src="/docs/{{.VersionPath}}js/codeSelector.js"></script>
   <meta name="viewport" content="width=1060">
 </head>
 <body>
@@ -18,7 +18,7 @@
   <div id="side-nav">
     <div class="row">
       <div class="brand">
-        <a class="mainsite" href="https://chain.com" title="Chain"><img src="/docs/images/chain-brand.png"> </a>
+        <a class="mainsite" href="https://chain.com" title="Chain"><img src="/docs/{{.VersionPath}}images/chain-brand.png"> </a>
         <a class="subsite" href="/docs">Docs</a>
       </div>
     </div>
@@ -63,9 +63,15 @@
         <li>
           <a class="toggle" href="javascript:void(0);">Reference</a>
           <ul class="inner">
+<<<<<<< Updated upstream
             <li><a href="/docs/java/javadoc/index.html" target="_blank" class="skip-next-up">Java SDK</a></li>
             <li><a href="/docs/node/doc/index.html" target="_blank" class="skip-next-up">Node SDK</a></li>
             <li><a href="/docs/ruby/doc/index.html" target="_blank" class="skip-next-up">Ruby SDK</a></li>
+=======
+            <li><a href="/docs/{{.VersionPath}}java/javadoc/index.html" target="_blank" class="skip-next-up">Java SDK</a></li>
+            <li><a href="/docs/{{.VersionPath}}node/doc/index.html" target="_blank" class="skip-next-up">Node SDK</a></li>
+            <li><a href="/docs/{{.VersionPath}}ruby/doc/index.html" target="_blank" class="skip-next-up">Ruby SDK</a></li>
+>>>>>>> Stashed changes
             <li><a href="/docs/{{.VersionPath}}core/reference/versioning">Versioning</a></li>
             <li><a href="/docs/{{.VersionPath}}core/reference/api-objects">API Objects</a></li>
             <li><a href="/docs/{{.VersionPath}}core/reference/license" class="skip-next-up">License</a></li>
@@ -105,7 +111,7 @@
           <h2 data-backtitle="Back to">Up next</h2>
 
           <a href="" class="next-step"><span>Placeholder</span>
-            <img src="/docs/images/arrow-right.png" class="btn-icon icon-next">
+            <img src="/docs/{{.VersionPath}}images/arrow-right.png" class="btn-icon icon-next">
           </a>
 
         </div>

--- a/docs/protocol/specifications/txgraph-draft.md
+++ b/docs/protocol/specifications/txgraph-draft.md
@@ -168,7 +168,7 @@ domain separation, prob)
     1. Let `src` be `nextentry.sources[destination.position]`. Fail if not present.
 6. Validate next entry’s source `src`:
     1. Validate that `src.ref` == `self.id`.
-    2. Validate that `src.position` == `0` (this is value's position in the spend). 
+    2. Validate that `src.position` == `0` (this is value's position in the spend).
     3. Validate that `src.value` == `self.spent_output.source.value`.
 7. The `spent_output.program` must evaluate to `true` with given `arguments`.
 8. Remove `spent_output` from UTXO set.
@@ -206,7 +206,7 @@ NB: `spent_output` is not validated, as it was already validated in the transact
     1. Let `src` be `nextentry.sources[destination.position]`. Fail if not present.
 6. Validate next entry’s source `src`:
     1. Validate that `src.ref` == `self.id`.
-    2. Validate that `src.position` == `0` (this is value's position in the input). 
+    2. Validate that `src.position` == `0` (this is value's position in the input).
     3. Validate that `src.value` == `self.value`.
 
 
@@ -237,7 +237,7 @@ NB: `spent_output` is not validated, as it was already validated in the transact
         1. Let `src` be `nextentry.sources[dest.position]`. Fail if not present.
     4. Validate next entry’s source `src`:    
         1. Validate that `src.ref` == `self.id`.
-        2. Validate that `src.position` == `i` (this is value's position in this mux's destinations list). 
+        2. Validate that `src.position` == `i` (this is value's position in this mux's destinations list).
         3. Validate that `src.value` == `dest.value`.
         4. Pull the AssetAmount `a` from that `src` and assign it to the `dest`.
 4. For each asset ID in the `sources` and `destinations`:
@@ -579,7 +579,7 @@ TODO: ...
 
 ### 3. VM mapping
 
-This shows how the implementation of each of the VM instructions need to be changed. Ones that say "no change" will work as already implemented on the OLD data structure. 
+This shows how the implementation of each of the VM instructions need to be changed. Ones that say "no change" will work as already implemented on the OLD data structure.
 
 * CHECKOUTPUT:   no change
 * ASSET:         no change
@@ -605,7 +605,7 @@ New opcodes:
 
 For simplicity and flexibility, we are removing the commitments to both the transaction witnesses and the block witness.
 
-1. The [transactions Merkle root](https://chain.com/docs/protocol/specifications/data#transactions-merkle-root) should be calculated based on the transaction IDs, rather than the transaction witness hashes. The code for calculating the transaction witness hashes can be eliminated.
+1. The [transactions Merkle root](https://chain.com/docs/{{.VersionPath}}protocol/specifications/data#transactions-merkle-root) should be calculated based on the transaction IDs, rather than the transaction witness hashes. The code for calculating the transaction witness hashes can be eliminated.
 
 2. `Block ID` (which is the ID included in the next block, and which currently includes the hash of the block witness) should be computed instead to be identical to how the block signature hash is currently computed (i.e., it should use 0x00 serialization flags).
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2876";
+	public final String Id = "main/rev2877";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2876"
+const ID string = "main/rev2877"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2876"
+export const rev_id = "main/rev2877"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2876".freeze
+	ID = "main/rev2877".freeze
 end


### PR DESCRIPTION
For layouts, the content variable is parsed first as its own template, followed 
by the layout with the newly updated content.

Valid filetypes are whitelisted for template processing. All others are passed 
through without processing.