### PR TITLE
analytics: add indexing of custom columns

### DIFF
--- a/analytics/src/main/java/com/chain/analytics/Application.java
+++ b/analytics/src/main/java/com/chain/analytics/Application.java
@@ -11,6 +11,7 @@ import java.beans.PropertyVetoException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.Logger;
@@ -74,7 +75,14 @@ public class Application {
       ds.setJdbcUrl(databaseUrl);
       ds.setTestConnectionOnCheckout(true);
 
-      importer = Importer.connect(client, ds, DEFAULT_FEED_ALIAS);
+      Config config = new Config();
+      config.transactionColumns.add(
+          new Config.CustomColumn(
+              "acc_id",
+              new Schema.Varchar2(64),
+              new JsonPath(Arrays.asList("reference_data", "account", "id"))));
+
+      importer = Importer.connect(client, ds, DEFAULT_FEED_ALIAS, config);
     } catch (BadURLException ex) {
       logger.fatal("Unable to parse the Chain Core URL provided \"{}\".", chainUrl, ex);
       System.exit(1);

--- a/analytics/src/main/java/com/chain/analytics/Config.java
+++ b/analytics/src/main/java/com/chain/analytics/Config.java
@@ -1,0 +1,28 @@
+package analytics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Config {
+  List<CustomColumn> transactionColumns;
+  List<CustomColumn> inputColumns;
+  List<CustomColumn> outputColumns;
+
+  public Config() {
+    transactionColumns = new ArrayList<>();
+    inputColumns = new ArrayList<>();
+    outputColumns = new ArrayList<>();
+  }
+
+  public static class CustomColumn {
+    String name;
+    Schema.SQLType type;
+    JsonPath jsonPath;
+
+    public CustomColumn(String name, Schema.SQLType type, JsonPath jsonPath) {
+      this.name = name;
+      this.type = type;
+      this.jsonPath = jsonPath;
+    }
+  }
+}

--- a/analytics/src/main/java/com/chain/analytics/JsonPath.java
+++ b/analytics/src/main/java/com/chain/analytics/JsonPath.java
@@ -1,0 +1,124 @@
+package analytics;
+
+import com.chain.api.Transaction;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A JsonPath specifies a path to a value within a JSON object.
+ *
+ * TODO(jackson): Do we need to support indexing into arrays?
+ */
+public class JsonPath {
+  private List<String> mPath;
+
+  public JsonPath(final List<String> path) {
+    mPath = Collections.unmodifiableList(path);
+  }
+
+  public String toString() {
+    return String.join(".", mPath);
+  }
+
+  public Object extract(final Transaction tx) {
+    if (mPath.isEmpty()) {
+      return tx;
+    }
+
+    // The first component in the path is a top-level transaction
+    // field. All the subsequent fields index into unstructured json.
+    String field = mPath.get(0);
+
+    Map<String, Object> deserializedJson = null;
+    switch (field.toLowerCase()) {
+      case "reference_data":
+        deserializedJson = tx.referenceData;
+        break;
+    }
+    return extract(deserializedJson, mPath.subList(1, mPath.size()));
+  }
+
+  public Object extract(final Transaction.Input input) {
+    if (mPath.isEmpty()) {
+      return input;
+    }
+
+    // The first component in the path is a top-level input
+    // field. All the subsequent fields index into unstructured json.
+    String field = mPath.get(0);
+
+    Map<String, Object> deserializedJson = null;
+    switch (field.toLowerCase()) {
+      case "account_tags":
+        deserializedJson = input.accountTags;
+        break;
+      case "asset_definition":
+        deserializedJson = input.assetDefinition;
+        break;
+      case "asset_tags":
+        deserializedJson = input.assetTags;
+        break;
+      case "reference_data":
+        deserializedJson = input.referenceData;
+        break;
+    }
+    return extract(deserializedJson, mPath.subList(1, mPath.size()));
+  }
+
+  public Object extract(final Transaction.Output output) {
+    if (mPath.isEmpty()) {
+      return output;
+    }
+
+    // The first component in the path is a top-level output
+    // field. All the subsequent fields index into unstructured json.
+    String field = mPath.get(0);
+
+    Map<String, Object> deserializedJson = null;
+    switch (field.toLowerCase()) {
+      case "account_tags":
+        deserializedJson = output.accountTags;
+        break;
+      case "asset_definition":
+        deserializedJson = output.assetDefinition;
+        break;
+      case "asset_tags":
+        deserializedJson = output.assetTags;
+        break;
+      case "reference_data":
+        deserializedJson = output.referenceData;
+        break;
+    }
+    return extract(deserializedJson, mPath.subList(1, mPath.size()));
+  }
+
+  @SuppressWarnings("unchecked")
+  private Object extract(final Map<String, Object> deserializedJson, final List<String> path) {
+    Map<String, Object> jsonObject = deserializedJson;
+    if (path.isEmpty()) {
+      return jsonObject;
+    }
+
+    try {
+      // Follow all of the path elements except for the last.
+      for (final String key : path.subList(0, path.size() - 1)) {
+        if (jsonObject == null) {
+          return null;
+        }
+
+        final Object v = jsonObject.get(key);
+        if (v == null) {
+          return null;
+        }
+        jsonObject = (Map<String, Object>) v;
+      }
+    } catch (ClassCastException ex) {
+      return null;
+    }
+
+    // Follow the final path element.
+    return jsonObject.get(path.get(path.size() - 1));
+  }
+}

--- a/analytics/src/main/java/com/chain/analytics/Schema.java
+++ b/analytics/src/main/java/com/chain/analytics/Schema.java
@@ -1,6 +1,7 @@
 package analytics;
 
 import java.util.*;
+import java.sql.Types;
 
 /**
  * Schema represents the schema of an Oracle database table. Schemas
@@ -32,6 +33,8 @@ public class Schema {
    */
   public interface SQLType {
     String toString();
+
+    int getType();
   }
 
   /**
@@ -173,11 +176,19 @@ public class Schema {
     public String toString() {
       return "BLOB";
     }
+
+    public int getType() {
+      return Types.BLOB;
+    }
   }
 
   public static class Boolean implements SQLType {
     public String toString() {
       return "CHAR(1)";
+    }
+
+    public int getType() {
+      return Types.CHAR;
     }
   }
 
@@ -185,17 +196,29 @@ public class Schema {
     public String toString() {
       return "CLOB";
     }
+
+    public int getType() {
+      return Types.CLOB;
+    }
   }
 
   public static class Integer implements SQLType {
     public String toString() {
       return "NUMBER(20)";
     }
+
+    public int getType() {
+      return Types.BIGINT;
+    }
   }
 
   public static class Timestamp implements SQLType {
     public String toString() {
       return "TIMESTAMP WITH TIME ZONE";
+    }
+
+    public int getType() {
+      return Types.TIMESTAMP_WITH_TIMEZONE;
     }
   }
 
@@ -208,6 +231,10 @@ public class Schema {
 
     public String toString() {
       return String.format("VARCHAR2(%d)", mLength);
+    }
+
+    public int getType() {
+      return Types.VARCHAR;
     }
   }
 }

--- a/analytics/src/test/java/com/chain/analytics/JsonPathTest.java
+++ b/analytics/src/test/java/com/chain/analytics/JsonPathTest.java
@@ -1,0 +1,35 @@
+package analytics;
+
+import com.chain.api.Transaction;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.TreeMap;
+import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
+public class JsonPathTest {
+
+  @Test
+  public void testExtract() {
+    Map<String, Object> map = new TreeMap<String, Object>();
+    Map<String, Object> innerMap = new TreeMap<String, Object>();
+    innerMap.put("id", "abc");
+    innerMap.put("account_number", 123);
+    map.put("account", innerMap);
+    map.put("id", 12345);
+
+    final Transaction tx = new Transaction();
+    tx.referenceData = map;
+
+    JsonPath pathId = new JsonPath(Arrays.asList("reference_data", "id"));
+    JsonPath pathAccountId = new JsonPath(Arrays.asList("reference_data", "account", "id"));
+    JsonPath pathAccountAccountNumber =
+        new JsonPath(Arrays.asList("reference_data", "account", "account_number"));
+
+    assertEquals(pathId.extract(tx), 12345);
+    assertEquals(pathAccountId.extract(tx), "abc");
+    assertEquals(pathAccountAccountNumber.extract(tx), 123);
+  }
+}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2924";
+	public final String Id = "main/rev2925";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2924"
+const ID string = "main/rev2925"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2924"
+export const rev_id = "main/rev2925"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2924".freeze
+	ID = "main/rev2925".freeze
 end


### PR DESCRIPTION
Add ability to index custom columns extracted from JSON reference data.

This does not yet handle configuration of these custom columns. I'm not
sure what the best interface for configuration is?

Some of the logic to follow json paths got a little gross. I was trying to avoid
unmarshaling the entire transaction object a second time into a 
`Map<String,Object>`, hence the `JsonPath.extract` methods for `Transaction`,
`Transaction.Input` and `Transaction.Output`.