### PR TITLE
database/sql: propagate context to standard lib

### DIFF
--- a/database/pg/pgtest/ctx_test.go
+++ b/database/pg/pgtest/ctx_test.go
@@ -1,0 +1,26 @@
+package pgtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"chain/database/pg"
+	"chain/errors"
+)
+
+func TestContextTimeout(t *testing.T) {
+	ctx := context.Background()
+	_, db := NewDB(t, SchemaPath)
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
+	defer cancel()
+
+	var err error
+	for err == nil {
+		err = pg.ForQueryRows(ctx, db, "SELECT 1", func(i int) {})
+	}
+	if errors.Root(err) != context.DeadlineExceeded {
+		t.Fatalf("Got %s, want %s", err, context.DeadlineExceeded)
+	}
+}

--- a/database/sql/sql.go
+++ b/database/sql/sql.go
@@ -204,14 +204,14 @@ func (db *DB) Begin(ctx context.Context) (*Tx, error) {
 // The args are for any placeholder parameters in the query.
 func (db *DB) Exec(ctx context.Context, query string, args ...interface{}) (Result, error) {
 	logQuery(ctx, query, args)
-	return db.db.Exec(query, args...)
+	return db.db.ExecContext(ctx, query, args...)
 }
 
 // Query executes a query that returns rows, typically a SELECT.
 // The args are for any placeholder parameters in the query.
 func (db *DB) Query(ctx context.Context, query string, args ...interface{}) (*Rows, error) {
 	logQuery(ctx, query, args)
-	rows, err := db.db.Query(query, args...)
+	rows, err := db.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
@@ -223,7 +223,7 @@ func (db *DB) Query(ctx context.Context, query string, args ...interface{}) (*Ro
 // Row's Scan method is called.
 func (db *DB) QueryRow(ctx context.Context, query string, args ...interface{}) *Row {
 	logQuery(ctx, query, args)
-	row := db.db.QueryRow(query, args...)
+	row := db.db.QueryRowContext(ctx, query, args...)
 	return &Row{row: row, ctx: ctx}
 }
 
@@ -241,14 +241,14 @@ func (tx *Tx) Rollback(ctx context.Context) error {
 // For example: an INSERT and UPDATE.
 func (tx *Tx) Exec(ctx context.Context, query string, args ...interface{}) (Result, error) {
 	logQuery(ctx, query, args)
-	return tx.tx.Exec(query, args...)
+	return tx.tx.ExecContext(ctx, query, args...)
 }
 
 // Query executes a query that returns rows, typically a SELECT.
 // The args are for any placeholder parameters in the query.
 func (tx *Tx) Query(ctx context.Context, query string, args ...interface{}) (*Rows, error) {
 	logQuery(ctx, query, args)
-	rows, err := tx.tx.Query(query, args...)
+	rows, err := tx.tx.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
@@ -260,7 +260,7 @@ func (tx *Tx) Query(ctx context.Context, query string, args ...interface{}) (*Ro
 // Row's Scan method is called.
 func (tx *Tx) QueryRow(ctx context.Context, query string, args ...interface{}) *Row {
 	logQuery(ctx, query, args)
-	row := tx.tx.QueryRow(query, args...)
+	row := tx.tx.QueryRowContext(ctx, query, args...)
 	return &Row{row: row, ctx: ctx}
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2893";
+	public final String Id = "main/rev2894";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2893"
+const ID string = "main/rev2894"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2893"
+export const rev_id = "main/rev2894"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2893".freeze
+	ID = "main/rev2894".freeze
 end


### PR DESCRIPTION
Propagate the context from our own database/sql package to the standard
library database/sql package.

For now, we still need our own database/sql wrapper for logging. We
might be able to replace it with a driver that performs the logging, but
composing drivers is tricky.