### PR TITLE
database/pg: ignore non-errors in listener

### DIFF
--- a/database/pg/listen.go
+++ b/database/pg/listen.go
@@ -16,7 +16,9 @@ func NewListener(ctx context.Context, dbURL, channel string) (*pq.Listener, erro
 	// We want etcd name lookups so we use our own Dialer.
 	d := new(net.Dialer)
 	result := pq.NewDialListener(d, dbURL, 1*time.Second, 10*time.Second, func(ev pq.ListenerEventType, err error) {
-		log.Error(ctx, errors.Wrapf(err, "event in %s listener: %v", channel, ev))
+		if err != nil {
+			log.Error(ctx, errors.Wrapf(err, "event in %s listener: %v", channel, ev))
+		}
 	})
 	err := result.Listen(channel)
 	return result, errors.Wrap(err, "listening to channel")

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2901";
+	public final String Id = "main/rev2902";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2901"
+const ID string = "main/rev2902"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2901"
+export const rev_id = "main/rev2902"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2901".freeze
+	ID = "main/rev2902".freeze
 end


### PR DESCRIPTION
The lib/pq library will invoke the listener callback for new database
connections in listeners, in addition to error conditions. Don't log
anything if there's no error.

This removes the error=<nil> log statements that appear during startup.

```
app=cored buildtag=? processID=chain-mba.local-15286-aa73de33b589e552cb0e at=leader.go:102 t=2017-04-12T01:06:13.303830156Z message="I am the core leader"
app=cored buildtag=? processID=chain-mba.local-15286-aa73de33b589e552cb0e at=listen.go:19 t=2017-04-12T01:06:13.309256877Z error=<nil>
app=cored buildtag=? processID=chain-mba.local-15286-aa73de33b589e552cb0e at=listen.go:19 t=2017-04-12T01:06:13.312147977Z error=<nil>
app=cored buildtag=? processID=chain-mba.local-15286-aa73de33b589e552cb0e at=listen.go:19 t=2017-04-12T01:06:13.312951798Z error=<nil>
app=cored buildtag=? processID=chain-mba.local-15286-aa73de33b589e552cb0e at=listen.go:19 t=2017-04-12T01:06:13.313016663Z error=<nil>
app=cored buildtag=? processID=chain-mba.local-15286-aa73de33b589e552cb0e at=listen.go:19 t=2017-04-12T01:06:13.315887436Z error=<nil>
```