### PR TITLE
protocol: wrap validation errors in an ErrBadTx

### DIFF
--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -20,6 +20,7 @@ import (
 	"chain/protocol/prottest"
 	"chain/protocol/prottest/memstore"
 	"chain/protocol/state"
+	"chain/protocol/vm"
 	"chain/testutil"
 )
 
@@ -159,6 +160,49 @@ func TestConflictingTxsInPool(t *testing.T) {
 	dumpBlocks(ctx, t, db)
 	if len(b.Transactions) != 1 {
 		t.Errorf("got block.Transactions = %#v\n, want exactly one tx", b.Transactions)
+	}
+}
+
+func TestInvalidTx(t *testing.T) {
+	c := prottest.NewChain(t)
+	ctx := context.Background()
+	prog := [...]byte{
+		byte(vm.OP_DATA_32),
+		0x34, 0x0a, 0x71, 0x56, 0x84, 0xc9, 0x83, 0x27, 0xf4, 0xa6, 0x1e, 0x7d, 0xdc, 0x54, 0xd1, 0xcd,
+		0x06, 0xab, 0x7b, 0x26, 0x65, 0x78, 0xbb, 0x16, 0x20, 0xc5, 0x45, 0xad, 0x1d, 0x31, 0x73, 0x7d,
+		byte(vm.OP_TXSIGHASH), byte(vm.OP_EQUAL),
+	}
+	badTx := bc.NewTx(bc.TxData{
+		Version: 1,
+		Inputs: []*bc.TxInput{
+			&bc.TxInput{
+				AssetVersion: 1,
+				TypedInput: &bc.SpendInput{
+					SpendCommitment: bc.SpendCommitment{
+						AssetAmount: bc.AssetAmount{
+							AssetId: &bc.AssetID{},
+							Amount:  1,
+						},
+						VMVersion:      1,
+						ControlProgram: []byte{byte(vm.OP_TRUE)},
+					},
+					Arguments: [][]byte{
+						{},
+						{},
+						prog[:],
+					},
+				},
+			},
+		},
+		Outputs: []*bc.TxOutput{
+			bc.NewTxOutput(bc.AssetID{}, 2, nil, nil),
+		},
+		MinTime: 1,
+		MaxTime: 2,
+	})
+	err := FinalizeTx(ctx, c, nil, badTx)
+	if errors.Root(err) != ErrRejected {
+		t.Errorf("got error %s, want %s", err, protocol.ErrBadTx)
 	}
 }
 

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -202,7 +202,7 @@ func TestInvalidTx(t *testing.T) {
 	})
 	err := FinalizeTx(ctx, c, nil, badTx)
 	if errors.Root(err) != ErrRejected {
-		t.Errorf("got error %s, want %s", err, protocol.ErrBadTx)
+		t.Errorf("got error %s, want %s", err, ErrRejected)
 	}
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2909";
+	public final String Id = "main/rev2910";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2909"
+const ID string = "main/rev2910"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2909"
+export const rev_id = "main/rev2910"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2909".freeze
+	ID = "main/rev2910".freeze
 end

--- a/protocol/tx.go
+++ b/protocol/tx.go
@@ -27,7 +27,7 @@ func (c *Chain) ValidateTx(tx *bc.TxEntries) error {
 		err = validation.ValidateTx(tx, c.InitialBlockHash)
 		c.prevalidated.cache(tx.ID, err)
 	}
-	return err
+	return errors.Sub(ErrBadTx, err)
 }
 
 type prevalidatedTxsCache struct {


### PR DESCRIPTION
In https://github.com/chain/chain/pull/788 we lost logic that wrapped validation errors in `ErrBadTx`, which `core/txbuilder` was expecting in order to produce a friendly "transaction rejected" message for the caller. This PR restores that and adds a regression test.

Fixes https://github.com/chain/chain/issues/924.