### PR TITLE
core/hsm: adhere to no_mockhsm tag

### DIFF
--- a/core/hsm.go
+++ b/core/hsm.go
@@ -1,4 +1,4 @@
-//+build !prod
+//+build !no_mockhsm
 
 package core
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2894";
+	public final String Id = "main/rev2895";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2894"
+const ID string = "main/rev2895"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2894"
+export const rev_id = "main/rev2895"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2894".freeze
+	ID = "main/rev2895".freeze
 end


### PR DESCRIPTION
This file should also be excluded when cored
is built using the `no_mockhsm` tag.