### PR TITLE
analytics: add Oracle transaction importer

### DIFF
--- a/analytics/.gitignore
+++ b/analytics/.gitignore
@@ -1,0 +1,2 @@
+log
+target

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,0 +1,25 @@
+# Chain Analytics
+
+Chain Analytics is a separate java service for importing transactions into an Oracle database. It reads transactions through a Chain Core transaction feed, inserting them one-by-one into an Oracle database.
+
+## Setup
+
+These instructions assume you already have Oracle and Chain Core running locally.
+
+**Compile and package**
+
+```
+mvn install
+```
+
+**Run the daemon**
+
+The daemon takes two environment variables: the URL of Chain Core and the DSN of the Oracle database. Replace `<oracle-username>` and `<oracle-password>` with your Oracle username and password. If you're using the Oracle Developer DB VM, you should be able to use `system` and `oracle`.
+
+```
+export CHAIN_URL="http://localhost:1999"
+export DATABASE_URL="jdbc:oracle:thin:<oracle-username>/<oracle-password>@127.0.0.1:1521/orcl"
+java -cp "target/analytics-1.0.0-jar-with-dependencies.jar" analytics.Application
+```
+
+The daemon will automatically initialize the Oracle database with a schema, create a transaction feed and begin syncing transactions. Create a transaction in dashboard and verify that it's synced.

--- a/analytics/pom.xml
+++ b/analytics/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.chain</groupId>
+    <artifactId>analytics</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.oracle.jdbc</groupId>
+            <artifactId>ojdbc7</artifactId>
+            <version>12.1.0.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.jdbc</groupId>
+            <artifactId>ucp</artifactId>
+            <version>12.1.0.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.chain</groupId>
+            <artifactId>chain-sdk-java</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.mchange</groupId>
+            <artifactId>c3p0</artifactId>
+            <version>0.9.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.8.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.8.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <java.version>1.8</java.version>
+        <start-class>com.chain.analytics.Application</start-class>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                      <manifest>
+                        <mainClass>com.chain.analytics.Application</mainClass>
+                      </manifest>
+                    </archive>
+                    <descriptorRefs>
+                      <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/analytics/src/main/java/com/chain/analytics/Application.java
+++ b/analytics/src/main/java/com/chain/analytics/Application.java
@@ -39,12 +39,12 @@ public class Application {
   // importer uses.
   public static final String DEFAULT_FEED_ALIAS = "chain-analytics-importer";
 
-  private static Logger logger = LogManager.getLogger();
+  private static final Logger logger = LogManager.getLogger();
 
   public static void main(String args[]) {
-    String chainUrl = System.getenv(ENV_CHAIN_URL);
-    String chainToken = System.getenv(ENV_CHAIN_TOKEN);
-    String databaseUrl = System.getenv(ENV_DATABASE_URL);
+    final String chainUrl = System.getenv(ENV_CHAIN_URL);
+    final String chainToken = System.getenv(ENV_CHAIN_TOKEN);
+    final String databaseUrl = System.getenv(ENV_DATABASE_URL);
 
     if (chainUrl == null || "".equals(chainUrl)) {
       logger.fatal("missing {} environment variable", ENV_CHAIN_URL);
@@ -62,7 +62,7 @@ public class Application {
     Importer importer = null;
     try {
       Client.Builder clientBuilder =
-          new Client.Builder().addURL(chainUrl).setReadTimeout(60, TimeUnit.SECONDS);
+          new Client.Builder().addURL(chainUrl).setReadTimeout(120, TimeUnit.SECONDS);
       if (chainToken != null && chainToken.length() > 0) {
         clientBuilder.setAccessToken(chainToken);
       }

--- a/analytics/src/main/java/com/chain/analytics/Application.java
+++ b/analytics/src/main/java/com/chain/analytics/Application.java
@@ -1,0 +1,104 @@
+package analytics;
+
+import com.chain.exception.BadURLException;
+import com.chain.exception.ChainException;
+import com.chain.exception.ConnectivityException;
+import com.chain.exception.HTTPException;
+import com.chain.http.Client;
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+import java.beans.PropertyVetoException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+/**
+ * Application is the Main class for the Chain Analytics
+ * importing service.
+ */
+public class Application {
+    // TODO(jackson): Allow configuration of custom columns.
+
+    // Environment variable key to find the Chain Core's URL.
+    public static final String ENV_CHAIN_URL = "CHAIN_URL";
+
+    // Environment variable key to find the Chain Core access token
+    // to use, if any.
+    public static final String ENV_CHAIN_TOKEN = "CHAIN_ACCESS_TOKEN";
+
+    // Environment variable key to find the JDBC URL to use to connect
+    // to the Oracle database.
+    // Example: jdbc:oracle:thin:username/password@127.0.0.1:1521/orcl
+    public static final String ENV_DATABASE_URL = "DATABASE_URL";
+
+    // The alias of the Chain Core transaction feed that the
+    // importer uses.
+    public static final String DEFAULT_FEED_ALIAS = "chain-analytics-importer";
+
+    private static Logger logger = LogManager.getLogger();
+
+    public static void main(String args[]) {
+        String chainUrl = System.getenv(ENV_CHAIN_URL);
+        String chainToken = System.getenv(ENV_CHAIN_TOKEN);
+        String databaseUrl = System.getenv(ENV_DATABASE_URL);
+
+        if (chainUrl == null || "".equals(chainUrl)) {
+            logger.fatal("missing {} environment variable", ENV_CHAIN_URL);
+            System.exit(1);
+        }
+        if (databaseUrl == null || "".equals(databaseUrl)) {
+            logger.fatal("missing {} environment variable", ENV_DATABASE_URL);
+            System.exit(1);
+        }
+
+        //
+        // Setup the importer. The majority of connectivity and
+        // configuration errors should be caught here.
+        //
+        Importer importer = null;
+        try {
+            Client.Builder clientBuilder = new Client.Builder()
+                .addURL(chainUrl)
+                .setReadTimeout(60, TimeUnit.SECONDS);
+            if (chainToken != null && chainToken.length() > 0) {
+                clientBuilder.setAccessToken(chainToken);
+            }
+            final Client client = clientBuilder.build();
+
+            // Use a connection pool.
+            ComboPooledDataSource ds = new ComboPooledDataSource();
+            ds.setDriverClass("oracle.jdbc.driver.OracleDriver");
+            ds.setJdbcUrl(databaseUrl);
+            ds.setTestConnectionOnCheckout(true);
+
+            importer = Importer.connect(client, ds, DEFAULT_FEED_ALIAS);
+        } catch(BadURLException ex) {
+            logger.fatal(
+                    "Unable to parse the Chain Core URL provided \"{}\".",
+                    chainUrl, ex);
+            System.exit(1);
+        } catch (PropertyVetoException ex) {
+            logger.fatal("Unable to setup JDBC. Is the Oracle driver in the classpath?", ex);
+            System.exit(1);
+        } catch (HTTPException | ConnectivityException ex) {
+            logger.fatal(
+                    "Unable to connect to Chain Core at the configured URL \"{}\". " +
+                    "Double check that the URL is correct and reachable.",
+                    chainUrl, ex);
+            System.exit(1);
+        } catch (ChainException | SQLException ex) {
+            logger.fatal("Unable to initialize importer.", ex);
+            System.exit(1);
+        }
+
+        // If we make it this far, the importer is properly configured.
+        // We can begin syncing. From now on, errors should not crash
+        // the process unless they're persistent.
+        logger.info("Transaction importer initialized");
+        importer.process();
+    }
+}

--- a/analytics/src/main/java/com/chain/analytics/Application.java
+++ b/analytics/src/main/java/com/chain/analytics/Application.java
@@ -21,84 +21,82 @@ import org.apache.logging.log4j.LogManager;
  * importing service.
  */
 public class Application {
-    // TODO(jackson): Allow configuration of custom columns.
+  // TODO(jackson): Allow configuration of custom columns.
 
-    // Environment variable key to find the Chain Core's URL.
-    public static final String ENV_CHAIN_URL = "CHAIN_URL";
+  // Environment variable key to find the Chain Core's URL.
+  public static final String ENV_CHAIN_URL = "CHAIN_URL";
 
-    // Environment variable key to find the Chain Core access token
-    // to use, if any.
-    public static final String ENV_CHAIN_TOKEN = "CHAIN_ACCESS_TOKEN";
+  // Environment variable key to find the Chain Core access token
+  // to use, if any.
+  public static final String ENV_CHAIN_TOKEN = "CHAIN_ACCESS_TOKEN";
 
-    // Environment variable key to find the JDBC URL to use to connect
-    // to the Oracle database.
-    // Example: jdbc:oracle:thin:username/password@127.0.0.1:1521/orcl
-    public static final String ENV_DATABASE_URL = "DATABASE_URL";
+  // Environment variable key to find the JDBC URL to use to connect
+  // to the Oracle database.
+  // Example: jdbc:oracle:thin:username/password@127.0.0.1:1521/orcl
+  public static final String ENV_DATABASE_URL = "DATABASE_URL";
 
-    // The alias of the Chain Core transaction feed that the
-    // importer uses.
-    public static final String DEFAULT_FEED_ALIAS = "chain-analytics-importer";
+  // The alias of the Chain Core transaction feed that the
+  // importer uses.
+  public static final String DEFAULT_FEED_ALIAS = "chain-analytics-importer";
 
-    private static Logger logger = LogManager.getLogger();
+  private static Logger logger = LogManager.getLogger();
 
-    public static void main(String args[]) {
-        String chainUrl = System.getenv(ENV_CHAIN_URL);
-        String chainToken = System.getenv(ENV_CHAIN_TOKEN);
-        String databaseUrl = System.getenv(ENV_DATABASE_URL);
+  public static void main(String args[]) {
+    String chainUrl = System.getenv(ENV_CHAIN_URL);
+    String chainToken = System.getenv(ENV_CHAIN_TOKEN);
+    String databaseUrl = System.getenv(ENV_DATABASE_URL);
 
-        if (chainUrl == null || "".equals(chainUrl)) {
-            logger.fatal("missing {} environment variable", ENV_CHAIN_URL);
-            System.exit(1);
-        }
-        if (databaseUrl == null || "".equals(databaseUrl)) {
-            logger.fatal("missing {} environment variable", ENV_DATABASE_URL);
-            System.exit(1);
-        }
-
-        //
-        // Setup the importer. The majority of connectivity and
-        // configuration errors should be caught here.
-        //
-        Importer importer = null;
-        try {
-            Client.Builder clientBuilder = new Client.Builder()
-                .addURL(chainUrl)
-                .setReadTimeout(60, TimeUnit.SECONDS);
-            if (chainToken != null && chainToken.length() > 0) {
-                clientBuilder.setAccessToken(chainToken);
-            }
-            final Client client = clientBuilder.build();
-
-            // Use a connection pool.
-            ComboPooledDataSource ds = new ComboPooledDataSource();
-            ds.setDriverClass("oracle.jdbc.driver.OracleDriver");
-            ds.setJdbcUrl(databaseUrl);
-            ds.setTestConnectionOnCheckout(true);
-
-            importer = Importer.connect(client, ds, DEFAULT_FEED_ALIAS);
-        } catch(BadURLException ex) {
-            logger.fatal(
-                    "Unable to parse the Chain Core URL provided \"{}\".",
-                    chainUrl, ex);
-            System.exit(1);
-        } catch (PropertyVetoException ex) {
-            logger.fatal("Unable to setup JDBC. Is the Oracle driver in the classpath?", ex);
-            System.exit(1);
-        } catch (HTTPException | ConnectivityException ex) {
-            logger.fatal(
-                    "Unable to connect to Chain Core at the configured URL \"{}\". " +
-                    "Double check that the URL is correct and reachable.",
-                    chainUrl, ex);
-            System.exit(1);
-        } catch (ChainException | SQLException ex) {
-            logger.fatal("Unable to initialize importer.", ex);
-            System.exit(1);
-        }
-
-        // If we make it this far, the importer is properly configured.
-        // We can begin syncing. From now on, errors should not crash
-        // the process unless they're persistent.
-        logger.info("Transaction importer initialized");
-        importer.process();
+    if (chainUrl == null || "".equals(chainUrl)) {
+      logger.fatal("missing {} environment variable", ENV_CHAIN_URL);
+      System.exit(1);
     }
+    if (databaseUrl == null || "".equals(databaseUrl)) {
+      logger.fatal("missing {} environment variable", ENV_DATABASE_URL);
+      System.exit(1);
+    }
+
+    //
+    // Setup the importer. The majority of connectivity and
+    // configuration errors should be caught here.
+    //
+    Importer importer = null;
+    try {
+      Client.Builder clientBuilder =
+          new Client.Builder().addURL(chainUrl).setReadTimeout(60, TimeUnit.SECONDS);
+      if (chainToken != null && chainToken.length() > 0) {
+        clientBuilder.setAccessToken(chainToken);
+      }
+      final Client client = clientBuilder.build();
+
+      // Use a connection pool.
+      ComboPooledDataSource ds = new ComboPooledDataSource();
+      ds.setDriverClass("oracle.jdbc.driver.OracleDriver");
+      ds.setJdbcUrl(databaseUrl);
+      ds.setTestConnectionOnCheckout(true);
+
+      importer = Importer.connect(client, ds, DEFAULT_FEED_ALIAS);
+    } catch (BadURLException ex) {
+      logger.fatal("Unable to parse the Chain Core URL provided \"{}\".", chainUrl, ex);
+      System.exit(1);
+    } catch (PropertyVetoException ex) {
+      logger.fatal("Unable to setup JDBC. Is the Oracle driver in the classpath?", ex);
+      System.exit(1);
+    } catch (HTTPException | ConnectivityException ex) {
+      logger.fatal(
+          "Unable to connect to Chain Core at the configured URL \"{}\". "
+              + "Double check that the URL is correct and reachable.",
+          chainUrl,
+          ex);
+      System.exit(1);
+    } catch (ChainException | SQLException ex) {
+      logger.fatal("Unable to initialize importer.", ex);
+      System.exit(1);
+    }
+
+    // If we make it this far, the importer is properly configured.
+    // We can begin syncing. From now on, errors should not crash
+    // the process unless they're persistent.
+    logger.info("Transaction importer initialized");
+    importer.process();
+  }
 }

--- a/analytics/src/main/java/com/chain/analytics/Importer.java
+++ b/analytics/src/main/java/com/chain/analytics/Importer.java
@@ -1,7 +1,10 @@
 package analytics;
 
 import com.chain.http.Client;
+import com.chain.api.PagedItems;
+import com.chain.api.Query;
 import com.chain.api.Transaction;
+import com.chain.api.Transaction.QueryBuilder;
 import com.chain.exception.APIException;
 import com.chain.exception.ChainException;
 import com.google.gson.Gson;
@@ -15,7 +18,9 @@ import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import javax.sql.DataSource;
 
 import org.apache.logging.log4j.Logger;
@@ -30,6 +35,7 @@ public class Importer {
 
     private static final String TRUE = "1";
     private static final String FALSE = "0";
+    private static final long defaultTimeoutMillis = 30 * 1000; // 30 seconds
 
     private static final Logger logger = LogManager.getLogger();
     private static final Gson gson = new Gson();
@@ -173,124 +179,167 @@ public class Importer {
      * TODO(jackson): Support propagating persistent errors?
      */
     public void process() {
-        final String insertTxQ = mTransactionsTbl.getInsertStatement();
-        final String insertInputQ = mTransactionInputsTbl.getInsertStatement();
-        final String insertOutputQ = mTransactionOutputsTbl.getInsertStatement();
+        ThreadContext.put("feed_id", mFeed.id);
+        ThreadContext.put("feed_filter", mFeed.filter);
 
-        // TODO(jackson): Batch insert transactions instead of inserting
-        // them individually. We'll need to circumvent the SDK's transaction
-        // feed interface.
         for (;;) {
-            try (Connection conn = mDataSource.getConnection()) {
-                // Manage our own SQL transactions so we can make this whole
-                // blockchain transaction atomic.
-                conn.setAutoCommit(false);
+            try {
+                ThreadContext.put("feed_after", mFeed.after);
 
-                final Transaction tx = mFeed.next(mChain);
-                ThreadContext.put("tx_id", tx.id);
-                logger.debug("Importing transaction {}", tx.id);
+                // Retrieve another page of transactions matching the feed.
+                final Transaction.Items page = new QueryBuilder()
+                    .setFilter(mFeed.filter)
+                    .setAfter(mFeed.after)
+                    .setTimeout(defaultTimeoutMillis)
+                    .setAscendingWithLongPoll()
+                    .execute(mChain);
 
-                // Insert the transaction itself.
-                try (PreparedStatement ps = conn.prepareStatement(insertTxQ)) {
-                    ps.setString(1, tx.id);
-                    ps.setLong(2, tx.blockHeight);
-                    ps.setTimestamp(3, new Timestamp(tx.timestamp.getTime()));
-                    ps.setInt(4, tx.position);
-                    ps.setString(5, "yes".equals(tx.isLocal) ? TRUE : FALSE);
-                    ps.setBlob(6, asJsonBlob(tx.referenceData));
-                    ps.setBlob(7, asJsonBlob(tx));
-                    ps.executeUpdate();
+                // Commit the batch of transactions to the database.
+                try {
+                    processBatch(page.list);
+                } catch (SQLException ex) {
+                    logger.catching(ex);
+                    // Skip the ack so we re-fetch this page and try again.
+                    // TODO(jackson): Do we need any backoff? Don't want to
+                    // hammer Chain Core or the Oracle database if there's
+                    // an issue.
+                    // TODO(jackson): Add retry logic in processBatch so that
+                    // we don't re-query Chain Core if we don't need to?
+                    continue;
                 }
 
-                // Insert each of the inputs.
-                try (PreparedStatement ps = conn.prepareStatement(insertInputQ)) {
-                    for (int i = 0; i < tx.inputs.size(); i++) {
-                        final Transaction.Input input = tx.inputs.get(i);
-
-                        ps.setString(1, tx.id);
-                        ps.setInt(2, i);
-                        ps.setString(3, input.type);
-                        ps.setString(4, input.assetId);
-                        ps.setString(5, input.assetAlias);
-                        ps.setBlob(6, asJsonBlob(input.assetDefinition));
-                        ps.setBlob(7, asJsonBlob(input.assetTags));
-                        ps.setString(8, "yes".equals(input.assetIsLocal) ? TRUE : FALSE);
-                        ps.setLong(9, input.amount);
-                        ps.setString(10, input.accountId);
-                        ps.setString(11, input.accountAlias);
-                        ps.setBlob(12, asJsonBlob(input.accountTags));
-                        ps.setString(13, input.issuanceProgram); // clob
-                        ps.setBlob(14, asJsonBlob(input.referenceData));
-                        ps.setString(15, "yes".equals(input.isLocal) ? TRUE : FALSE);
-                        ps.setString(16, input.spentOutputId);
-
-                        // TODO(jackson): We can't use addBatch in Oracle
-                        // earlier than 12.1. If customers need support for
-                        // Oracle < 12.1, we'll need to use the deprecated
-                        // OraclePreparedStatement.setExecuteBatch method:
-                        // http://docs.oracle.com/cd/B28359_01/java.111/b31224/oraperf.htm
-                        ps.addBatch();
-                    }
-                    ps.executeBatch();
-                }
-
-                // Insert each of the outputs.
-                try (PreparedStatement ps = conn.prepareStatement(insertOutputQ)) {
-                    for (int i = 0; i < tx.outputs.size(); i++) {
-                        final Transaction.Output output = tx.outputs.get(i);
-
-                        ps.setString(1, tx.id);
-                        ps.setInt(2, i);
-                        ps.setString(3, output.id);
-                        ps.setString(4, output.type);
-                        ps.setString(5, output.purpose);
-                        ps.setString(6, output.assetId);
-                        ps.setString(7, output.assetAlias);
-                        ps.setBlob(8, asJsonBlob(output.assetDefinition));
-                        ps.setBlob(9, asJsonBlob(output.assetTags));
-                        ps.setString(10, "yes".equals(output.assetIsLocal) ? TRUE : FALSE);
-                        ps.setLong(11, output.amount);
-                        ps.setString(12, output.accountId);
-                        ps.setString(13, output.accountAlias);
-                        ps.setBlob(14, asJsonBlob(output.accountTags));
-                        ps.setString(15, output.controlProgram); // clob
-                        ps.setBlob(16, asJsonBlob(output.referenceData));
-                        ps.setString(17, "yes".equals(output.isLocal) ? TRUE : FALSE);
-                        ps.setString(18, FALSE);
-
-                        ps.addBatch();
-                    }
-                    ps.executeBatch();
-                }
-
-                // Commit the entire transaction at once.
-                conn.commit();
-
-                // Mark this transaction as processed, now that we've
-                // successfully indexed it.
-                mFeed.ack(mChain);
-            } catch (SQLException ex) {
-                // We can hit a unique constraint violation (ORA-00001)
-                // iff we already processed this transaction but have not
-                // yet successfully acked the transaction. If that's the
-                // case, just ack the transaction and move on to the next
-                // blockchain transaction.
-                if (ex.getErrorCode() == 1) {
-                    logger.info("Processed transaction twice; acking and continuing");
-                    try {
-                        mFeed.ack(mChain);
-                    } catch(ChainException chainEx) {
-                        logger.catching(chainEx);
-                    }
-                } else {
-                    // If it's a different error code, log the error, don't
-                    // ack and try again.
+                // Acknowledge that we've processed the entire page.
+                Map<String, Object> requestBody = new TreeMap<>();
+                requestBody.put("id", mFeed.id);
+                requestBody.put("previous_after", mFeed.after);
+                requestBody.put("after", page.next.after);
+                mFeed = mChain.request("update-transaction-feed", requestBody, Transaction.Feed.class);
+            } catch (APIException ex) {
+                // If there was an issue retrieving the transactions,
+                // log it. If the request just timed out, no matching
+                // transactions were committed so just silently ignore it.
+                if (!"CH001".equals(ex.code)) {
                     logger.catching(ex);
                 }
             } catch (ChainException ex) {
                 logger.catching(ex);
             } finally {
-                ThreadContext.remove("tx_id");
+                ThreadContext.remove("feed_after");
+            }
+        }
+    }
+
+    // processBatch inserts a batch of transactions into the Oracle
+    // database.
+    //
+    // TODO(jackson): Ideally we'd call executeBatch once per prepared-statement
+    // per call to processBatch, but handling the unique constraint violations
+    // gets trickier. We might be able to write a PL/SQL function that ignores
+    // the ORA-00001 exception in Oracle instead of client-side to get around
+    // that.
+    void processBatch(final List<Transaction> transactions) throws SQLException {
+        final String insertTxQ = mTransactionsTbl.getInsertStatement();
+        final String insertInputQ = mTransactionInputsTbl.getInsertStatement();
+        final String insertOutputQ = mTransactionOutputsTbl.getInsertStatement();
+
+        try (   Connection conn = mDataSource.getConnection();
+                PreparedStatement psTx = conn.prepareStatement(insertTxQ);
+                PreparedStatement psIn = conn.prepareStatement(insertInputQ);
+                PreparedStatement psOut = conn.prepareStatement(insertOutputQ)) {
+
+            // Manage our own SQL transactions so we can make this whole
+            // blockchain transaction atomic.
+            conn.setAutoCommit(false);
+
+            for (Transaction tx : transactions) {
+                try {
+                    ThreadContext.put("tx_id", tx.id);
+                    logger.debug("Importing transaction {}", tx.id);
+
+                    // Insert the transaction itself.
+                    psTx.setString(1, tx.id);
+                    psTx.setLong(2, tx.blockHeight);
+                    psTx.setTimestamp(3, new Timestamp(tx.timestamp.getTime()));
+                    psTx.setInt(4, tx.position);
+                    psTx.setString(5, "yes".equals(tx.isLocal) ? TRUE : FALSE);
+                    psTx.setBlob(6, asJsonBlob(tx.referenceData));
+                    psTx.setBlob(7, asJsonBlob(tx));
+
+                    // TODO(jackson): We can't use addBatch in Oracle
+                    // earlier than 12.1. If customers need support for
+                    // Oracle < 12.1, we'll need to use the deprecated
+                    // OraclePreparedStatement.setExecuteBatch method:
+                    // http://docs.oracle.com/cd/B28359_01/java.111/b31224/oraperf.htm
+                    psTx.addBatch();
+
+                    // Insert each of the inputs.
+                    for (int i = 0; i < tx.inputs.size(); i++) {
+                        final Transaction.Input input = tx.inputs.get(i);
+
+                        psIn.setString(1, tx.id);
+                        psIn.setInt(2, i);
+                        psIn.setString(3, input.type);
+                        psIn.setString(4, input.assetId);
+                        psIn.setString(5, input.assetAlias);
+                        psIn.setBlob(6, asJsonBlob(input.assetDefinition));
+                        psIn.setBlob(7, asJsonBlob(input.assetTags));
+                        psIn.setString(8, "yes".equals(input.assetIsLocal) ? TRUE : FALSE);
+                        psIn.setLong(9, input.amount);
+                        psIn.setString(10, input.accountId);
+                        psIn.setString(11, input.accountAlias);
+                        psIn.setBlob(12, asJsonBlob(input.accountTags));
+                        psIn.setString(13, input.issuanceProgram); // clob
+                        psIn.setBlob(14, asJsonBlob(input.referenceData));
+                        psIn.setString(15, "yes".equals(input.isLocal) ? TRUE : FALSE);
+                        psIn.setString(16, input.spentOutputId);
+
+                        psIn.addBatch();
+                    }
+
+                    // Insert each of the outputs.
+                    for (int i = 0; i < tx.outputs.size(); i++) {
+                        final Transaction.Output output = tx.outputs.get(i);
+
+                        psOut.setString(1, tx.id);
+                        psOut.setInt(2, i);
+                        psOut.setString(3, output.id);
+                        psOut.setString(4, output.type);
+                        psOut.setString(5, output.purpose);
+                        psOut.setString(6, output.assetId);
+                        psOut.setString(7, output.assetAlias);
+                        psOut.setBlob(8, asJsonBlob(output.assetDefinition));
+                        psOut.setBlob(9, asJsonBlob(output.assetTags));
+                        psOut.setString(10, "yes".equals(output.assetIsLocal) ? TRUE : FALSE);
+                        psOut.setLong(11, output.amount);
+                        psOut.setString(12, output.accountId);
+                        psOut.setString(13, output.accountAlias);
+                        psOut.setBlob(14, asJsonBlob(output.accountTags));
+                        psOut.setString(15, output.controlProgram); // clob
+                        psOut.setBlob(16, asJsonBlob(output.referenceData));
+                        psOut.setString(17, "yes".equals(output.isLocal) ? TRUE : FALSE);
+                        psOut.setString(18, FALSE);
+
+                        psOut.addBatch();
+                    }
+
+                    // Commit the entire blockchain transaction at once.
+                    psTx.executeBatch();
+                    psIn.executeBatch();
+                    psOut.executeBatch();
+                    conn.commit();
+                } catch (SQLException ex) {
+                    // We can hit a unique constraint violation (ORA-00001)
+                    // iff we already processed these transactions but have not
+                    // yet successfully acked them. If that's the case, just
+                    // fallthrough to the acknowledgement below.
+                    if (ex.getErrorCode() == 1) {
+                        logger.info("Processed transaction twice; ignoring");
+                    } else {
+                        throw ex;
+                    }
+                } finally {
+                    ThreadContext.remove("tx_id");
+                }
             }
         }
     }

--- a/analytics/src/main/java/com/chain/analytics/Importer.java
+++ b/analytics/src/main/java/com/chain/analytics/Importer.java
@@ -1,0 +1,305 @@
+package analytics;
+
+import com.chain.http.Client;
+import com.chain.api.Transaction;
+import com.chain.exception.APIException;
+import com.chain.exception.ChainException;
+import com.google.gson.Gson;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Map;
+import javax.sql.DataSource;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * Importer is responsible for reading transactions from a Chain Core
+ * transaction feed and writing them to an Oracle database.
+ */
+public class Importer {
+
+    private static final String TRUE = "1";
+    private static final String FALSE = "0";
+
+    private static final Logger logger = LogManager.getLogger();
+    private static final Gson gson = new Gson();
+
+    private Client mChain;
+    private DataSource mDataSource;
+    private Transaction.Feed mFeed;
+    private Schema mTransactionsTbl;
+    private Schema mTransactionInputsTbl;
+    private Schema mTransactionOutputsTbl;
+
+    /**
+     * connect initializes an Importer using the transaction feed specified
+     * by the alias. If the feed doesn't yet exist, it will be created. It
+     * does not begin syncing yet.
+     * @param client    a client for the Chain Core
+     * @param ds        the database to populate
+     * @param feedAlias the alias of the transaction feed to use
+     * @return          the initialized transaction importer
+     */
+    public static Importer connect(
+            final Client client,
+            final DataSource ds,
+            final String feedAlias) throws ChainException, SQLException {
+        // Create or load the transaction feed for the provided alias.
+        try {
+            Transaction.Feed.create(client, feedAlias, "");
+        } catch (APIException ex) {
+            // CH050 means the transaction feed already existed. If that's
+            // the case, ignore the exception because we'll retrieve the
+            // feed down below by its alias.
+            if (!"CH050".equals(ex.code)) {
+                logger.catching(ex);
+                throw ex;
+            }
+            logger.info("Transaction feed {} already exists", feedAlias);
+        }
+        final Transaction.Feed feed = Transaction.Feed.getByAlias(client, feedAlias);
+        logger.info("Using transaction feed {} starting at cursor {}", feed.id, feed.after);
+
+        // Initialize the schema based on the configuration.
+        final Importer importer = new Importer(client, ds, feed);
+        importer.initializeSchema();
+        return importer;
+    }
+
+    private Importer(final Client client, final DataSource ds, final Transaction.Feed feed) {
+        mChain = client;
+        mDataSource = ds;
+        mFeed = feed;
+    }
+
+    void initializeSchema() throws SQLException {
+
+        mTransactionsTbl = new Schema.Builder("transactions")
+            .setPrimaryKey(Arrays.asList("id"))
+            .addColumn("id", new Schema.Varchar2(64))
+            .addColumn("block_height", new Schema.Integer())
+            .addColumn("timestamp", new Schema.Timestamp())
+            .addColumn("position", new Schema.Integer())
+            .addColumn("local", new Schema.Boolean())
+            .addColumn("reference_data", new Schema.Blob())
+            .addColumn("data", new Schema.Blob())
+            .build();
+
+        mTransactionInputsTbl = new Schema.Builder("transaction_inputs")
+            .setPrimaryKey(Arrays.asList("transaction_id", "index"))
+            .addColumn("transaction_id", new Schema.Varchar2(64))
+            .addColumn("index", new Schema.Integer())
+            .addColumn("type", new Schema.Varchar2(64))
+            .addColumn("asset_id", new Schema.Varchar2(64))
+            .addColumn("asset_alias", new Schema.Varchar2(2000))
+            .addColumn("asset_definition", new Schema.Blob())
+            .addColumn("asset_tags", new Schema.Blob())
+            .addColumn("local_asset", new Schema.Boolean())
+            .addColumn("amount", new Schema.Integer())
+            .addColumn("account_id", new Schema.Varchar2(64))
+            .addColumn("account_alias", new Schema.Varchar2(2000))
+            .addColumn("account_tags", new Schema.Blob())
+            .addColumn("issuance_program", new Schema.Clob())
+            .addColumn("reference_data", new Schema.Blob())
+            .addColumn("local", new Schema.Boolean())
+            .addColumn("spent_output_id", new Schema.Varchar2(64))
+            .build();
+
+        mTransactionOutputsTbl = new Schema.Builder("transaction_outputs")
+            .setPrimaryKey(Arrays.asList("output_id"))
+            .addColumn("transaction_id", new Schema.Varchar2(64))
+            .addColumn("index", new Schema.Integer())
+            .addColumn("output_id", new Schema.Varchar2(64))
+            .addColumn("type", new Schema.Varchar2(64))
+            .addColumn("purpose", new Schema.Varchar2(64))
+            .addColumn("asset_id", new Schema.Varchar2(64))
+            .addColumn("asset_alias", new Schema.Varchar2(2000))
+            .addColumn("asset_definition", new Schema.Blob())
+            .addColumn("asset_tags", new Schema.Blob())
+            .addColumn("local_asset", new Schema.Boolean())
+            .addColumn("amount", new Schema.Integer())
+            .addColumn("account_id", new Schema.Varchar2(64))
+            .addColumn("account_alias", new Schema.Varchar2(2000))
+            .addColumn("account_tags", new Schema.Blob())
+            .addColumn("control_program", new Schema.Clob())
+            .addColumn("reference_data", new Schema.Blob())
+            .addColumn("local", new Schema.Boolean())
+            .addColumn("spent", new Schema.Boolean())
+            .build();
+
+        try (Connection conn = mDataSource.getConnection()) {
+            createTableIfNotExists(conn, mTransactionsTbl.getDDLStatement());
+            createTableIfNotExists(conn, mTransactionInputsTbl.getDDLStatement());
+            createTableIfNotExists(conn, mTransactionOutputsTbl.getDDLStatement());
+        }
+
+        // TODO(jackson): Perform some kind of checksuming on the DDL
+        // statements so that we notice if the existing tables were created
+        // from a different configuration? Or store the configuration
+        // itself in Oracle so that they *must* run a program to reconfigure.
+    }
+
+    private boolean createTableIfNotExists(
+            final Connection conn, final String query) throws SQLException {
+        logger.info("Creating table: \n{}", query);
+        try (PreparedStatement ps = conn.prepareStatement(query)) {
+            ps.executeUpdate();
+        } catch(SQLSyntaxErrorException ex) {
+            // If "ORA-00955: name is already used by an existing object",
+            // the table already exists. Otherwise, it's an unexpected exception.
+            if (ex.getErrorCode() != 955) {
+                throw ex;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Processes transactions, reading them from the transaction feed
+     * and inserting them into the configured Oracle database. This
+     * function blocks indefinitely. Errors are logged to log4j2.
+     *
+     * TODO(jackson): Support propagating persistent errors?
+     */
+    public void process() {
+        final String insertTxQ = mTransactionsTbl.getInsertStatement();
+        final String insertInputQ = mTransactionInputsTbl.getInsertStatement();
+        final String insertOutputQ = mTransactionOutputsTbl.getInsertStatement();
+
+        // TODO(jackson): Batch insert transactions instead of inserting
+        // them individually. We'll need to circumvent the SDK's transaction
+        // feed interface.
+        for (;;) {
+            try (Connection conn = mDataSource.getConnection()) {
+                // Manage our own SQL transactions so we can make this whole
+                // blockchain transaction atomic.
+                conn.setAutoCommit(false);
+
+                final Transaction tx = mFeed.next(mChain);
+                ThreadContext.put("tx_id", tx.id);
+                logger.debug("Importing transaction {}", tx.id);
+
+                // Insert the transaction itself.
+                try (PreparedStatement ps = conn.prepareStatement(insertTxQ)) {
+                    ps.setString(1, tx.id);
+                    ps.setLong(2, tx.blockHeight);
+                    ps.setTimestamp(3, new Timestamp(tx.timestamp.getTime()));
+                    ps.setInt(4, tx.position);
+                    ps.setString(5, "yes".equals(tx.isLocal) ? TRUE : FALSE);
+                    ps.setBlob(6, asJsonBlob(tx.referenceData));
+                    ps.setBlob(7, asJsonBlob(tx));
+                    ps.executeUpdate();
+                }
+
+                // Insert each of the inputs.
+                try (PreparedStatement ps = conn.prepareStatement(insertInputQ)) {
+                    for (int i = 0; i < tx.inputs.size(); i++) {
+                        final Transaction.Input input = tx.inputs.get(i);
+
+                        ps.setString(1, tx.id);
+                        ps.setInt(2, i);
+                        ps.setString(3, input.type);
+                        ps.setString(4, input.assetId);
+                        ps.setString(5, input.assetAlias);
+                        ps.setBlob(6, asJsonBlob(input.assetDefinition));
+                        ps.setBlob(7, asJsonBlob(input.assetTags));
+                        ps.setString(8, "yes".equals(input.assetIsLocal) ? TRUE : FALSE);
+                        ps.setLong(9, input.amount);
+                        ps.setString(10, input.accountId);
+                        ps.setString(11, input.accountAlias);
+                        ps.setBlob(12, asJsonBlob(input.accountTags));
+                        ps.setString(13, input.issuanceProgram); // clob
+                        ps.setBlob(14, asJsonBlob(input.referenceData));
+                        ps.setString(15, "yes".equals(input.isLocal) ? TRUE : FALSE);
+                        ps.setString(16, input.spentOutputId);
+
+                        // TODO(jackson): We can't use addBatch in Oracle
+                        // earlier than 12.1. If customers need support for
+                        // Oracle < 12.1, we'll need to use the deprecated
+                        // OraclePreparedStatement.setExecuteBatch method:
+                        // http://docs.oracle.com/cd/B28359_01/java.111/b31224/oraperf.htm
+                        ps.addBatch();
+                    }
+                    ps.executeBatch();
+                }
+
+                // Insert each of the outputs.
+                try (PreparedStatement ps = conn.prepareStatement(insertOutputQ)) {
+                    for (int i = 0; i < tx.outputs.size(); i++) {
+                        final Transaction.Output output = tx.outputs.get(i);
+
+                        ps.setString(1, tx.id);
+                        ps.setInt(2, i);
+                        ps.setString(3, output.id);
+                        ps.setString(4, output.type);
+                        ps.setString(5, output.purpose);
+                        ps.setString(6, output.assetId);
+                        ps.setString(7, output.assetAlias);
+                        ps.setBlob(8, asJsonBlob(output.assetDefinition));
+                        ps.setBlob(9, asJsonBlob(output.assetTags));
+                        ps.setString(10, "yes".equals(output.assetIsLocal) ? TRUE : FALSE);
+                        ps.setLong(11, output.amount);
+                        ps.setString(12, output.accountId);
+                        ps.setString(13, output.accountAlias);
+                        ps.setBlob(14, asJsonBlob(output.accountTags));
+                        ps.setString(15, output.controlProgram); // clob
+                        ps.setBlob(16, asJsonBlob(output.referenceData));
+                        ps.setString(17, "yes".equals(output.isLocal) ? TRUE : FALSE);
+                        ps.setString(18, FALSE);
+
+                        ps.addBatch();
+                    }
+                    ps.executeBatch();
+                }
+
+                // Commit the entire transaction at once.
+                conn.commit();
+
+                // Mark this transaction as processed, now that we've
+                // successfully indexed it.
+                mFeed.ack(mChain);
+            } catch (SQLException ex) {
+                // We can hit a unique constraint violation (ORA-00001)
+                // iff we already processed this transaction but have not
+                // yet successfully acked the transaction. If that's the
+                // case, just ack the transaction and move on to the next
+                // blockchain transaction.
+                if (ex.getErrorCode() == 1) {
+                    logger.info("Processed transaction twice; acking and continuing");
+                    try {
+                        mFeed.ack(mChain);
+                    } catch(ChainException chainEx) {
+                        logger.catching(chainEx);
+                    }
+                } else {
+                    // If it's a different error code, log the error, don't
+                    // ack and try again.
+                    logger.catching(ex);
+                }
+            } catch (ChainException ex) {
+                logger.catching(ex);
+            } finally {
+                ThreadContext.remove("tx_id");
+            }
+        }
+    }
+
+    private static InputStream asJsonBlob(final Object obj) {
+        if (obj == null) return null;
+        return new ByteArrayInputStream(
+                gson
+                .toJson(obj)
+                .getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/analytics/src/main/java/com/chain/analytics/Importer.java
+++ b/analytics/src/main/java/com/chain/analytics/Importer.java
@@ -124,6 +124,7 @@ public class Importer {
     mTransactionOutputsTbl =
         new Schema.Builder("transaction_outputs")
             .setPrimaryKey(Arrays.asList("output_id"))
+            .addUniqueConstraint(Arrays.asList("transaction_id", "index"))
             .addColumn("transaction_id", new Schema.Varchar2(64))
             .addColumn("index", new Schema.Integer())
             .addColumn("output_id", new Schema.Varchar2(64))

--- a/analytics/src/main/java/com/chain/analytics/Importer.java
+++ b/analytics/src/main/java/com/chain/analytics/Importer.java
@@ -35,7 +35,7 @@ public class Importer {
 
   private static final String TRUE = "1";
   private static final String FALSE = "0";
-  private static final long defaultTimeoutMillis = 30 * 1000; // 30 seconds
+  private static final long DEFAULT_TIMEOUT_MILLIS = 60 * 1000; // 60 seconds
 
   private static final Logger logger = LogManager.getLogger();
   private static final Gson gson = new Gson();
@@ -192,7 +192,7 @@ public class Importer {
             new QueryBuilder()
                 .setFilter(mFeed.filter)
                 .setAfter(mFeed.after)
-                .setTimeout(defaultTimeoutMillis)
+                .setTimeout(DEFAULT_TIMEOUT_MILLIS)
                 .setAscendingWithLongPoll()
                 .execute(mChain);
 

--- a/analytics/src/main/java/com/chain/analytics/Importer.java
+++ b/analytics/src/main/java/com/chain/analytics/Importer.java
@@ -33,64 +33,63 @@ import org.apache.logging.log4j.ThreadContext;
  */
 public class Importer {
 
-    private static final String TRUE = "1";
-    private static final String FALSE = "0";
-    private static final long defaultTimeoutMillis = 30 * 1000; // 30 seconds
+  private static final String TRUE = "1";
+  private static final String FALSE = "0";
+  private static final long defaultTimeoutMillis = 30 * 1000; // 30 seconds
 
-    private static final Logger logger = LogManager.getLogger();
-    private static final Gson gson = new Gson();
+  private static final Logger logger = LogManager.getLogger();
+  private static final Gson gson = new Gson();
 
-    private Client mChain;
-    private DataSource mDataSource;
-    private Transaction.Feed mFeed;
-    private Schema mTransactionsTbl;
-    private Schema mTransactionInputsTbl;
-    private Schema mTransactionOutputsTbl;
+  private Client mChain;
+  private DataSource mDataSource;
+  private Transaction.Feed mFeed;
+  private Schema mTransactionsTbl;
+  private Schema mTransactionInputsTbl;
+  private Schema mTransactionOutputsTbl;
 
-    /**
-     * connect initializes an Importer using the transaction feed specified
-     * by the alias. If the feed doesn't yet exist, it will be created. It
-     * does not begin syncing yet.
-     * @param client    a client for the Chain Core
-     * @param ds        the database to populate
-     * @param feedAlias the alias of the transaction feed to use
-     * @return          the initialized transaction importer
-     */
-    public static Importer connect(
-            final Client client,
-            final DataSource ds,
-            final String feedAlias) throws ChainException, SQLException {
-        // Create or load the transaction feed for the provided alias.
-        try {
-            Transaction.Feed.create(client, feedAlias, "");
-        } catch (APIException ex) {
-            // CH050 means the transaction feed already existed. If that's
-            // the case, ignore the exception because we'll retrieve the
-            // feed down below by its alias.
-            if (!"CH050".equals(ex.code)) {
-                logger.catching(ex);
-                throw ex;
-            }
-            logger.info("Transaction feed {} already exists", feedAlias);
-        }
-        final Transaction.Feed feed = Transaction.Feed.getByAlias(client, feedAlias);
-        logger.info("Using transaction feed {} starting at cursor {}", feed.id, feed.after);
-
-        // Initialize the schema based on the configuration.
-        final Importer importer = new Importer(client, ds, feed);
-        importer.initializeSchema();
-        return importer;
+  /**
+   * connect initializes an Importer using the transaction feed specified
+   * by the alias. If the feed doesn't yet exist, it will be created. It
+   * does not begin syncing yet.
+   * @param client    a client for the Chain Core
+   * @param ds        the database to populate
+   * @param feedAlias the alias of the transaction feed to use
+   * @return          the initialized transaction importer
+   */
+  public static Importer connect(final Client client, final DataSource ds, final String feedAlias)
+      throws ChainException, SQLException {
+    // Create or load the transaction feed for the provided alias.
+    try {
+      Transaction.Feed.create(client, feedAlias, "");
+    } catch (APIException ex) {
+      // CH050 means the transaction feed already existed. If that's
+      // the case, ignore the exception because we'll retrieve the
+      // feed down below by its alias.
+      if (!"CH050".equals(ex.code)) {
+        logger.catching(ex);
+        throw ex;
+      }
+      logger.info("Transaction feed {} already exists", feedAlias);
     }
+    final Transaction.Feed feed = Transaction.Feed.getByAlias(client, feedAlias);
+    logger.info("Using transaction feed {} starting at cursor {}", feed.id, feed.after);
 
-    private Importer(final Client client, final DataSource ds, final Transaction.Feed feed) {
-        mChain = client;
-        mDataSource = ds;
-        mFeed = feed;
-    }
+    // Initialize the schema based on the configuration.
+    final Importer importer = new Importer(client, ds, feed);
+    importer.initializeSchema();
+    return importer;
+  }
 
-    void initializeSchema() throws SQLException {
+  private Importer(final Client client, final DataSource ds, final Transaction.Feed feed) {
+    mChain = client;
+    mDataSource = ds;
+    mFeed = feed;
+  }
 
-        mTransactionsTbl = new Schema.Builder("transactions")
+  void initializeSchema() throws SQLException {
+
+    mTransactionsTbl =
+        new Schema.Builder("transactions")
             .setPrimaryKey(Arrays.asList("id"))
             .addColumn("id", new Schema.Varchar2(64))
             .addColumn("block_height", new Schema.Integer())
@@ -101,7 +100,8 @@ public class Importer {
             .addColumn("data", new Schema.Blob())
             .build();
 
-        mTransactionInputsTbl = new Schema.Builder("transaction_inputs")
+    mTransactionInputsTbl =
+        new Schema.Builder("transaction_inputs")
             .setPrimaryKey(Arrays.asList("transaction_id", "index"))
             .addColumn("transaction_id", new Schema.Varchar2(64))
             .addColumn("index", new Schema.Integer())
@@ -121,7 +121,8 @@ public class Importer {
             .addColumn("spent_output_id", new Schema.Varchar2(64))
             .build();
 
-        mTransactionOutputsTbl = new Schema.Builder("transaction_outputs")
+    mTransactionOutputsTbl =
+        new Schema.Builder("transaction_outputs")
             .setPrimaryKey(Arrays.asList("output_id"))
             .addColumn("transaction_id", new Schema.Varchar2(64))
             .addColumn("index", new Schema.Integer())
@@ -143,212 +144,210 @@ public class Importer {
             .addColumn("spent", new Schema.Boolean())
             .build();
 
-        try (Connection conn = mDataSource.getConnection()) {
-            createTableIfNotExists(conn, mTransactionsTbl.getDDLStatement());
-            createTableIfNotExists(conn, mTransactionInputsTbl.getDDLStatement());
-            createTableIfNotExists(conn, mTransactionOutputsTbl.getDDLStatement());
+    try (Connection conn = mDataSource.getConnection()) {
+      createTableIfNotExists(conn, mTransactionsTbl.getDDLStatement());
+      createTableIfNotExists(conn, mTransactionInputsTbl.getDDLStatement());
+      createTableIfNotExists(conn, mTransactionOutputsTbl.getDDLStatement());
+    }
+
+    // TODO(jackson): Perform some kind of checksuming on the DDL
+    // statements so that we notice if the existing tables were created
+    // from a different configuration? Or store the configuration
+    // itself in Oracle so that they *must* run a program to reconfigure.
+  }
+
+  private boolean createTableIfNotExists(final Connection conn, final String query)
+      throws SQLException {
+    logger.info("Creating table: \n{}", query);
+    try (PreparedStatement ps = conn.prepareStatement(query)) {
+      ps.executeUpdate();
+    } catch (SQLSyntaxErrorException ex) {
+      // If "ORA-00955: name is already used by an existing object",
+      // the table already exists. Otherwise, it's an unexpected exception.
+      if (ex.getErrorCode() != 955) {
+        throw ex;
+      }
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Processes transactions, reading them from the transaction feed
+   * and inserting them into the configured Oracle database. This
+   * function blocks indefinitely. Errors are logged to log4j2.
+   *
+   * TODO(jackson): Support propagating persistent errors?
+   */
+  public void process() {
+    ThreadContext.put("feed_id", mFeed.id);
+    ThreadContext.put("feed_filter", mFeed.filter);
+
+    for (; ; ) {
+      try {
+        ThreadContext.put("feed_after", mFeed.after);
+
+        // Retrieve another page of transactions matching the feed.
+        final Transaction.Items page =
+            new QueryBuilder()
+                .setFilter(mFeed.filter)
+                .setAfter(mFeed.after)
+                .setTimeout(defaultTimeoutMillis)
+                .setAscendingWithLongPoll()
+                .execute(mChain);
+
+        // Commit the batch of transactions to the database.
+        try {
+          processBatch(page.list);
+        } catch (SQLException ex) {
+          logger.catching(ex);
+          // Skip the ack so we re-fetch this page and try again.
+          // TODO(jackson): Do we need any backoff? Don't want to
+          // hammer Chain Core or the Oracle database if there's
+          // an issue.
+          // TODO(jackson): Add retry logic in processBatch so that
+          // we don't re-query Chain Core if we don't need to?
+          continue;
         }
 
-        // TODO(jackson): Perform some kind of checksuming on the DDL
-        // statements so that we notice if the existing tables were created
-        // from a different configuration? Or store the configuration
-        // itself in Oracle so that they *must* run a program to reconfigure.
-    }
-
-    private boolean createTableIfNotExists(
-            final Connection conn, final String query) throws SQLException {
-        logger.info("Creating table: \n{}", query);
-        try (PreparedStatement ps = conn.prepareStatement(query)) {
-            ps.executeUpdate();
-        } catch(SQLSyntaxErrorException ex) {
-            // If "ORA-00955: name is already used by an existing object",
-            // the table already exists. Otherwise, it's an unexpected exception.
-            if (ex.getErrorCode() != 955) {
-                throw ex;
-            }
-            return false;
+        // Acknowledge that we've processed the entire page.
+        Map<String, Object> requestBody = new TreeMap<>();
+        requestBody.put("id", mFeed.id);
+        requestBody.put("previous_after", mFeed.after);
+        requestBody.put("after", page.next.after);
+        mFeed = mChain.request("update-transaction-feed", requestBody, Transaction.Feed.class);
+      } catch (APIException ex) {
+        // If there was an issue retrieving the transactions,
+        // log it. If the request just timed out, no matching
+        // transactions were committed so just silently ignore it.
+        if (!"CH001".equals(ex.code)) {
+          logger.catching(ex);
         }
-        return true;
+      } catch (ChainException ex) {
+        logger.catching(ex);
+      } finally {
+        ThreadContext.remove("feed_after");
+      }
     }
+  }
 
-    /**
-     * Processes transactions, reading them from the transaction feed
-     * and inserting them into the configured Oracle database. This
-     * function blocks indefinitely. Errors are logged to log4j2.
-     *
-     * TODO(jackson): Support propagating persistent errors?
-     */
-    public void process() {
-        ThreadContext.put("feed_id", mFeed.id);
-        ThreadContext.put("feed_filter", mFeed.filter);
+  // processBatch inserts a batch of transactions into the Oracle
+  // database.
+  //
+  // TODO(jackson): Ideally we'd call executeBatch once per prepared-statement
+  // per call to processBatch, but handling the unique constraint violations
+  // gets trickier. We might be able to write a PL/SQL function that ignores
+  // the ORA-00001 exception in Oracle instead of client-side to get around
+  // that.
+  void processBatch(final List<Transaction> transactions) throws SQLException {
+    final String insertTxQ = mTransactionsTbl.getInsertStatement();
+    final String insertInputQ = mTransactionInputsTbl.getInsertStatement();
+    final String insertOutputQ = mTransactionOutputsTbl.getInsertStatement();
 
-        for (;;) {
-            try {
-                ThreadContext.put("feed_after", mFeed.after);
+    try (Connection conn = mDataSource.getConnection();
+        PreparedStatement psTx = conn.prepareStatement(insertTxQ);
+        PreparedStatement psIn = conn.prepareStatement(insertInputQ);
+        PreparedStatement psOut = conn.prepareStatement(insertOutputQ)) {
 
-                // Retrieve another page of transactions matching the feed.
-                final Transaction.Items page = new QueryBuilder()
-                    .setFilter(mFeed.filter)
-                    .setAfter(mFeed.after)
-                    .setTimeout(defaultTimeoutMillis)
-                    .setAscendingWithLongPoll()
-                    .execute(mChain);
+      // Manage our own SQL transactions so we can make this whole
+      // blockchain transaction atomic.
+      conn.setAutoCommit(false);
 
-                // Commit the batch of transactions to the database.
-                try {
-                    processBatch(page.list);
-                } catch (SQLException ex) {
-                    logger.catching(ex);
-                    // Skip the ack so we re-fetch this page and try again.
-                    // TODO(jackson): Do we need any backoff? Don't want to
-                    // hammer Chain Core or the Oracle database if there's
-                    // an issue.
-                    // TODO(jackson): Add retry logic in processBatch so that
-                    // we don't re-query Chain Core if we don't need to?
-                    continue;
-                }
+      for (Transaction tx : transactions) {
+        try {
+          ThreadContext.put("tx_id", tx.id);
+          logger.debug("Importing transaction {}", tx.id);
 
-                // Acknowledge that we've processed the entire page.
-                Map<String, Object> requestBody = new TreeMap<>();
-                requestBody.put("id", mFeed.id);
-                requestBody.put("previous_after", mFeed.after);
-                requestBody.put("after", page.next.after);
-                mFeed = mChain.request("update-transaction-feed", requestBody, Transaction.Feed.class);
-            } catch (APIException ex) {
-                // If there was an issue retrieving the transactions,
-                // log it. If the request just timed out, no matching
-                // transactions were committed so just silently ignore it.
-                if (!"CH001".equals(ex.code)) {
-                    logger.catching(ex);
-                }
-            } catch (ChainException ex) {
-                logger.catching(ex);
-            } finally {
-                ThreadContext.remove("feed_after");
-            }
+          // Insert the transaction itself.
+          psTx.setString(1, tx.id);
+          psTx.setLong(2, tx.blockHeight);
+          psTx.setTimestamp(3, new Timestamp(tx.timestamp.getTime()));
+          psTx.setInt(4, tx.position);
+          psTx.setString(5, "yes".equals(tx.isLocal) ? TRUE : FALSE);
+          psTx.setBlob(6, asJsonBlob(tx.referenceData));
+          psTx.setBlob(7, asJsonBlob(tx));
+
+          // TODO(jackson): We can't use addBatch in Oracle
+          // earlier than 12.1. If customers need support for
+          // Oracle < 12.1, we'll need to use the deprecated
+          // OraclePreparedStatement.setExecuteBatch method:
+          // http://docs.oracle.com/cd/B28359_01/java.111/b31224/oraperf.htm
+          psTx.addBatch();
+
+          // Insert each of the inputs.
+          for (int i = 0; i < tx.inputs.size(); i++) {
+            final Transaction.Input input = tx.inputs.get(i);
+
+            psIn.setString(1, tx.id);
+            psIn.setInt(2, i);
+            psIn.setString(3, input.type);
+            psIn.setString(4, input.assetId);
+            psIn.setString(5, input.assetAlias);
+            psIn.setBlob(6, asJsonBlob(input.assetDefinition));
+            psIn.setBlob(7, asJsonBlob(input.assetTags));
+            psIn.setString(8, "yes".equals(input.assetIsLocal) ? TRUE : FALSE);
+            psIn.setLong(9, input.amount);
+            psIn.setString(10, input.accountId);
+            psIn.setString(11, input.accountAlias);
+            psIn.setBlob(12, asJsonBlob(input.accountTags));
+            psIn.setString(13, input.issuanceProgram); // clob
+            psIn.setBlob(14, asJsonBlob(input.referenceData));
+            psIn.setString(15, "yes".equals(input.isLocal) ? TRUE : FALSE);
+            psIn.setString(16, input.spentOutputId);
+
+            psIn.addBatch();
+          }
+
+          // Insert each of the outputs.
+          for (int i = 0; i < tx.outputs.size(); i++) {
+            final Transaction.Output output = tx.outputs.get(i);
+
+            psOut.setString(1, tx.id);
+            psOut.setInt(2, i);
+            psOut.setString(3, output.id);
+            psOut.setString(4, output.type);
+            psOut.setString(5, output.purpose);
+            psOut.setString(6, output.assetId);
+            psOut.setString(7, output.assetAlias);
+            psOut.setBlob(8, asJsonBlob(output.assetDefinition));
+            psOut.setBlob(9, asJsonBlob(output.assetTags));
+            psOut.setString(10, "yes".equals(output.assetIsLocal) ? TRUE : FALSE);
+            psOut.setLong(11, output.amount);
+            psOut.setString(12, output.accountId);
+            psOut.setString(13, output.accountAlias);
+            psOut.setBlob(14, asJsonBlob(output.accountTags));
+            psOut.setString(15, output.controlProgram); // clob
+            psOut.setBlob(16, asJsonBlob(output.referenceData));
+            psOut.setString(17, "yes".equals(output.isLocal) ? TRUE : FALSE);
+            psOut.setString(18, FALSE);
+
+            psOut.addBatch();
+          }
+
+          // Commit the entire blockchain transaction at once.
+          psTx.executeBatch();
+          psIn.executeBatch();
+          psOut.executeBatch();
+          conn.commit();
+        } catch (SQLException ex) {
+          // We can hit a unique constraint violation (ORA-00001)
+          // iff we already processed these transactions but have not
+          // yet successfully acked them. If that's the case, just
+          // fallthrough to the acknowledgement below.
+          if (ex.getErrorCode() == 1) {
+            logger.info("Processed transaction twice; ignoring");
+          } else {
+            throw ex;
+          }
+        } finally {
+          ThreadContext.remove("tx_id");
         }
+      }
     }
+  }
 
-    // processBatch inserts a batch of transactions into the Oracle
-    // database.
-    //
-    // TODO(jackson): Ideally we'd call executeBatch once per prepared-statement
-    // per call to processBatch, but handling the unique constraint violations
-    // gets trickier. We might be able to write a PL/SQL function that ignores
-    // the ORA-00001 exception in Oracle instead of client-side to get around
-    // that.
-    void processBatch(final List<Transaction> transactions) throws SQLException {
-        final String insertTxQ = mTransactionsTbl.getInsertStatement();
-        final String insertInputQ = mTransactionInputsTbl.getInsertStatement();
-        final String insertOutputQ = mTransactionOutputsTbl.getInsertStatement();
-
-        try (   Connection conn = mDataSource.getConnection();
-                PreparedStatement psTx = conn.prepareStatement(insertTxQ);
-                PreparedStatement psIn = conn.prepareStatement(insertInputQ);
-                PreparedStatement psOut = conn.prepareStatement(insertOutputQ)) {
-
-            // Manage our own SQL transactions so we can make this whole
-            // blockchain transaction atomic.
-            conn.setAutoCommit(false);
-
-            for (Transaction tx : transactions) {
-                try {
-                    ThreadContext.put("tx_id", tx.id);
-                    logger.debug("Importing transaction {}", tx.id);
-
-                    // Insert the transaction itself.
-                    psTx.setString(1, tx.id);
-                    psTx.setLong(2, tx.blockHeight);
-                    psTx.setTimestamp(3, new Timestamp(tx.timestamp.getTime()));
-                    psTx.setInt(4, tx.position);
-                    psTx.setString(5, "yes".equals(tx.isLocal) ? TRUE : FALSE);
-                    psTx.setBlob(6, asJsonBlob(tx.referenceData));
-                    psTx.setBlob(7, asJsonBlob(tx));
-
-                    // TODO(jackson): We can't use addBatch in Oracle
-                    // earlier than 12.1. If customers need support for
-                    // Oracle < 12.1, we'll need to use the deprecated
-                    // OraclePreparedStatement.setExecuteBatch method:
-                    // http://docs.oracle.com/cd/B28359_01/java.111/b31224/oraperf.htm
-                    psTx.addBatch();
-
-                    // Insert each of the inputs.
-                    for (int i = 0; i < tx.inputs.size(); i++) {
-                        final Transaction.Input input = tx.inputs.get(i);
-
-                        psIn.setString(1, tx.id);
-                        psIn.setInt(2, i);
-                        psIn.setString(3, input.type);
-                        psIn.setString(4, input.assetId);
-                        psIn.setString(5, input.assetAlias);
-                        psIn.setBlob(6, asJsonBlob(input.assetDefinition));
-                        psIn.setBlob(7, asJsonBlob(input.assetTags));
-                        psIn.setString(8, "yes".equals(input.assetIsLocal) ? TRUE : FALSE);
-                        psIn.setLong(9, input.amount);
-                        psIn.setString(10, input.accountId);
-                        psIn.setString(11, input.accountAlias);
-                        psIn.setBlob(12, asJsonBlob(input.accountTags));
-                        psIn.setString(13, input.issuanceProgram); // clob
-                        psIn.setBlob(14, asJsonBlob(input.referenceData));
-                        psIn.setString(15, "yes".equals(input.isLocal) ? TRUE : FALSE);
-                        psIn.setString(16, input.spentOutputId);
-
-                        psIn.addBatch();
-                    }
-
-                    // Insert each of the outputs.
-                    for (int i = 0; i < tx.outputs.size(); i++) {
-                        final Transaction.Output output = tx.outputs.get(i);
-
-                        psOut.setString(1, tx.id);
-                        psOut.setInt(2, i);
-                        psOut.setString(3, output.id);
-                        psOut.setString(4, output.type);
-                        psOut.setString(5, output.purpose);
-                        psOut.setString(6, output.assetId);
-                        psOut.setString(7, output.assetAlias);
-                        psOut.setBlob(8, asJsonBlob(output.assetDefinition));
-                        psOut.setBlob(9, asJsonBlob(output.assetTags));
-                        psOut.setString(10, "yes".equals(output.assetIsLocal) ? TRUE : FALSE);
-                        psOut.setLong(11, output.amount);
-                        psOut.setString(12, output.accountId);
-                        psOut.setString(13, output.accountAlias);
-                        psOut.setBlob(14, asJsonBlob(output.accountTags));
-                        psOut.setString(15, output.controlProgram); // clob
-                        psOut.setBlob(16, asJsonBlob(output.referenceData));
-                        psOut.setString(17, "yes".equals(output.isLocal) ? TRUE : FALSE);
-                        psOut.setString(18, FALSE);
-
-                        psOut.addBatch();
-                    }
-
-                    // Commit the entire blockchain transaction at once.
-                    psTx.executeBatch();
-                    psIn.executeBatch();
-                    psOut.executeBatch();
-                    conn.commit();
-                } catch (SQLException ex) {
-                    // We can hit a unique constraint violation (ORA-00001)
-                    // iff we already processed these transactions but have not
-                    // yet successfully acked them. If that's the case, just
-                    // fallthrough to the acknowledgement below.
-                    if (ex.getErrorCode() == 1) {
-                        logger.info("Processed transaction twice; ignoring");
-                    } else {
-                        throw ex;
-                    }
-                } finally {
-                    ThreadContext.remove("tx_id");
-                }
-            }
-        }
-    }
-
-    private static InputStream asJsonBlob(final Object obj) {
-        if (obj == null) return null;
-        return new ByteArrayInputStream(
-                gson
-                .toJson(obj)
-                .getBytes(StandardCharsets.UTF_8));
-    }
+  private static InputStream asJsonBlob(final Object obj) {
+    if (obj == null) return null;
+    return new ByteArrayInputStream(gson.toJson(obj).getBytes(StandardCharsets.UTF_8));
+  }
 }

--- a/analytics/src/main/java/com/chain/analytics/Importer.java
+++ b/analytics/src/main/java/com/chain/analytics/Importer.java
@@ -186,7 +186,7 @@ public class Importer {
     ThreadContext.put("feed_id", mFeed.id);
     ThreadContext.put("feed_filter", mFeed.filter);
 
-    for (; ; ) {
+    while (true) {
       try {
         ThreadContext.put("feed_after", mFeed.after);
 

--- a/analytics/src/main/java/com/chain/analytics/Schema.java
+++ b/analytics/src/main/java/com/chain/analytics/Schema.java
@@ -14,7 +14,7 @@ public class Schema {
   List<List<String>> mUniqueConstraints;
 
   /**
-   * Column represetns a single column in a table.
+   * Column represents a single column in a table.
    */
   public static class Column {
     String name;

--- a/analytics/src/main/java/com/chain/analytics/Schema.java
+++ b/analytics/src/main/java/com/chain/analytics/Schema.java
@@ -1,0 +1,227 @@
+package analytics;
+
+import java.util.*;
+
+/**
+ * Schema represents the schema of an Oracle database table. Schemas
+ * are generated based on the Chain Analytics configuration. Once
+ * constructed, a Schema is immutable.
+ */
+public class Schema {
+    String mName;
+    List<Column> mColumns;
+    List<String> mPrimaryKey;
+    List<List<String>> mUniqueConstraints;
+
+    /**
+     * Column represetns a single column in a table.
+     */
+    public static class Column {
+        String name;
+        SQLType type;
+        public Column(final String name, final SQLType type) {
+            this.name = name;
+            this.type = type;
+        }
+    }
+
+    /**
+     * SQLType describes a SQL type that can be used when
+     * constructing a DDL query.
+     */
+    public interface SQLType {
+        String toString();
+    }
+
+    /**
+     * Builder implements the builder pattern for a Schema.
+     */
+    public static class Builder {
+        private String mName;
+        private List<Column> mColumns;
+        private List<String> mPrimaryKey;
+        private List<List<String>> mUniqueConstraints;
+
+        /**
+         * Constructor for a builder.
+         *
+         * @param name the name of the table
+         */
+        public Builder(final String name) {
+            mName = name;
+            mColumns = new ArrayList<>();
+            mPrimaryKey = Collections.emptyList();
+            mUniqueConstraints = new ArrayList<>();
+        }
+
+        /**
+         * Adds a column to the table.
+         *
+         * @param name the name of the SQL column
+         * @param typ  the Oracle SQL type of the column
+         */
+        public Builder addColumn(final String name, final SQLType typ) {
+            mColumns.add(new Column(name, typ));
+            return this;
+        }
+
+        /**
+         * Adds a uniqueness constraint on the provided columns.
+         *
+         * @param columns a list of the columns that the uniqueness
+         *                constraint covers.
+         */
+        public Builder addUniqueConstraint(final List<String> columns) {
+            mUniqueConstraints.add(columns);
+            return this;
+        }
+
+        /**
+         * Adds a primary key constraint on the provided columns.
+         *
+         * @param columns a list of one or more columns that form
+         *                the table's primary key.
+         */
+        public Builder setPrimaryKey(final List<String> columns) {
+            mPrimaryKey = columns;
+            return this;
+        }
+
+        /**
+         * Constructs the schema.
+         *
+         * @return the built, immutable Schema
+         */
+        public Schema build() {
+            final Schema schema = new Schema();
+            schema.mName = mName;
+            schema.mColumns = Collections.unmodifiableList(mColumns);
+            schema.mPrimaryKey = Collections.unmodifiableList(mPrimaryKey);
+            schema.mUniqueConstraints = Collections.unmodifiableList(mUniqueConstraints);
+            return schema;
+        }
+    }
+
+    /**
+     * Constructs a CREATE TABLE statement for the schema.
+     * @return a CREATE TABLE DDL statement
+     */
+    public String getDDLStatement() {
+        final StringBuilder sb = new StringBuilder();
+        sb
+            .append("CREATE TABLE ")
+            .append(mName.toUpperCase())
+            .append(" (");
+
+        String sep = "";
+        for (final Column col : mColumns) {
+            sb
+                .append(sep)
+                .append("\n")
+                .append("  ")
+                .append("\"")
+                .append(col.name.toUpperCase())
+                .append("\"")
+                .append(" ")
+                .append(col.type.toString());
+
+            // use a comma separator before every column after the first.
+            sep = ",";
+        }
+
+        for (final List<String> cols : mUniqueConstraints) {
+            sb
+                .append(",\n  CONSTRAINT ")
+                .append(String.join("_", cols))
+                .append("_u UNIQUE (");
+            sep = "";
+            for (final String col : cols) {
+                sb
+                    .append(sep)
+                    .append("\"")
+                    .append(col.toUpperCase())
+                    .append("\"");
+                sep = ", ";
+            }
+            sb.append(")");
+        }
+
+        if (!mPrimaryKey.isEmpty()) {
+            sb
+                .append(",\n  CONSTRAINT ")
+                .append(mName)
+                .append("_pk PRIMARY KEY (");
+            sep = "";
+            for (final String keyCol : mPrimaryKey) {
+                sb
+                    .append(sep)
+                    .append("\"")
+                    .append(keyCol.toUpperCase())
+                    .append("\"");
+                sep = ", ";
+            }
+            sb.append(")");
+        }
+
+        sb.append(")");
+        return sb.toString();
+    }
+
+    /**
+     * Constructs the beginning of an INSERT statement for the
+     * table.
+     */
+    public String getInsertStatement() {
+        final StringBuilder sb = new StringBuilder()
+            .append("INSERT INTO ")
+            .append(mName.toUpperCase())
+            .append("\n(");
+
+        String sep = "";
+        for (final Column col : mColumns) {
+            sb
+                .append(sep)
+                .append("\"")
+                .append(col.name.toUpperCase())
+                .append("\"");
+            sep = ", ";
+        }
+        sb
+            .append(")\nVALUES(")
+            .append(String.join(", ", Collections.nCopies(mColumns.size(), "?")))
+            .append(")");
+        return sb.toString();
+    }
+
+    public static class Blob implements SQLType {
+        public String toString() { return "BLOB"; }
+    }
+
+    public static class Boolean implements SQLType {
+        public String toString() { return "CHAR(1)"; }
+    }
+
+    public static class Clob implements SQLType {
+        public String toString() { return "CLOB"; }
+    }
+
+    public static class Integer implements SQLType {
+        public String toString() { return "NUMBER(20)"; }
+    }
+
+    public static class Timestamp implements SQLType {
+        public String toString() { return "TIMESTAMP WITH TIME ZONE"; }
+    }
+
+    public static class Varchar2 implements SQLType {
+        private int mLength;
+
+        public Varchar2(final int maxLength) {
+            mLength = maxLength;
+        }
+
+        public String toString() {
+            return String.format("VARCHAR2(%d)", mLength);
+        }
+    }
+}

--- a/analytics/src/main/java/com/chain/analytics/Schema.java
+++ b/analytics/src/main/java/com/chain/analytics/Schema.java
@@ -8,220 +8,206 @@ import java.util.*;
  * constructed, a Schema is immutable.
  */
 public class Schema {
-    String mName;
-    List<Column> mColumns;
-    List<String> mPrimaryKey;
-    List<List<String>> mUniqueConstraints;
+  String mName;
+  List<Column> mColumns;
+  List<String> mPrimaryKey;
+  List<List<String>> mUniqueConstraints;
 
-    /**
-     * Column represetns a single column in a table.
-     */
-    public static class Column {
-        String name;
-        SQLType type;
-        public Column(final String name, final SQLType type) {
-            this.name = name;
-            this.type = type;
-        }
+  /**
+   * Column represetns a single column in a table.
+   */
+  public static class Column {
+    String name;
+    SQLType type;
+
+    public Column(final String name, final SQLType type) {
+      this.name = name;
+      this.type = type;
     }
+  }
+
+  /**
+   * SQLType describes a SQL type that can be used when
+   * constructing a DDL query.
+   */
+  public interface SQLType {
+    String toString();
+  }
+
+  /**
+   * Builder implements the builder pattern for a Schema.
+   */
+  public static class Builder {
+    private String mName;
+    private List<Column> mColumns;
+    private List<String> mPrimaryKey;
+    private List<List<String>> mUniqueConstraints;
 
     /**
-     * SQLType describes a SQL type that can be used when
-     * constructing a DDL query.
+     * Constructor for a builder.
+     *
+     * @param name the name of the table
      */
-    public interface SQLType {
-        String toString();
-    }
-
-    /**
-     * Builder implements the builder pattern for a Schema.
-     */
-    public static class Builder {
-        private String mName;
-        private List<Column> mColumns;
-        private List<String> mPrimaryKey;
-        private List<List<String>> mUniqueConstraints;
-
-        /**
-         * Constructor for a builder.
-         *
-         * @param name the name of the table
-         */
-        public Builder(final String name) {
-            mName = name;
-            mColumns = new ArrayList<>();
-            mPrimaryKey = Collections.emptyList();
-            mUniqueConstraints = new ArrayList<>();
-        }
-
-        /**
-         * Adds a column to the table.
-         *
-         * @param name the name of the SQL column
-         * @param typ  the Oracle SQL type of the column
-         */
-        public Builder addColumn(final String name, final SQLType typ) {
-            mColumns.add(new Column(name, typ));
-            return this;
-        }
-
-        /**
-         * Adds a uniqueness constraint on the provided columns.
-         *
-         * @param columns a list of the columns that the uniqueness
-         *                constraint covers.
-         */
-        public Builder addUniqueConstraint(final List<String> columns) {
-            mUniqueConstraints.add(columns);
-            return this;
-        }
-
-        /**
-         * Adds a primary key constraint on the provided columns.
-         *
-         * @param columns a list of one or more columns that form
-         *                the table's primary key.
-         */
-        public Builder setPrimaryKey(final List<String> columns) {
-            mPrimaryKey = columns;
-            return this;
-        }
-
-        /**
-         * Constructs the schema.
-         *
-         * @return the built, immutable Schema
-         */
-        public Schema build() {
-            final Schema schema = new Schema();
-            schema.mName = mName;
-            schema.mColumns = Collections.unmodifiableList(mColumns);
-            schema.mPrimaryKey = Collections.unmodifiableList(mPrimaryKey);
-            schema.mUniqueConstraints = Collections.unmodifiableList(mUniqueConstraints);
-            return schema;
-        }
+    public Builder(final String name) {
+      mName = name;
+      mColumns = new ArrayList<>();
+      mPrimaryKey = Collections.emptyList();
+      mUniqueConstraints = new ArrayList<>();
     }
 
     /**
-     * Constructs a CREATE TABLE statement for the schema.
-     * @return a CREATE TABLE DDL statement
+     * Adds a column to the table.
+     *
+     * @param name the name of the SQL column
+     * @param typ  the Oracle SQL type of the column
      */
-    public String getDDLStatement() {
-        final StringBuilder sb = new StringBuilder();
-        sb
-            .append("CREATE TABLE ")
-            .append(mName.toUpperCase())
-            .append(" (");
-
-        String sep = "";
-        for (final Column col : mColumns) {
-            sb
-                .append(sep)
-                .append("\n")
-                .append("  ")
-                .append("\"")
-                .append(col.name.toUpperCase())
-                .append("\"")
-                .append(" ")
-                .append(col.type.toString());
-
-            // use a comma separator before every column after the first.
-            sep = ",";
-        }
-
-        for (final List<String> cols : mUniqueConstraints) {
-            sb
-                .append(",\n  CONSTRAINT ")
-                .append(String.join("_", cols))
-                .append("_u UNIQUE (");
-            sep = "";
-            for (final String col : cols) {
-                sb
-                    .append(sep)
-                    .append("\"")
-                    .append(col.toUpperCase())
-                    .append("\"");
-                sep = ", ";
-            }
-            sb.append(")");
-        }
-
-        if (!mPrimaryKey.isEmpty()) {
-            sb
-                .append(",\n  CONSTRAINT ")
-                .append(mName)
-                .append("_pk PRIMARY KEY (");
-            sep = "";
-            for (final String keyCol : mPrimaryKey) {
-                sb
-                    .append(sep)
-                    .append("\"")
-                    .append(keyCol.toUpperCase())
-                    .append("\"");
-                sep = ", ";
-            }
-            sb.append(")");
-        }
-
-        sb.append(")");
-        return sb.toString();
+    public Builder addColumn(final String name, final SQLType typ) {
+      mColumns.add(new Column(name, typ));
+      return this;
     }
 
     /**
-     * Constructs the beginning of an INSERT statement for the
-     * table.
+     * Adds a uniqueness constraint on the provided columns.
+     *
+     * @param columns a list of the columns that the uniqueness
+     *                constraint covers.
      */
-    public String getInsertStatement() {
-        final StringBuilder sb = new StringBuilder()
-            .append("INSERT INTO ")
-            .append(mName.toUpperCase())
-            .append("\n(");
-
-        String sep = "";
-        for (final Column col : mColumns) {
-            sb
-                .append(sep)
-                .append("\"")
-                .append(col.name.toUpperCase())
-                .append("\"");
-            sep = ", ";
-        }
-        sb
-            .append(")\nVALUES(")
-            .append(String.join(", ", Collections.nCopies(mColumns.size(), "?")))
-            .append(")");
-        return sb.toString();
+    public Builder addUniqueConstraint(final List<String> columns) {
+      mUniqueConstraints.add(columns);
+      return this;
     }
 
-    public static class Blob implements SQLType {
-        public String toString() { return "BLOB"; }
+    /**
+     * Adds a primary key constraint on the provided columns.
+     *
+     * @param columns a list of one or more columns that form
+     *                the table's primary key.
+     */
+    public Builder setPrimaryKey(final List<String> columns) {
+      mPrimaryKey = columns;
+      return this;
     }
 
-    public static class Boolean implements SQLType {
-        public String toString() { return "CHAR(1)"; }
+    /**
+     * Constructs the schema.
+     *
+     * @return the built, immutable Schema
+     */
+    public Schema build() {
+      final Schema schema = new Schema();
+      schema.mName = mName;
+      schema.mColumns = Collections.unmodifiableList(mColumns);
+      schema.mPrimaryKey = Collections.unmodifiableList(mPrimaryKey);
+      schema.mUniqueConstraints = Collections.unmodifiableList(mUniqueConstraints);
+      return schema;
+    }
+  }
+
+  /**
+   * Constructs a CREATE TABLE statement for the schema.
+   * @return a CREATE TABLE DDL statement
+   */
+  public String getDDLStatement() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("CREATE TABLE ").append(mName.toUpperCase()).append(" (");
+
+    String sep = "";
+    for (final Column col : mColumns) {
+      sb.append(sep)
+          .append("\n")
+          .append("  ")
+          .append("\"")
+          .append(col.name.toUpperCase())
+          .append("\"")
+          .append(" ")
+          .append(col.type.toString());
+
+      // use a comma separator before every column after the first.
+      sep = ",";
     }
 
-    public static class Clob implements SQLType {
-        public String toString() { return "CLOB"; }
+    for (final List<String> cols : mUniqueConstraints) {
+      sb.append(",\n  CONSTRAINT ").append(String.join("_", cols)).append("_u UNIQUE (");
+      sep = "";
+      for (final String col : cols) {
+        sb.append(sep).append("\"").append(col.toUpperCase()).append("\"");
+        sep = ", ";
+      }
+      sb.append(")");
     }
 
-    public static class Integer implements SQLType {
-        public String toString() { return "NUMBER(20)"; }
+    if (!mPrimaryKey.isEmpty()) {
+      sb.append(",\n  CONSTRAINT ").append(mName).append("_pk PRIMARY KEY (");
+      sep = "";
+      for (final String keyCol : mPrimaryKey) {
+        sb.append(sep).append("\"").append(keyCol.toUpperCase()).append("\"");
+        sep = ", ";
+      }
+      sb.append(")");
     }
 
-    public static class Timestamp implements SQLType {
-        public String toString() { return "TIMESTAMP WITH TIME ZONE"; }
+    sb.append(")");
+    return sb.toString();
+  }
+
+  /**
+   * Constructs the beginning of an INSERT statement for the
+   * table.
+   */
+  public String getInsertStatement() {
+    final StringBuilder sb =
+        new StringBuilder().append("INSERT INTO ").append(mName.toUpperCase()).append("\n(");
+
+    String sep = "";
+    for (final Column col : mColumns) {
+      sb.append(sep).append("\"").append(col.name.toUpperCase()).append("\"");
+      sep = ", ";
+    }
+    sb.append(")\nVALUES(")
+        .append(String.join(", ", Collections.nCopies(mColumns.size(), "?")))
+        .append(")");
+    return sb.toString();
+  }
+
+  public static class Blob implements SQLType {
+    public String toString() {
+      return "BLOB";
+    }
+  }
+
+  public static class Boolean implements SQLType {
+    public String toString() {
+      return "CHAR(1)";
+    }
+  }
+
+  public static class Clob implements SQLType {
+    public String toString() {
+      return "CLOB";
+    }
+  }
+
+  public static class Integer implements SQLType {
+    public String toString() {
+      return "NUMBER(20)";
+    }
+  }
+
+  public static class Timestamp implements SQLType {
+    public String toString() {
+      return "TIMESTAMP WITH TIME ZONE";
+    }
+  }
+
+  public static class Varchar2 implements SQLType {
+    private int mLength;
+
+    public Varchar2(final int maxLength) {
+      mLength = maxLength;
     }
 
-    public static class Varchar2 implements SQLType {
-        private int mLength;
-
-        public Varchar2(final int maxLength) {
-            mLength = maxLength;
-        }
-
-        public String toString() {
-            return String.format("VARCHAR2(%d)", mLength);
-        }
+    public String toString() {
+      return String.format("VARCHAR2(%d)", mLength);
     }
+  }
 }

--- a/analytics/src/main/resources/log4j2.xml
+++ b/analytics/src/main/resources/log4j2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="info">
+  <Properties>
+    <Property name="filename">target/chain-analytics.log</Property>
+  </Properties>
+  <Filter type="ThresholdFilter" level="info"/>
+
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+        <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n" />
+    </Console>
+
+    <RollingFile name="RollingFile" filename="log/chain-analytics.log"
+        filepattern="${logPath}/%d{YYYYMMddHHmmss}-chain-analytics.log">
+        <PatternLayout pattern="%d{YYYY-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n" />
+        <Policies>
+            <SizeBasedTriggeringPolicy size="100 MB" />
+        </Policies>
+        <DefaultRolloverStrategy max="20" />
+    </RollingFile>
+  </Appenders>
+
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/analytics/src/test/java/com/chain/analytics/SchemaTest.java
+++ b/analytics/src/test/java/com/chain/analytics/SchemaTest.java
@@ -6,45 +6,50 @@ import static junit.framework.TestCase.assertEquals;
 
 public class SchemaTest {
 
-    static final Schema oneColumn = new Schema.Builder("transactions")
-            .addColumn("id", new Schema.Varchar2(32))
-            .setPrimaryKey(Arrays.asList("id"))
-            .build();
-    static final Schema multipleColumns = new Schema.Builder("transaction_outputs")
-            .addColumn("transaction_id", new Schema.Varchar2(32))
-            .addColumn("index", new Schema.Integer())
-            .addColumn("output_id", new Schema.Varchar2(32))
-            .addUniqueConstraint(Arrays.asList("transaction_id", "index"))
-            .setPrimaryKey(Arrays.asList("output_id"))
-            .build();
+  static final Schema oneColumn =
+      new Schema.Builder("transactions")
+          .addColumn("id", new Schema.Varchar2(32))
+          .setPrimaryKey(Arrays.asList("id"))
+          .build();
+  static final Schema multipleColumns =
+      new Schema.Builder("transaction_outputs")
+          .addColumn("transaction_id", new Schema.Varchar2(32))
+          .addColumn("index", new Schema.Integer())
+          .addColumn("output_id", new Schema.Varchar2(32))
+          .addUniqueConstraint(Arrays.asList("transaction_id", "index"))
+          .setPrimaryKey(Arrays.asList("output_id"))
+          .build();
 
-    @Test
-    public void testOneColumnSchemaDDL() {
-        final String ddl = oneColumn.getDDLStatement();
-        assertEquals("CREATE TABLE TRANSACTIONS (\n" +
-                "  \"ID\" VARCHAR2(32),\n" +
-                "  CONSTRAINT transactions_pk PRIMARY KEY (\"ID\"))", ddl);
-    }
+  @Test
+  public void testOneColumnSchemaDDL() {
+    final String ddl = oneColumn.getDDLStatement();
+    assertEquals(
+        "CREATE TABLE TRANSACTIONS (\n"
+            + "  \"ID\" VARCHAR2(32),\n"
+            + "  CONSTRAINT transactions_pk PRIMARY KEY (\"ID\"))",
+        ddl);
+  }
 
-    @Test
-    public void testMultipleColumnSchemaDDL() {
-        final String ddl = multipleColumns.getDDLStatement();
-        assertEquals(
-                "CREATE TABLE TRANSACTION_OUTPUTS (\n" +
-                "  \"TRANSACTION_ID\" VARCHAR2(32),\n" +
-                "  \"INDEX\" NUMBER(20),\n" +
-                "  \"OUTPUT_ID\" VARCHAR2(32),\n" +
-                "  CONSTRAINT transaction_id_index_u UNIQUE (\"TRANSACTION_ID\", \"INDEX\"),\n" +
-                "  CONSTRAINT transaction_outputs_pk PRIMARY KEY (\"OUTPUT_ID\"))", ddl);
-    }
+  @Test
+  public void testMultipleColumnSchemaDDL() {
+    final String ddl = multipleColumns.getDDLStatement();
+    assertEquals(
+        "CREATE TABLE TRANSACTION_OUTPUTS (\n"
+            + "  \"TRANSACTION_ID\" VARCHAR2(32),\n"
+            + "  \"INDEX\" NUMBER(20),\n"
+            + "  \"OUTPUT_ID\" VARCHAR2(32),\n"
+            + "  CONSTRAINT transaction_id_index_u UNIQUE (\"TRANSACTION_ID\", \"INDEX\"),\n"
+            + "  CONSTRAINT transaction_outputs_pk PRIMARY KEY (\"OUTPUT_ID\"))",
+        ddl);
+  }
 
-    @Test
-    public void testMultipleColumnSchemaInsert() {
-        final String insertQuery = multipleColumns.getInsertStatement();
-        assertEquals(
-                "INSERT INTO TRANSACTION_OUTPUTS\n" +
-                "(\"TRANSACTION_ID\", \"INDEX\", \"OUTPUT_ID\")\n" +
-                "VALUES(?, ?, ?)", insertQuery);
-    }
-
+  @Test
+  public void testMultipleColumnSchemaInsert() {
+    final String insertQuery = multipleColumns.getInsertStatement();
+    assertEquals(
+        "INSERT INTO TRANSACTION_OUTPUTS\n"
+            + "(\"TRANSACTION_ID\", \"INDEX\", \"OUTPUT_ID\")\n"
+            + "VALUES(?, ?, ?)",
+        insertQuery);
+  }
 }

--- a/analytics/src/test/java/com/chain/analytics/SchemaTest.java
+++ b/analytics/src/test/java/com/chain/analytics/SchemaTest.java
@@ -1,0 +1,50 @@
+package analytics;
+
+import java.util.Arrays;
+import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+
+public class SchemaTest {
+
+    static final Schema oneColumn = new Schema.Builder("transactions")
+            .addColumn("id", new Schema.Varchar2(32))
+            .setPrimaryKey(Arrays.asList("id"))
+            .build();
+    static final Schema multipleColumns = new Schema.Builder("transaction_outputs")
+            .addColumn("transaction_id", new Schema.Varchar2(32))
+            .addColumn("index", new Schema.Integer())
+            .addColumn("output_id", new Schema.Varchar2(32))
+            .addUniqueConstraint(Arrays.asList("transaction_id", "index"))
+            .setPrimaryKey(Arrays.asList("output_id"))
+            .build();
+
+    @Test
+    public void testOneColumnSchemaDDL() {
+        final String ddl = oneColumn.getDDLStatement();
+        assertEquals("CREATE TABLE TRANSACTIONS (\n" +
+                "  \"ID\" VARCHAR2(32),\n" +
+                "  CONSTRAINT transactions_pk PRIMARY KEY (\"ID\"))", ddl);
+    }
+
+    @Test
+    public void testMultipleColumnSchemaDDL() {
+        final String ddl = multipleColumns.getDDLStatement();
+        assertEquals(
+                "CREATE TABLE TRANSACTION_OUTPUTS (\n" +
+                "  \"TRANSACTION_ID\" VARCHAR2(32),\n" +
+                "  \"INDEX\" NUMBER(20),\n" +
+                "  \"OUTPUT_ID\" VARCHAR2(32),\n" +
+                "  CONSTRAINT transaction_id_index_u UNIQUE (\"TRANSACTION_ID\", \"INDEX\"),\n" +
+                "  CONSTRAINT transaction_outputs_pk PRIMARY KEY (\"OUTPUT_ID\"))", ddl);
+    }
+
+    @Test
+    public void testMultipleColumnSchemaInsert() {
+        final String insertQuery = multipleColumns.getInsertStatement();
+        assertEquals(
+                "INSERT INTO TRANSACTION_OUTPUTS\n" +
+                "(\"TRANSACTION_ID\", \"INDEX\", \"OUTPUT_ID\")\n" +
+                "VALUES(?, ?, ?)", insertQuery);
+    }
+
+}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2906";
+	public final String Id = "main/rev2907";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2906"
+const ID string = "main/rev2907"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2906"
+export const rev_id = "main/rev2907"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2906".freeze
+	ID = "main/rev2907".freeze
 end


### PR DESCRIPTION
Add new java service for importing Chain Core transactions
to an Oracle database.

Future work:
 * custom reference data fields
 * high-availability (leader election?)
 * true batch inserts of transactions
 * PL/SQL function for archiving old data
 * alerting / health checks?
 * configuring views / materialized views?