### PR TITLE
docs: improve version string parsing

### DIFF
--- a/docs/js/layout.js
+++ b/docs/js/layout.js
@@ -167,11 +167,12 @@ function fixupSidenotes() {
 
 function loadVersionOptions() {
 	var currentVersion
-	var matchedVersion = location.pathname.match('/docs/([0-9].*)/core')
+	var matchedVersion = location.pathname.match('/docs/([0-9]\\.[0-9])/')
 	if (matchedVersion) {
 		currentVersion = matchedVersion[1]
 	} else {
-		currentVersion = "x.y"
+		$('#version-select').remove()
+		return
 	}
 
 	var versions = window.documentationVersions

--- a/docs/js/layout.js
+++ b/docs/js/layout.js
@@ -167,10 +167,12 @@ function fixupSidenotes() {
 
 function loadVersionOptions() {
 	var currentVersion
-	var matchedVersion = location.pathname.match('/docs/([0-9]\\.[0-9])/')
+	var matchedVersion = location.pathname.match('/docs/(\\d+\\.\\d+)/')
 	if (matchedVersion) {
 		currentVersion = matchedVersion[1]
 	} else {
+		// When running docs without a numeric prefix (i.e. local development)
+		// hide the version selector and the legacy version alert.
 		$('#version-select').remove()
 		return
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "1.0-stable/rev2507";
+	public final String Id = "1.0-stable/rev2508";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.0-stable/rev2507"
+const ID string = "1.0-stable/rev2508"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "1.0-stable/rev2507"
+export const rev_id = "1.0-stable/rev2508"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "1.0-stable/rev2507".freeze
+	ID = "1.0-stable/rev2508".freeze
 end


### PR DESCRIPTION
Previous regex relied on the presence of `/core` in the
URL. This prevented the correct version from being detected
on multiple paths.

Backport of #883