### PR TITLE
cmd/slashland: support new GitHub merge API

### DIFF
--- a/cmd/slashland/main.go
+++ b/cmd/slashland/main.go
@@ -224,8 +224,8 @@ func land(req *landReq) {
 		CommitTitle   string `json:"commit_title"`
 		CommitMessage string `json:"commit_message"`
 		SHA           string `json:"sha"`
-		Squash        bool   `json:"squash"`
-	}{prState.Title, wrapMessage(body, 75), commit, true}
+		MergeMethod   string `json:"merge_method"`
+	}{prState.Title, wrapMessage(body, 75), commit, "squash"}
 	var mergeResp struct {
 		Merged  bool
 		Message string

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2887";
+	public final String Id = "main/rev2888";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2887"
+const ID string = "main/rev2888"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2887"
+export const rev_id = "main/rev2888"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2887".freeze
+	ID = "main/rev2888".freeze
 end


### PR DESCRIPTION
GitHub removed support for the squash property in merge
requests. They replaced it with a new property called
merge_method, which is an enum rather than a bool.

See https://developer.github.com/changes/2017-04-07-end-merge-methods-api-preview/.