### PR TITLE
docs: add version prefix

### DIFF
--- a/cmd/md2html/doc.go
+++ b/cmd/md2html/doc.go
@@ -5,13 +5,13 @@ For each markdown file in the current directory, md2html will convert
 the markdown to html and write the resulting html to a file of
 the same name in the destination directory.
 
-If there is a file named layout.html which contains `{{Body}}`
+If there is a file named layout.html which contains `{{.Body}}`
 in the current directory, md2html use that data to wrap the html output
 of the converted markdown.
 
 Usage
 
-	md2html [destination]
+	md2html [-prefix <major>.<minor>] build DEST_PATH
 
 
 	destination - address or directory
@@ -30,12 +30,7 @@ Example
 
 Start a server in the current directory:
 
-	$ md2html
-
-Copy all files --and convert .md to HTML-- in the current directory and
-write them to ~/site:
-
-	$ md2html ~/site
+	$ md2html [-prefix <major>.<minor>] serve [port]
 
 Code Interpolation
 

--- a/docs/core/get-started/install.partial.html
+++ b/docs/core/get-started/install.partial.html
@@ -36,7 +36,7 @@
           <p>
             <a href="https://download.chain.com/mac/Chain_Core_Latest.zip" onclick="track('download-app','mac')" class="downloadBtn btn success">
               Download App
-              <img src="/docs/images/download-icon.png" class="btn-icon icon-download">
+              <img src="/docs/{{.VersionPath}}images/download-icon.png" class="btn-icon icon-download">
             </a>
           </p>
 
@@ -50,7 +50,7 @@
           <p>
             <a href="https://download.chain.com/windows/Chain_Core_Latest.exe" onclick="track('download-app','windows')" class="downloadBtn btn success">
               Download Installer
-              <img src="/docs/images/download-icon.png" class="btn-icon icon-download">
+              <img src="/docs/{{.VersionPath}}images/download-icon.png" class="btn-icon icon-download">
             </a>
           </p>
 
@@ -82,7 +82,7 @@
             requests.
           <p><strong>If you are running the latest version of Docker on Windows 10, you can skip this step.</strong></p>
           <p>
-            <video src="/docs/images/vitualbox-config.mov" controls width=100%></video>
+            <video src="/docs/{{.VersionPath}}images/vitualbox-config.mov" controls width=100%></video>
           </p>
 
         </div>
@@ -111,7 +111,7 @@
 
 <div id="downloadModal" class="modal md-modal md-effect-1">
   <div class="modal-content">
-    <span class="close"><img src="/docs/images/close.png" class="close-icon"> </span>
+    <span class="close"><img src="/docs/{{.VersionPath}}images/close.png" class="close-icon"> </span>
     <div class="form-container">
       <div class="modal-title ">Stay up to date with Chain Core</div>
       <p class="modal-subtitle">We're constantly developing new features and we want you to be the first to try them. Enter your email

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -3,40 +3,40 @@
 
 @font-face {
     font-family: 'Nitti-Normal';
-    src: url('/docs/fonts/Nitti-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/Nitti-Normal.otf')  format('opentype'),
-    url('/docs/fonts/Nitti-Normal.woff') format('woff'), url('/docs/fonts/Nitti-Normal.ttf')  format('truetype'), url('/docs/fonts/Nitti-Normal.svg#Nitti-Normal') format('svg');
+    src: url('/docs/{{.VersionPath}}fonts/Nitti-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/Nitti-Normal.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/Nitti-Normal.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/Nitti-Normal.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/Nitti-Normal.svg#Nitti-Normal') format('svg');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Nitti-Medium';
-    src: url('/docs/fonts/Nitti-Medium.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/Nitti-Medium.otf')  format('opentype'),
-    url('/docs/fonts/Nitti-Medium.woff') format('woff'), url('/docs/fonts/Nitti-Medium.ttf')  format('truetype'), url('/docs/fonts/Nitti-Medium.svg#Nitti-Medium') format('svg');
+    src: url('/docs/{{.VersionPath}}fonts/Nitti-Medium.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/Nitti-Medium.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/Nitti-Medium.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/Nitti-Medium.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/Nitti-Medium.svg#Nitti-Medium') format('svg');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'NittiGrotesk-Normal';
-    src: url('/docs/fonts/NittiGrotesk-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/NittiGrotesk-Normal.otf')  format('opentype'),
-    url('/docs/fonts/NittiGrotesk-Normal.woff') format('woff'), url('/docs/fonts/NittiGrotesk-Normal.ttf')  format('truetype'), url('/docs/fonts/NittiGrotesk-Normal.svg#NittiGrotesk-Normal') format('svg');
+    src: url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Normal.svg#NittiGrotesk-Normal') format('svg');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'NittiGrotesk-Medium';
-    src: url('/docs/fonts/NittiGrotesk-Medium.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/NittiGrotesk-Medium.otf')  format('opentype'),
-    url('/docs/fonts/NittiGrotesk-Medium.woff') format('woff'), url('/docs/fonts/NittiGrotesk-Medium.ttf')  format('truetype'), url('/docs/fonts/NittiGrotesk-Medium.svg#NittiGrotesk-Medium') format('svg');
+    src: url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Medium.svg#NittiGrotesk-Medium') format('svg');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'NittiGrotesk-Bold';
-    src: url('/docs/fonts/NittiGrotesk-Bold.eot?#iefix') format('embedded-opentype'),  url('/docs/fonts/NittiGrotesk-Bold.otf')  format('opentype'),
-    url('/docs/fonts/NittiGrotesk-Bold.woff') format('woff'), url('/docs/fonts/NittiGrotesk-Bold.ttf')  format('truetype'), url('/docs/fonts/NittiGrotesk-Bold.svg#NittiGrotesk-Bold') format('svg');
+    src: url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.eot?#iefix') format('embedded-opentype'),  url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.otf')  format('opentype'),
+    url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.woff') format('woff'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.ttf')  format('truetype'), url('/docs/{{.VersionPath}}fonts/NittiGrotesk-Bold.svg#NittiGrotesk-Bold') format('svg');
     font-weight: normal;
     font-style: normal;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=/docs/core/get-started/introduction">
+    <meta http-equiv="refresh" content="0; url=/docs/{{.VersionPath}}core/get-started/introduction">
   </head>
 </html>

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -5,12 +5,12 @@
   <meta name="description" content="">
   <meta name="viewport" content ="width=device-width,initial-scale=1,user-scalable=yes" />
   <title>Chain Documentation</title>
-  <link rel="stylesheet" href="/docs/css/style.css">
-  <link rel="stylesheet" href="/docs/css/prettify.css">
-  <script src="/docs/js/jquery.min.js"></script>
-  <script src="/docs/js/layout.js"></script>
-  <script src="/docs/js/init.js"></script>
-  <script src="/docs/js/codeSelector.js"></script>
+  <link rel="stylesheet" href="/docs/{{.VersionPath}}css/style.css">
+  <link rel="stylesheet" href="/docs/{{.VersionPath}}css/prettify.css">
+  <script src="/docs/{{.VersionPath}}js/jquery.min.js"></script>
+  <script src="/docs/{{.VersionPath}}js/layout.js"></script>
+  <script src="/docs/{{.VersionPath}}js/init.js"></script>
+  <script src="/docs/{{.VersionPath}}js/codeSelector.js"></script>
   <meta name="viewport" content="width=1060">
 </head>
 <body>
@@ -18,7 +18,7 @@
   <div id="side-nav">
     <div class="row">
       <div class="brand">
-        <a class="mainsite" href="https://chain.com" title="Chain"><img src="/docs/images/chain-brand.png"> </a>
+        <a class="mainsite" href="https://chain.com" title="Chain"><img src="/docs/{{.VersionPath}}images/chain-brand.png"> </a>
         <a class="subsite" href="/docs">Docs</a>
       </div>
     </div>
@@ -63,9 +63,9 @@
         <li>
           <a class="toggle" href="javascript:void(0);">Reference</a>
           <ul class="inner">
-            <li><a href="/docs/java/javadoc/index.html" target="_blank" class="skip-next-up">Java SDK</a></li>
-            <li><a href="/docs/node/doc/index.html" target="_blank" class="skip-next-up">Node SDK</a></li>
-            <li><a href="/docs/ruby/doc/index.html" target="_blank" class="skip-next-up">Ruby SDK</a></li>
+            <li><a href="/docs/{{.VersionPath}}java/javadoc/index.html" target="_blank" class="skip-next-up">Java SDK</a></li>
+            <li><a href="/docs/{{.VersionPath}}node/doc/index.html" target="_blank" class="skip-next-up">Node SDK</a></li>
+            <li><a href="/docs/{{.VersionPath}}ruby/doc/index.html" target="_blank" class="skip-next-up">Ruby SDK</a></li>
             <li><a href="/docs/{{.VersionPath}}core/reference/versioning">Versioning</a></li>
             <li><a href="/docs/{{.VersionPath}}core/reference/api-objects">API Objects</a></li>
             <li><a href="/docs/{{.VersionPath}}core/reference/license" class="skip-next-up">License</a></li>
@@ -105,7 +105,7 @@
           <h2 data-backtitle="Back to">Up next</h2>
 
           <a href="" class="next-step"><span>Placeholder</span>
-            <img src="/docs/images/arrow-right.png" class="btn-icon icon-next">
+            <img src="/docs/{{.VersionPath}}images/arrow-right.png" class="btn-icon icon-next">
           </a>
 
         </div>

--- a/docs/layout.html
+++ b/docs/layout.html
@@ -29,35 +29,35 @@
         <li>
           <a class="toggle" href="javascript:void(0);">Get Started</a>
           <ul class="inner">
-            <li><a href="/docs/core/get-started/introduction">Introduction</a></li>
-            <li><a href="/docs/core/get-started/install" title="Install Chain Core">Install</a></li>
-            <li><a href="/docs/core/get-started/sdk" title="Download SDK">SDK</a></li>
-            <li><a href="/docs/core/get-started/configure" title="Configure Chain Core">Configure</a></li>
-            <li><a href="/docs/core/get-started/five-minute-guide">5-Minute Guide</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/introduction">Introduction</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/install" title="Install Chain Core">Install</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/sdk" title="Download SDK">SDK</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/configure" title="Configure Chain Core">Configure</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/get-started/five-minute-guide">5-Minute Guide</a></li>
           </ul>
         </li>
         <li>
           <a class="toggle" href="javascript:void(0);">Build Applications</a>
           <ul class="inner">
-            <li><a href="/docs/core/build-applications/keys">Keys</a></li>
-            <li><a href="/docs/core/build-applications/assets">Assets</a></li>
-            <li><a href="/docs/core/build-applications/accounts">Accounts</a></li>
-            <li><a href="/docs/core/build-applications/transaction-basics">Transaction Basics</a></li>
-            <li><a href="/docs/core/build-applications/unspent-outputs">Unspent Outputs</a></li>
-            <li><a href="/docs/core/build-applications/control-programs">Control Programs</a></li>
-            <li><a href="/docs/core/build-applications/queries">Queries</a></li>
-            <li><a href="/docs/core/build-applications/multiparty-trades">Multiparty Trades</a></li>
-            <li><a href="/docs/core/build-applications/real-time-transaction-processing">Real-time Processing</a></li>
-            <li><a href="/docs/core/build-applications/batch-operations">Batch Operations</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/keys">Keys</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/assets">Assets</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/accounts">Accounts</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/transaction-basics">Transaction Basics</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/unspent-outputs">Unspent Outputs</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/control-programs">Control Programs</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/queries">Queries</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/multiparty-trades">Multiparty Trades</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/real-time-transaction-processing">Real-time Processing</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/build-applications/batch-operations">Batch Operations</a></li>
           </ul>
         </li>
         <li>
           <a class="toggle" href="javascript:void(0);">Learn More</a>
           <ul class="inner">
-            <li><a href="/docs/core/learn-more/global-vs-local-data">Global vs Local Data</a></li>
-            <li><a href="/docs/core/learn-more/authentication" title="Authentication">Authentication</a></li>
-            <li><a href="/docs/core/learn-more/blockchain-operators">Blockchain Operators</a></li>
-            <li><a href="/docs/core/learn-more/blockchain-participants">Blockchain Participants</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/learn-more/global-vs-local-data">Global vs Local Data</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/learn-more/authentication" title="Authentication">Authentication</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/learn-more/blockchain-operators">Blockchain Operators</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/learn-more/blockchain-participants">Blockchain Participants</a></li>
           </ul>
         </li>
         <li>
@@ -66,9 +66,9 @@
             <li><a href="/docs/java/javadoc/index.html" target="_blank" class="skip-next-up">Java SDK</a></li>
             <li><a href="/docs/node/doc/index.html" target="_blank" class="skip-next-up">Node SDK</a></li>
             <li><a href="/docs/ruby/doc/index.html" target="_blank" class="skip-next-up">Ruby SDK</a></li>
-            <li><a href="/docs/core/reference/versioning">Versioning</a></li>
-            <li><a href="/docs/core/reference/api-objects">API Objects</a></li>
-            <li><a href="/docs/core/reference/license" class="skip-next-up">License</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/reference/versioning">Versioning</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/reference/api-objects">API Objects</a></li>
+            <li><a href="/docs/{{.VersionPath}}core/reference/license" class="skip-next-up">License</a></li>
           </ul>
         </li>
 
@@ -76,20 +76,20 @@
         <li>
           <a class="toggle" href="javascript:void(0);">Papers</a>
           <ul class="inner">
-            <li><a href="/docs/protocol/papers/whitepaper">Whitepaper</a></li>
-            <li><a href="/docs/protocol/papers/federated-consensus">Federated Consensus</a></li>
-            <li><a href="/docs/protocol/papers/blockchain-programs">Blockchain Programs</a></li>
-            <li><a href="/docs/protocol/papers/blockchain-extensibility">Blockchain Extensibility</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/papers/whitepaper">Whitepaper</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/papers/federated-consensus">Federated Consensus</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/papers/blockchain-programs">Blockchain Programs</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/papers/blockchain-extensibility">Blockchain Extensibility</a></li>
           </ul>
         </li>
         <li>
           <a class="toggle" href="javascript:void(0);">Specifications</a>
           <ul class="inner">
-            <li><a href="/docs/protocol/specifications/data" title="Data Model Specification">Data Model</a></li>
-            <li><a href="/docs/protocol/specifications/validation" title="Validation Specification">Validation</a></li>
-            <li><a href="/docs/protocol/specifications/consensus"  title="Consensus Specification">Consensus</a></li>
-            <li><a href="/docs/protocol/specifications/vm1" title="Virtual Machine Specification">Virtual Machine</a></li>
-            <li><a href="/docs/protocol/specifications/chainkd" title="Chain Key Derivation Specification">ChainKD</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/data" title="Data Model Specification">Data Model</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/validation" title="Validation Specification">Validation</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/consensus"  title="Consensus Specification">Consensus</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/vm1" title="Virtual Machine Specification">Virtual Machine</a></li>
+            <li><a href="/docs/{{.VersionPath}}protocol/specifications/chainkd" title="Chain Key Derivation Specification">ChainKD</a></li>
           </ul>
         </li>
       </ul>
@@ -97,8 +97,8 @@
     </div>
   </div>
   <div id="doc-wrapper" tabindex="0">
-    <article id="doc-content" class="{{Filename}}">
-      {{Body}}
+    <article id="doc-content" class="{{.Filename}}">
+      {{.Body}}
 
       <footer>
         <div id="up-next" style="display:none">

--- a/docs/protocol/specifications/txgraph-draft.md
+++ b/docs/protocol/specifications/txgraph-draft.md
@@ -168,7 +168,7 @@ domain separation, prob)
     1. Let `src` be `nextentry.sources[destination.position]`. Fail if not present.
 6. Validate next entry’s source `src`:
     1. Validate that `src.ref` == `self.id`.
-    2. Validate that `src.position` == `0` (this is value's position in the spend). 
+    2. Validate that `src.position` == `0` (this is value's position in the spend).
     3. Validate that `src.value` == `self.spent_output.source.value`.
 7. The `spent_output.program` must evaluate to `true` with given `arguments`.
 8. Remove `spent_output` from UTXO set.
@@ -206,7 +206,7 @@ NB: `spent_output` is not validated, as it was already validated in the transact
     1. Let `src` be `nextentry.sources[destination.position]`. Fail if not present.
 6. Validate next entry’s source `src`:
     1. Validate that `src.ref` == `self.id`.
-    2. Validate that `src.position` == `0` (this is value's position in the input). 
+    2. Validate that `src.position` == `0` (this is value's position in the input).
     3. Validate that `src.value` == `self.value`.
 
 
@@ -237,7 +237,7 @@ NB: `spent_output` is not validated, as it was already validated in the transact
         1. Let `src` be `nextentry.sources[dest.position]`. Fail if not present.
     4. Validate next entry’s source `src`:    
         1. Validate that `src.ref` == `self.id`.
-        2. Validate that `src.position` == `i` (this is value's position in this mux's destinations list). 
+        2. Validate that `src.position` == `i` (this is value's position in this mux's destinations list).
         3. Validate that `src.value` == `dest.value`.
         4. Pull the AssetAmount `a` from that `src` and assign it to the `dest`.
 4. For each asset ID in the `sources` and `destinations`:
@@ -579,7 +579,7 @@ TODO: ...
 
 ### 3. VM mapping
 
-This shows how the implementation of each of the VM instructions need to be changed. Ones that say "no change" will work as already implemented on the OLD data structure. 
+This shows how the implementation of each of the VM instructions need to be changed. Ones that say "no change" will work as already implemented on the OLD data structure.
 
 * CHECKOUTPUT:   no change
 * ASSET:         no change
@@ -605,7 +605,7 @@ New opcodes:
 
 For simplicity and flexibility, we are removing the commitments to both the transaction witnesses and the block witness.
 
-1. The [transactions Merkle root](https://chain.com/docs/protocol/specifications/data#transactions-merkle-root) should be calculated based on the transaction IDs, rather than the transaction witness hashes. The code for calculating the transaction witness hashes can be eliminated.
+1. The [transactions Merkle root](https://chain.com/docs/{{.VersionPath}}protocol/specifications/data#transactions-merkle-root) should be calculated based on the transaction IDs, rather than the transaction witness hashes. The code for calculating the transaction witness hashes can be eliminated.
 
 2. `Block ID` (which is the ID included in the next block, and which currently includes the hash of the block witness) should be computed instead to be identical to how the block signature hash is currently computed (i.e., it should use 0x00 serialization flags).
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "1.1-stable/rev2754";
+	public final String Id = "1.1-stable/rev2755";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.1-stable/rev2754"
+const ID string = "1.1-stable/rev2755"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,0 +1,2 @@
+
+export const rev_id = "1.1-stable/rev2755"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,0 +1,4 @@
+
+module Chain::Rev
+	ID = "1.1-stable/rev2755".freeze
+end


### PR DESCRIPTION
Backport of #852 and #866 from main. 

Includes version strings in documentation templates, and an updated
`md2html` supporting template substitution.