### PR TITLE
protocol/vm: create a Context directly

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2911";
+	public final String Id = "main/rev2912";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2911"
+const ID string = "main/rev2912"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2911"
+export const rev_id = "main/rev2912"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2911".freeze
+	ID = "main/rev2912".freeze
 end


### PR DESCRIPTION
This change converts the tests in introspection_test.go
to stop using packages bc and validation to build test
fixtures, and instead define a Context object in one
step. Code coverage stays at 95.3%.

This completes the work in #886 and #907. Now no files
in chain/protocol/vm depend on packages validation or bc.

Future work: move the test code back into package vm
(from vm_test).