### PR TITLE
bin/wait-and-configure: new utility script

### DIFF
--- a/bin/wait-and-configure
+++ b/bin/wait-and-configure
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# TODO: move this wait functionality to corectl as a -wait flag.
 while ! `curl -s http://localhost:1999 | grep -q Found`
 do
   sleep 0.5

--- a/bin/wait-and-configure
+++ b/bin/wait-and-configure
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+while ! `curl -s http://localhost:1999 | grep -q Found`
+do
+  sleep 0.5
+  echo "waiting..."
+done
+
+corectl config-generator

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2900";
+	public final String Id = "main/rev2901";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2900"
+const ID string = "main/rev2901"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2900"
+export const rev_id = "main/rev2901"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2900".freeze
+	ID = "main/rev2901".freeze
 end


### PR DESCRIPTION
`wait-and-configure` waits until a local Chain Core daemon is ready, and
then attempts to configure it. You can use this script as part of a
quick reset-and-configure loop while iterating on code. For example,
some of our teammates use a Make target that executes the equivalent of
the following:

```
  go install $(CHAIN)/cmd/corectl
  go install $(REPO)/cmd/cored
  -dropdb core
  createdb core
  rm -rf ~/Library/Application\ Support/Chain\ Core/raft
  bin/wait-and-configure &
  cored
```

Previously, `corectl config-generator` could be used in place of `wait-and-configure` for fast iteration loops, but since it now requires a running instance of Chain Core, we need something that can run in the background.