### PR TITLE
protocol/validation: add test of expansion flag to checkoutput

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2895";
+	public final String Id = "main/rev2896";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2895"
+const ID string = "main/rev2896"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2895"
+export const rev_id = "main/rev2896"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2895".freeze
+	ID = "main/rev2896".freeze
 end

--- a/protocol/validation/vmcontext_test.go
+++ b/protocol/validation/vmcontext_test.go
@@ -82,7 +82,7 @@ func TestCheckOutput(t *testing.T) {
 
 	for i, test := range cases {
 		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
-			gotOk, err := txCtx.checkOutput(test.index, test.data, test.amount, test.assetID, test.vmVersion, test.code)
+			gotOk, err := txCtx.checkOutput(test.index, test.data, test.amount, test.assetID, test.vmVersion, test.code, false)
 			if g := errors.Root(err); g != test.wantErr {
 				t.Errorf("checkOutput(%v, %v, %v, %x, %v, %x) err = %v, want %v",
 					test.index, test.data, test.amount, test.assetID, test.vmVersion, test.code,

--- a/protocol/vm/context.go
+++ b/protocol/vm/context.go
@@ -41,5 +41,5 @@ type Context struct {
 	SpentOutputID *[]byte
 
 	TxSigHash   func() []byte
-	CheckOutput func(index uint64, data []byte, amount uint64, assetID []byte, vmVersion uint64, code []byte) (bool, error)
+	CheckOutput func(index uint64, data []byte, amount uint64, assetID []byte, vmVersion uint64, code []byte, expansion bool) (bool, error)
 }

--- a/protocol/vm/introspection.go
+++ b/protocol/vm/introspection.go
@@ -46,7 +46,7 @@ func opCheckOutput(vm *virtualMachine) error {
 		return ErrContext
 	}
 
-	ok, err := vm.context.CheckOutput(uint64(index), data, uint64(amount), assetID, uint64(vmVersion), code)
+	ok, err := vm.context.CheckOutput(uint64(index), data, uint64(amount), assetID, uint64(vmVersion), code, vm.expansionReserved)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The spec for `CHECKOUTPUT` says that when matching a retirement entry, `code` must be the empty string only if the expansion flag is false. The implementation was missing that check.