### PR TITLE
core/config: remove unused Production field

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,7 @@ There are four build tags that change the behavior of the resulting binary:
   - `reset`: allows the core database to be reset through the api
   - `loopback_auth`: allows unauthenticated requests on the loopback device
   - `no_mockhsm`: disables the MockHSM provided for development
-  - `plain_http`: allows plain HTTP requests
+  - `plain_http`: allows plain HTTP requests (not yet implemented)
 
 ```
 $ git clone https://github.com/chain/chain $CHAIN

--- a/Readme.md
+++ b/Readme.md
@@ -49,6 +49,12 @@ You might want to open a new terminal window to pick up the change.
 
 Build and install from source:
 
+There are four build tags that change the behavior of the resulting binary:
+  - `reset`: allows the core database to be reset through the api
+  - `loopback_auth`: allows unauthenticated requests on the loopback device
+  - `no_mockhsm`: disables the MockHSM provided for development
+  - `plain_http`: allows plain HTTP requests
+
 ```
 $ git clone https://github.com/chain/chain $CHAIN
 $ cd $CHAIN

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -41,7 +41,6 @@ var (
 	ErrNoBlockHSMURL   = errors.New("block hsm URL cannot be empty in mockhsm disabled build")
 
 	Version, BuildCommit, BuildDate string
-	Production                      bool
 
 	// This is the default, Chain development configuration.
 	// These options can be updated with build tags.

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2905";
+	public final String Id = "main/rev2906";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2905"
+const ID string = "main/rev2906"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2905"
+export const rev_id = "main/rev2906"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2905".freeze
+	ID = "main/rev2906".freeze
 end


### PR DESCRIPTION
The `prod` build tag has been replaced with granular options.
This commit also adds notes to the Readme about the build
tags that have replaced it.