### PR TITLE
protocol/vm: create a Context directly

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2908";
+	public final String Id = "main/rev2909";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2908"
+const ID string = "main/rev2909"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2908"
+export const rev_id = "main/rev2909"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2908".freeze
+	ID = "main/rev2909".freeze
 end


### PR DESCRIPTION
This change converts the tests in crypto_test.go to stop
using packages bc and validation to build test fixtures,
and instead define a Context object in one step. Code
coverage stays at 95.3%.

This is a continuation of #886.

Future work: once all test files stop depending on
package bc, move the test code back into package vm
(from vm_test).