### PR TITLE
sdk/node: transactionFeeds use correct MAX_BLOCK_HEIGHT

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "1.0-stable/rev2504";
+	public final String Id = "1.0-stable/rev2505";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.0-stable/rev2504"
+const ID string = "1.0-stable/rev2505"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "1.0-stable/rev2504"
+export const rev_id = "1.0-stable/rev2505"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "1.0-stable/rev2504".freeze
+	ID = "1.0-stable/rev2505".freeze
 end

--- a/sdk/node/src/api/transactionFeeds.js
+++ b/sdk/node/src/api/transactionFeeds.js
@@ -1,7 +1,12 @@
 const shared = require('../shared')
 
 const uuid = require('uuid')
-const MAX_BLOCK_HEIGHT = (2 * 63) - 1
+
+/**
+ * Hardcoding value of (2 ** 63) - 1 since JavaScript rounds this value up,
+ * which causes issues when attempting to query TransactionFeed.
+ */
+const MAX_BLOCK_HEIGHT = '9223372036854775807'
 
 /**
  * @class


### PR DESCRIPTION
reported by @Tkwon123

backport of #875