### PR TITLE
all: support client cert authentication

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -53,9 +53,9 @@ const (
 
 var (
 	// config vars
-	tlsCrt        = env.String("TLSCRT", "")
-	tlsKey        = env.String("TLSKEY", "")
-	rootCAs       = env.String("ROOT_CA_CERTS", "")
+	tlsCrt        = env.String("TLSCRT", "")        // file path
+	tlsKey        = env.String("TLSKEY", "")        // file path
+	rootCAs       = env.String("ROOT_CA_CERTS", "") // file path
 	listenAddr    = env.String("LISTEN", ":1999")
 	dbURL         = env.String("DATABASE_URL", "postgres:///core?sslmode=disable")
 	splunkAddr    = os.Getenv("SPLUNKADDR")

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -55,7 +55,7 @@ var (
 	// config vars
 	tlsCrt        = env.String("TLSCRT", "")
 	tlsKey        = env.String("TLSKEY", "")
-	rootCAs       = env.String("ROOT_CA_CERTS", "") // file path
+	rootCAs       = env.String("ROOT_CA_CERTS", "")
 	listenAddr    = env.String("LISTEN", ":1999")
 	dbURL         = env.String("DATABASE_URL", "postgres:///core?sslmode=disable")
 	splunkAddr    = os.Getenv("SPLUNKADDR")
@@ -142,6 +142,9 @@ func runServer() {
 	ctx := context.Background()
 	env.Parse()
 
+	// needs to happen after env.Parse()
+	config.TLS = *tlsCrt != "" && *tlsKey != "" && *rootCAs != ""
+
 	raftDir := filepath.Join(*dataDir, "raft") // TODO(kr): better name for this
 	// TODO(tessr): remove tls param once we have tls everywhere
 	raftDB, err := raft.Start(*listenAddr, raftDir, *bootURL, *tlsCrt != "")
@@ -183,14 +186,21 @@ func runServer() {
 	// it's blocking and we need to proceed to the rest of the core setup after
 	// we call it.
 	go func() {
-		if *tlsCrt != "" {
-			cert, err := tls.X509KeyPair([]byte(*tlsCrt), []byte(*tlsKey))
+		if config.TLS {
+			caPool := loadRootCAs(*rootCAs)
+			http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+				RootCAs: caPool,
+			}
+
+			cert, err := loadX509KeyPair(*tlsCrt, *tlsKey)
 			if err != nil {
 				chainlog.Fatalkv(ctx, chainlog.KeyError, errors.Wrap(err, "parsing tls X509 key pair"))
 			}
 
 			server.TLSConfig = &tls.Config{
 				Certificates: []tls.Certificate{cert},
+				ClientAuth:   tls.VerifyClientCertIfGiven,
+				ClientCAs:    caPool,
 			}
 			err = server.ListenAndServeTLS("", "") // uses TLS certs from above
 			if err != nil {
@@ -203,12 +213,6 @@ func runServer() {
 			}
 		}
 	}()
-
-	if *rootCAs != "" {
-		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
-			RootCAs: loadRootCAs(*rootCAs),
-		}
-	}
 
 	sql.EnableQueryLogging(*logQueries)
 	db, err := sql.Open("hapg", *dbURL)
@@ -460,4 +464,19 @@ func loadRootCAs(name string) *x509.CertPool {
 		chainlog.Fatalkv(context.Background(), chainlog.KeyError, "no certs found in "+name)
 	}
 	return pool
+}
+
+// loadX509KeyPair reads a PEM-encoded X.509 certificate and
+// corresponding, RSA private key from provided file paths
+func loadX509KeyPair(cName, kName string) (tls.Certificate, error) {
+	cBytes, err := ioutil.ReadFile(cName)
+	if err != nil {
+		chainlog.Fatalkv(context.Background(), chainlog.KeyError, err)
+	}
+
+	kBytes, err := ioutil.ReadFile(kName)
+	if err != nil {
+		chainlog.Fatalkv(context.Background(), chainlog.KeyError, err)
+	}
+	return tls.X509KeyPair(cBytes, kBytes)
 }

--- a/core/api.go
+++ b/core/api.go
@@ -318,10 +318,13 @@ func (a *API) forwardToLeader(ctx context.Context, path string, body interface{}
 		return errLeaderElection
 	}
 
-	// TODO(jackson): If using TLS, use https:// here.
-	l := &rpc.Client{
-		BaseURL: "http://" + addr,
+	leaderURL := "http://" + addr
+	if config.TLS {
+		// Issue #674: If cored is configured to use TLS,
+		// assume the leader is reachable via https.
+		leaderURL = "https://" + addr
 	}
+	l := &rpc.Client{BaseURL: leaderURL}
 
 	// Forward the request credentials if we have them.
 	// TODO(jackson): Don't use the incoming request's credentials and

--- a/core/authn.go
+++ b/core/authn.go
@@ -45,7 +45,7 @@ func (a *apiAuthn) handler(next http.Handler) http.Handler {
 
 func (a *apiAuthn) auth(req *http.Request) error {
 	if req.TLS != nil && req.TLS.HandshakeComplete && len(req.TLS.VerifiedChains) > 0 {
-		// A client certificate was received.
+		// A valid client certificate was received.
 		// No need to authenticate access token.
 		//
 		// TODO(boymanjor): use subject name

--- a/core/authn.go
+++ b/core/authn.go
@@ -44,6 +44,15 @@ func (a *apiAuthn) handler(next http.Handler) http.Handler {
 }
 
 func (a *apiAuthn) auth(req *http.Request) error {
+	if req.TLS != nil && req.TLS.HandshakeComplete && len(req.TLS.VerifiedChains) > 0 {
+		// A client certificate was received.
+		// No need to authenticate access token.
+		//
+		// TODO(boymanjor): use subject name
+		// from req.TLS.PeerCertificates for authz.
+		return nil
+	}
+
 	user, pw, ok := req.BasicAuth()
 	if !ok && a.alt != nil && a.alt(req) {
 		return nil

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -41,6 +41,7 @@ var (
 	ErrNoBlockHSMURL   = errors.New("block hsm URL cannot be empty in mockhsm disabled build")
 
 	Version, BuildCommit, BuildDate string
+	TLS                             bool
 
 	// This is the default, Chain development configuration.
 	// These options can be updated with build tags.

--- a/sdk/java/src/main/java/com/chain/api/MockHsm.java
+++ b/sdk/java/src/main/java/com/chain/api/MockHsm.java
@@ -25,7 +25,7 @@ public class MockHsm {
    * @return new client object
    * @throws BadURLException
    */
-  public static Client getSignerClient(Client client) throws BadURLException {
+  public static Client getSignerClient(Client client) throws ChainException {
     try {
       URL signerUrl = new URL(client.url().toString() + "/mockhsm");
       if (client.hasAccessToken()) {

--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -5,11 +5,20 @@ import com.chain.common.*;
 
 import java.io.*;
 import java.lang.reflect.Type;
+import java.math.BigInteger;
 import java.net.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
 import java.security.KeyStore;
+import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.spec.KeySpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPrivateCrtKeySpec;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -25,6 +34,10 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 
+import sun.misc.BASE64Decoder;
+import sun.security.util.DerInputStream;
+import sun.security.util.DerValue;
+
 import javax.net.ssl.*;
 
 /**
@@ -35,12 +48,16 @@ import javax.net.ssl.*;
  * to an HSM server.
  */
 public class Client {
-
   private AtomicInteger urlIndex;
   private List<URL> urls;
   private String accessToken;
   private OkHttpClient httpClient;
+
   private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+  private static final String PKCS1_HEADER = "-----BEGIN RSA PRIVATE KEY-----\n";
+  private static final String PKCS1_FOOTER = "-----END RSA PRIVATE KEY-----\n";
+  private static final String PKCS8_HEADER = "-----BEGIN PRIVATE KEY-----\n";
+  private static final String PKCS8_FOOTER = "-----END PRIVATE KEY-----\n";
   private static String version = "dev"; // updated in the static initializer
 
   private static class BuildProperties {
@@ -55,7 +72,7 @@ public class Client {
     }
   }
 
-  public Client(Builder builder) {
+  public Client(Builder builder) throws HTTPException {
     List<URL> urls = new ArrayList<URL>(builder.urls);
     if (urls.isEmpty()) {
       try {
@@ -74,7 +91,7 @@ public class Client {
   /**
    * Create a new http Client object using the default development host URL.
    */
-  public Client() {
+  public Client() throws ChainException {
     this(new Builder());
   }
 
@@ -83,7 +100,7 @@ public class Client {
    *
    * @param url the URL of the Chain Core or HSM
    */
-  public Client(String url) throws BadURLException {
+  public Client(String url) throws ChainException {
     this(new Builder().setURL(url));
   }
 
@@ -92,7 +109,7 @@ public class Client {
    *
    * @param url the URL of the Chain Core or HSM
    */
-  public Client(URL url) {
+  public Client(URL url) throws HTTPException {
     this(new Builder().setURL(url));
   }
 
@@ -102,7 +119,7 @@ public class Client {
    * @param url the URL of the Chain Core or HSM
    * @param accessToken a Client API access token
    */
-  public Client(String url, String accessToken) throws BadURLException {
+  public Client(String url, String accessToken) throws ChainException {
     this(new Builder().setURL(url).setAccessToken(accessToken));
   }
 
@@ -112,7 +129,7 @@ public class Client {
    * @param url the URL of the Chain Core or HSM
    * @param accessToken a Client API access token
    */
-  public Client(URL url, String accessToken) {
+  public Client(URL url, String accessToken) throws ChainException {
     this(new Builder().setURL(url).setAccessToken(accessToken));
   }
 
@@ -378,11 +395,18 @@ public class Client {
     throw exception;
   }
 
-  private OkHttpClient buildHttpClient(Builder builder) {
+  private OkHttpClient buildHttpClient(Builder builder) throws HTTPException {
     OkHttpClient httpClient = new OkHttpClient();
 
-    if (builder.sslSocketFactory != null) {
-      httpClient.setSslSocketFactory(builder.sslSocketFactory);
+    // Finally, configure the socket factory.
+    try {
+      if (builder.trustManagers != null) {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(builder.keyManagers, builder.trustManagers, null);
+        httpClient.setSslSocketFactory(sslContext.getSocketFactory());
+      }
+    } catch (GeneralSecurityException ex) {
+      throw new HTTPException("Unable to configure TLS", ex);
     }
 
     httpClient.setFollowRedirects(false);
@@ -529,7 +553,8 @@ public class Client {
     private List<URL> urls;
     private String accessToken;
     private CertificatePinner cp;
-    private SSLSocketFactory sslSocketFactory;
+    private KeyManager[] keyManagers;
+    private TrustManager[] trustManagers;
     private long connectTimeout;
     private TimeUnit connectTimeoutUnit;
     private long readTimeout;
@@ -609,13 +634,91 @@ public class Client {
     }
 
     /**
+     * Sets the client's certificate/key pair for mutual TLS authentication.
+     * @param certPath filepath to pem encoded X.509 certificate
+     * @param keyPath filepath to pem encoded X.509 private key
+     */
+    public Builder setX509KeyPair(String certPath, String keyPath) throws HTTPException {
+      try (InputStream pemStream =
+          new ByteArrayInputStream(Files.readAllBytes(Paths.get(certPath)))) {
+        // parse certificate
+        CertificateFactory factory = CertificateFactory.getInstance("X.509");
+        X509Certificate certificate = (X509Certificate) factory.generateCertificate(pemStream);
+
+        // The PKCS standard used by the private key must be determined before parsing.
+        // Currently, Chain Core supports PKCS#1 and PKCS#8.
+        byte[] keyBytes = Files.readAllBytes(Paths.get(keyPath));
+        String key = new String(keyBytes, "ASCII");
+        BASE64Decoder b64 = new BASE64Decoder();
+        KeySpec spec;
+        byte[] decoded;
+        if (key.contains(PKCS1_HEADER)) {
+          key = key.replace(PKCS1_HEADER, "").replace(PKCS1_FOOTER, "").replaceAll("\\s", "");
+          decoded = b64.decodeBuffer(new ByteArrayInputStream(key.getBytes()));
+          DerInputStream derReader = new DerInputStream(decoded);
+          DerValue[] seq = derReader.getSequence(0);
+
+          if (seq.length < 9) {
+            // The ASN.1 type RSAPrivateKey specifies 9 required fields
+            throw new HTTPException("Unable to parse PKCS#1 private key");
+          }
+
+          // The first field (seq[0]) is a version identifier
+          BigInteger modulus = seq[1].getBigInteger();
+          BigInteger publicExponent = seq[2].getBigInteger();
+          BigInteger privateExponent = seq[3].getBigInteger();
+          BigInteger primeP = seq[4].getBigInteger();
+          BigInteger primeQ = seq[5].getBigInteger();
+          BigInteger primeExponentP = seq[6].getBigInteger();
+          BigInteger primeExponentQ = seq[7].getBigInteger();
+          BigInteger crtCoefficient = seq[8].getBigInteger();
+
+          spec =
+              new RSAPrivateCrtKeySpec(
+                  modulus,
+                  publicExponent,
+                  privateExponent,
+                  primeP,
+                  primeQ,
+                  primeExponentP,
+                  primeExponentQ,
+                  crtCoefficient);
+        } else if (key.contains(PKCS8_HEADER)) {
+          key = key.replace(PKCS8_HEADER, "").replace(PKCS8_FOOTER, "").replaceAll("\\s", "");
+          decoded = b64.decodeBuffer(new ByteArrayInputStream(key.getBytes()));
+          spec = new PKCS8EncodedKeySpec(decoded);
+        } else {
+          throw new HTTPException("Unsupported RSA private key provided.");
+        }
+
+        // create a new key store including pair
+        KeyFactory kf = KeyFactory.getInstance("RSA");
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, "password".toCharArray());
+        keyStore.setCertificateEntry("cert", certificate);
+        keyStore.setKeyEntry(
+            "key",
+            kf.generatePrivate(spec),
+            "password".toCharArray(),
+            new X509Certificate[] {certificate});
+        KeyManagerFactory keyManagerFactory =
+            KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, "password".toCharArray());
+        this.keyManagers = keyManagerFactory.getKeyManagers();
+        return this;
+      } catch (GeneralSecurityException | IOException ex) {
+        throw new HTTPException("Unable to store X509 cert/key pair", ex);
+      }
+    }
+
+    /**
      * Trusts the given CA certs, and no others. Use this if you are running
      * your own CA, or are using a self-signed server certificate.
      * @param path The path of a file containing certificates to trust, in PEM format.
      */
     public Builder setTrustedCerts(String path) throws HTTPException {
-      // Extract certs from PEM-encoded input.
       try (InputStream pemStream = new FileInputStream(path)) {
+        // Extract certs from PEM-encoded input.
         CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
         Collection<? extends Certificate> certificates =
             certificateFactory.generateCertificates(pemStream);
@@ -649,11 +752,7 @@ public class Client {
           throw new IllegalStateException(
               "Unexpected default trust managers:" + Arrays.toString(trustManagers));
         }
-
-        // Finally, configure the socket factory.
-        SSLContext sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(null, trustManagers, null);
-        sslSocketFactory = sslContext.getSocketFactory();
+        this.trustManagers = trustManagers;
         return this;
       } catch (GeneralSecurityException | IOException ex) {
         throw new HTTPException("Unable to configure trusted CA certs", ex);
@@ -744,7 +843,7 @@ public class Client {
     /**
      * Builds a client with all of the provided parameters.
      */
-    public Client build() {
+    public Client build() throws HTTPException {
       return new Client(this);
     }
   }

--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -12,7 +12,6 @@ import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.KeyStore;
-import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -58,6 +57,8 @@ public class Client {
   private static final String PKCS1_FOOTER = "-----END RSA PRIVATE KEY-----\n";
   private static final String PKCS8_HEADER = "-----BEGIN PRIVATE KEY-----\n";
   private static final String PKCS8_FOOTER = "-----END PRIVATE KEY-----\n";
+  // Used to create empty, in-memory key stores.
+  private static final char[] DEFAULT_KEYSTORE_PASSWORD = "password".toCharArray();
   private static String version = "dev"; // updated in the static initializer
 
   private static class BuildProperties {
@@ -694,16 +695,16 @@ public class Client {
         // create a new key store including pair
         KeyFactory kf = KeyFactory.getInstance("RSA");
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        keyStore.load(null, "password".toCharArray());
+        keyStore.load(null, DEFAULT_KEYSTORE_PASSWORD);
         keyStore.setCertificateEntry("cert", certificate);
         keyStore.setKeyEntry(
             "key",
             kf.generatePrivate(spec),
-            "password".toCharArray(),
+            DEFAULT_KEYSTORE_PASSWORD,
             new X509Certificate[] {certificate});
         KeyManagerFactory keyManagerFactory =
             KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        keyManagerFactory.init(keyStore, "password".toCharArray());
+        keyManagerFactory.init(keyStore, DEFAULT_KEYSTORE_PASSWORD);
         this.keyManagers = keyManagerFactory.getKeyManagers();
         return this;
       } catch (GeneralSecurityException | IOException ex) {
@@ -728,10 +729,7 @@ public class Client {
 
         // Create empty key store.
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        char[] password =
-            "password"
-                .toCharArray(); // The password is unimportant as long as it used consistently.
-        keyStore.load(null, password);
+        keyStore.load(null, DEFAULT_KEYSTORE_PASSWORD);
 
         // Load certs into key store.
         int index = 0;
@@ -743,7 +741,7 @@ public class Client {
         // Use key store to build an X509 trust manager.
         KeyManagerFactory keyManagerFactory =
             KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        keyManagerFactory.init(keyStore, password);
+        keyManagerFactory.init(keyStore, DEFAULT_KEYSTORE_PASSWORD);
         TrustManagerFactory trustManagerFactory =
             TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustManagerFactory.init(keyStore);

--- a/sdk/java/src/test/java/com/chain/TestUtils.java
+++ b/sdk/java/src/test/java/com/chain/TestUtils.java
@@ -1,13 +1,14 @@
 package com.chain;
 
 import com.chain.exception.BadURLException;
+import com.chain.exception.ChainException;
 import com.chain.http.Client;
 
 /**
  * TestUtils provides a simplified api for testing.
  */
 public class TestUtils {
-  public static Client generateClient() throws BadURLException {
+  public static Client generateClient() throws ChainException {
     String coreURL = System.getProperty("chain.api.url");
     String accessToken = System.getProperty("client.access.token");
     if (coreURL == null || coreURL.isEmpty()) {

--- a/sdk/node/src/client.js
+++ b/sdk/node/src/client.js
@@ -22,11 +22,12 @@ class Client {
    *
    * @param {String} baseUrl - Chain Core URL.
    * @param {String} token - Chain Core client token for API access.
+   * @param {Object} agent - https.Agent used to provide TLS configuration to the client
    * @returns {Client}
    */
-  constructor(baseUrl, token = '') {
+  constructor(baseUrl, token = '', agent = {}) {
     baseUrl = baseUrl || 'http://localhost:1999'
-    this.connection = new Connection(baseUrl, token)
+    this.connection = new Connection(baseUrl, token, agent)
 
     /**
      * API actions for access tokens
@@ -64,7 +65,7 @@ class Client {
      */
     this.mockHsm = {
       keys: mockHsmKeysAPI(this),
-      signerConnection: new Connection(`${baseUrl}/mockhsm`, token)
+      signerConnection: new Connection(`${baseUrl}/mockhsm`, token, agent)
     }
 
     /**

--- a/sdk/node/src/connection.js
+++ b/sdk/node/src/connection.js
@@ -66,11 +66,13 @@ class Connection {
    *
    * @param {String} baseUrl Chain Core URL.
    * @param {String} token   Chain Core client token for API access.
+   * @param {Object} agent - https.Agent used to provide TLS configuration to the client
    * @returns {Client}
    */
-  constructor(baseUrl, token = '') {
+  constructor(baseUrl, token = '', agent = {}) {
     this.baseUrl = baseUrl
     this.token = token || ''
+	this.agent = agent || {}
   }
 
   /**
@@ -112,6 +114,10 @@ class Connection {
     if (this.token) {
       req.headers['Authorization'] = `Basic ${btoa(this.token)}`
     }
+
+	this(Object.keys(this.agent).length !== 0 {
+		req.agent = this.agent
+	}
 
     return fetch(this.baseUrl + path, req).catch((err) => {
       throw errors.create(

--- a/sdk/node/src/connection.js
+++ b/sdk/node/src/connection.js
@@ -72,7 +72,7 @@ class Connection {
   constructor(baseUrl, token = '', agent = {}) {
     this.baseUrl = baseUrl
     this.token = token || ''
-	this.agent = agent || {}
+    this.agent = agent || {}
   }
 
   /**
@@ -115,9 +115,9 @@ class Connection {
       req.headers['Authorization'] = `Basic ${btoa(this.token)}`
     }
 
-	this(Object.keys(this.agent).length !== 0 {
-		req.agent = this.agent
-	}
+    if (Object.keys(this.agent).length !== 0) {
+      req.agent = this.agent
+    }
 
     return fetch(this.baseUrl + path, req).catch((err) => {
       throw errors.create(

--- a/sdk/ruby/lib/chain/connection.rb
+++ b/sdk/ruby/lib/chain/connection.rb
@@ -182,6 +182,16 @@ module Chain
       if @url.scheme == 'https'
         @http.use_ssl = true
         @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        if @opts.key?(:root_ca_certs)
+          @http.ca_file = @opts[:root_ca_certs]
+          @http.verify_depth = 5
+        end
+        if @opts.key?(:cert) && opts.key?(:key)
+          cert = File.read(@opts[:cert])
+          key = File.read(@opts[:key])
+          @http.cert = OpenSSL::X509::Certificate.new(cert)
+          @http.key = OpenSSL::PKey::RSA.new(key)
+        end
       end
 
       @http


### PR DESCRIPTION
Support for client cert authentication has been implemented
in cored and all SDKs.  If a valid client cert is detected, basic
auth is bypassed. File paths to pem encoded X.509 certs and
keys are expected to be passed as env vars.

Initially the server will not require client certs and only verify
certs received from the client.