### PR TITLE
core/config: set ConfiguredAt

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -253,6 +253,7 @@ func Configure(ctx context.Context, db pg.DB, rDB *raft.Service, c *Config) erro
 		return errors.Wrap(err)
 	}
 	c.Id = hex.EncodeToString(b)
+	c.ConfiguredAt = bc.Millis(time.Now())
 
 	val, err := proto.Marshal(c)
 	if err != nil {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2904";
+	public final String Id = "main/rev2905";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2904"
+const ID string = "main/rev2905"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2904"
+export const rev_id = "main/rev2905"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2904".freeze
+	ID = "main/rev2905".freeze
 end


### PR DESCRIPTION
Before using raft to store core config, this value was directly
inserted into the config table. This fixes a bug causing this
value to default to 0.