### PR TITLE
docker/ci: install Thales CodeSafe SDK

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -30,3 +30,4 @@ RUN yum -y update \
     && go get -u google.golang.org/grpc \
     && yum remove -y autoconf automake libtool gcc-c++ unzip \
     && yum clean all
+

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,5 +1,11 @@
 FROM centos:6
 
+# Do this in its own "layer" before everything else
+# because it will change rarely and it is huge (about 1.5GB).
+# This way it will be cached separately.
+COPY install/install-codesafe /tmp
+RUN /tmp/install-codesafe && rm -f /tmp/install-codesafe
+
 ENV CHAIN="/go/src/chain" \
     BUNDLE_APP_CONFIG="/usr/local/bundle" \
     GEM_HOME="/usr/local/bundle" \
@@ -8,7 +14,7 @@ ENV CHAIN="/go/src/chain" \
     JAVA_HOME="/opt/jdk1.7.0_79" \
     JRE_HOME="/opt/jdk1.7.0_79/jre" \
     MAVEN_HOME="/usr/share/maven" \
-    PATH="$PATH:/go/src/chain/docker/ci/bin/:/usr/local/bundle/bin:/go/bin:/usr/local/go/bin:/opt/jdk1.7.0_79/bin:/opt/jdk1.7.0_79/jre/bin"
+    PATH="$PATH:/go/src/chain/docker/ci/bin/:/usr/local/bundle/bin:/go/bin:/usr/local/go/bin:/opt/jdk1.7.0_79/bin:/opt/jdk1.7.0_79/jre/bin:/opt/nfast/bin"
 
 ADD install /usr/bin
 
@@ -24,4 +30,3 @@ RUN yum -y update \
     && go get -u google.golang.org/grpc \
     && yum remove -y autoconf automake libtool gcc-c++ unzip \
     && yum clean all
-

--- a/docker/ci/Readme.md
+++ b/docker/ci/Readme.md
@@ -4,6 +4,7 @@ This dockerfile produces the image used for continuous integration. Installed so
 - Java 1.7
 - Ruby 2.0.0
 - Node 4.8.0
+- CodeSafe 12.10.01
 - various build/test dependencies
 
 To update it, do:

--- a/docker/ci/install/install-codesafe
+++ b/docker/ci/install/install-codesafe
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eo pipefail
+cd /
+
+url=https://s3.amazonaws.com/chain-qa/CodeSafe-linux64-dev-12.10.01.tar.gz
+
+(
+	cd /tmp
+	curl -o CodeSafe.tar.gz "$url"
+	gunzip CodeSafe.tar.gz
+	sha256sum -c - <<-EOF
+	7c77b2c07749b19b3cc11f213f31753d1ec88c69ceb5a33c995152bf0b19b7df  CodeSafe.tar
+	EOF
+	tar xf CodeSafe.tar
+	rm CodeSafe.tar
+)
+
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/csd/agg.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/csdref/agg.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/ctls/agg.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/devref/agg.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/dsserv/user.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/gccsrc/ppcdev.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/hwcrhk/user.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/hwsp/agg.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/javasp/agg.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/jcecsp/user.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/jd/agg.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/ncsnmp/user.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/nhfw/agg.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/pkcs11/user.tar
+tar xf /tmp/CodeSafe-linux64/linux/libc6_11/amd64/nfast/ratls/agg.tar
+rm -rf /tmp/CodeSafe-linux64

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2910";
+	public final String Id = "main/rev2911";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2910"
+const ID string = "main/rev2911"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2910"
+export const rev_id = "main/rev2911"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2910".freeze
+	ID = "main/rev2911".freeze
 end

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20170407
+box: chaindev/ci:20170412
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 


### PR DESCRIPTION
This will allow us to test our production build targets.

Future work: update the test harness in chainprv to
check production builds.