### PR TITLE
crypto/ed25519/math: EC math primitives

### DIFF
--- a/crypto/ed25519/internal/edwards25519/chain_export.go
+++ b/crypto/ed25519/internal/edwards25519/chain_export.go
@@ -1,3 +1,6 @@
 package edwards25519
 
-var GeAdd = geAdd
+var (
+	GeAdd = geAdd
+	GeSub = geSub
+)

--- a/crypto/ed25519/math/point.go
+++ b/crypto/ed25519/math/point.go
@@ -1,0 +1,92 @@
+package math
+
+import (
+	"crypto/subtle"
+
+	"chain/crypto/ed25519/internal/edwards25519"
+)
+
+type (
+	// Point is a point on the ed25519 curve.
+	Point edwards25519.ExtendedGroupElement
+
+	// EncodedPoint is a serialized representation of a point.
+	EncodedPoint [32]byte
+)
+
+// ZeroPoint is the zero point on the ed25519 curve.
+var ZeroPoint Point
+
+// Add adds the points in x and y, storing the result in z and
+// returning that. Any or all of x, y, and z may be the same pointers.
+func (z *Point) Add(x, y *Point) *Point {
+	var y2 edwards25519.CachedGroupElement
+	(*edwards25519.ExtendedGroupElement)(y).ToCached(&y2)
+
+	var z2 edwards25519.CompletedGroupElement
+	edwards25519.GeAdd(&z2, (*edwards25519.ExtendedGroupElement)(x), &y2)
+
+	z2.ToExtended((*edwards25519.ExtendedGroupElement)(z))
+	return z
+}
+
+// Sub subtracts y from x, storing the result in z and
+// returning that. Any or all of x, y, and z may be the same pointers.
+func (z *Point) Sub(x, y *Point) *Point {
+	var y2 edwards25519.CachedGroupElement
+	(*edwards25519.ExtendedGroupElement)(y).ToCached(&y2)
+
+	var z2 edwards25519.CompletedGroupElement
+	edwards25519.GeSub(&z2, (*edwards25519.ExtendedGroupElement)(x), &y2)
+
+	z2.ToExtended((*edwards25519.ExtendedGroupElement)(z))
+	return z
+}
+
+// ScMul multiplies the EC point x by the scalar y, placing the result
+// in z and returning that. X and z may be the same pointer.
+func (z *Point) ScMul(x *Point, y *Uint256le) *Point {
+	return z.ScMulAdd(x, y, &Zero)
+}
+
+// ScMulBase multiplies the ed25519 base point by x and places the
+// result in z, returning that.
+func (z *Point) ScMulBase(x *Uint256le) *Point {
+	edwards25519.GeScalarMultBase((*edwards25519.ExtendedGroupElement)(z), (*[32]byte)(x))
+	return z
+}
+
+// ScMulAdd computes xa+yB, where B is the ed25519 base point, and
+// places the result in z, returning that.
+func (z *Point) ScMulAdd(a *Point, x, y *Uint256le) *Point {
+	// TODO: replace with constant-time implementation to avoid
+	// sidechannel attacks
+
+	var p edwards25519.ProjectiveGroupElement
+	edwards25519.GeDoubleScalarMultVartime(&p, (*[32]byte)(x), (*edwards25519.ExtendedGroupElement)(a), (*[32]byte)(y))
+
+	var buf [32]byte
+	p.ToBytes(&buf)
+	(*edwards25519.ExtendedGroupElement)(z).FromBytes(&buf) // xxx don't need to check return val, right?
+	return z
+}
+
+func (z *Point) Encode() (e EncodedPoint) {
+	(*edwards25519.ExtendedGroupElement)(z).ToBytes((*[32]byte)(&e))
+	return e
+}
+
+func (z *Point) Decode(e EncodedPoint) (*Point, bool) {
+	ok := (*edwards25519.ExtendedGroupElement)(z).FromBytes((*[32]byte)(&e))
+	return z, ok
+}
+
+func (z *Point) ConstTimeEqual(x *Point) bool {
+	xe := x.Encode()
+	ze := z.Encode()
+	return subtle.ConstantTimeCompare(xe[:], ze[:]) == 1
+}
+
+func init() {
+	(*edwards25519.ExtendedGroupElement)(&ZeroPoint).Zero()
+}

--- a/crypto/ed25519/math/point.go
+++ b/crypto/ed25519/math/point.go
@@ -6,15 +6,10 @@ import (
 	"chain/crypto/ed25519/internal/edwards25519"
 )
 
-type (
-	// Point is a point on the ed25519 curve.
-	Point edwards25519.ExtendedGroupElement
+// Point is a point on the ed25519 curve.
+type Point edwards25519.ExtendedGroupElement
 
-	// EncodedPoint is a serialized representation of a point.
-	EncodedPoint [32]byte
-)
-
-// ZeroPoint is the zero point on the ed25519 curve.
+// ZeroPoint is the zero point on the ed25519 curve (not the zero value of Point).
 var ZeroPoint Point
 
 // Add adds the points in x and y, storing the result in z and
@@ -67,16 +62,20 @@ func (z *Point) ScMulAdd(a *Point, x, y *Uint256le) *Point {
 
 	var buf [32]byte
 	p.ToBytes(&buf)
+	// TODO(bobg): double-check that it's OK to ignore the return value
+	// from ExtendedGroupElement.FromBytes here. (It's a bool indicating
+	// that its input represented a legal value.)
 	(*edwards25519.ExtendedGroupElement)(z).FromBytes(&buf)
 	return z
 }
 
-func (z *Point) Encode() (e EncodedPoint) {
+func (z *Point) Encode() [32]byte {
+	var e [32]byte
 	(*edwards25519.ExtendedGroupElement)(z).ToBytes((*[32]byte)(&e))
 	return e
 }
 
-func (z *Point) Decode(e EncodedPoint) (*Point, bool) {
+func (z *Point) Decode(e [32]byte) (*Point, bool) {
 	ok := (*edwards25519.ExtendedGroupElement)(z).FromBytes((*[32]byte)(&e))
 	return z, ok
 }

--- a/crypto/ed25519/math/point.go
+++ b/crypto/ed25519/math/point.go
@@ -67,7 +67,7 @@ func (z *Point) ScMulAdd(a *Point, x, y *Uint256le) *Point {
 
 	var buf [32]byte
 	p.ToBytes(&buf)
-	(*edwards25519.ExtendedGroupElement)(z).FromBytes(&buf) // xxx don't need to check return val, right?
+	(*edwards25519.ExtendedGroupElement)(z).FromBytes(&buf)
 	return z
 }
 

--- a/crypto/ed25519/math/point.go
+++ b/crypto/ed25519/math/point.go
@@ -71,12 +71,12 @@ func (z *Point) ScMulAdd(a *Point, x, y *Uint256le) *Point {
 
 func (z *Point) Encode() [32]byte {
 	var e [32]byte
-	(*edwards25519.ExtendedGroupElement)(z).ToBytes((*[32]byte)(&e))
+	(*edwards25519.ExtendedGroupElement)(z).ToBytes(&e)
 	return e
 }
 
 func (z *Point) Decode(e [32]byte) (*Point, bool) {
-	ok := (*edwards25519.ExtendedGroupElement)(z).FromBytes((*[32]byte)(&e))
+	ok := (*edwards25519.ExtendedGroupElement)(z).FromBytes(&e)
 	return z, ok
 }
 

--- a/crypto/ed25519/math/point_test.go
+++ b/crypto/ed25519/math/point_test.go
@@ -1,0 +1,44 @@
+package math
+
+import "testing"
+
+// base is the ed25519 base point
+var base Point
+
+func init() {
+	base.ScMulBase(&One)
+}
+
+func TestBasePointArith(t *testing.T) {
+	var base1 Point
+	base1.ScMul(&base, &One)
+	if !base.ConstTimeEqual(&base1) {
+		ebase := base.Encode()
+		ebase1 := base1.Encode()
+		t.Errorf("base [%x] != 1*base [%x]", ebase[:], ebase1[:])
+	}
+
+	Two := One
+	Two.Add(&Two, &One)
+
+	base2a := base
+	base2a.Add(&base2a, &base)
+
+	base2b := base
+	base2b.ScMul(&base2b, &Two)
+
+	if !base2a.ConstTimeEqual(&base2b) {
+		ebase2a := base2a.Encode()
+		ebase2b := base2b.Encode()
+		t.Errorf("base+base [%x] != 2*base [%x] (1)", ebase2a[:], ebase2b[:])
+	}
+
+	var base2c Point
+	base2c.ScMulBase(&Two)
+
+	if !base2a.ConstTimeEqual(&base2c) {
+		ebase2a := base2a.Encode()
+		ebase2c := base2c.Encode()
+		t.Errorf("base+base [%x] != 2*base [%x] (2)", ebase2a[:], ebase2c[:])
+	}
+}

--- a/crypto/ed25519/math/scalar.go
+++ b/crypto/ed25519/math/scalar.go
@@ -1,0 +1,77 @@
+package math
+
+import (
+	"chain-stealth/crypto/ed25519/edwards25519"
+	"crypto/subtle"
+)
+
+// Uint256le is a 256-bit little-endian scalar.
+type Uint256le [32]byte
+
+var (
+	// Zero is the number 0.
+	Zero Uint256le
+
+	// One is the number 1.
+	One = Uint256le{1}
+
+	// NegOne is the number -1 mod L
+	NegOne = Uint256le{
+		0xec, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
+		0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10,
+	}
+
+	// L is the subgroup order:
+	// 2^252 + 27742317777372353535851937790883648493
+	L = Uint256le{
+		0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
+		0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10,
+	}
+)
+
+// Add computes x+y (mod L) and places the result in z, returning
+// that. Any or all of x, y, and z may be the same pointer.
+func (z *Uint256le) Add(x, y *Uint256le) *Uint256le {
+	return z.MulAdd(x, &One, y)
+}
+
+// Sub computes x-y (mod L) and places the result in z, returning
+// that. Any or all of x, y, and z may be the same pointer.
+func (z *Uint256le) Sub(x, y *Uint256le) *Uint256le {
+	return z.MulAdd(y, &NegOne, x)
+}
+
+// Neg negates x (mod L) and places the result in z, returning that. X
+// and z may be the same pointer.
+func (z *Uint256le) Neg(x *Uint256le) *Uint256le {
+	return z.MulAdd(x, &NegOne, &Zero)
+}
+
+// MulAdd computes ab+c (mod L) and places the result in z, returning
+// that. Any or all of the pointers may be the same.
+func (z *Uint256le) MulAdd(a, b, c *Uint256le) *Uint256le {
+	edwards25519.ScMulAdd((*[32]byte)(z), (*[32]byte)(a), (*[32]byte)(b), (*[32]byte)(c))
+	return z
+}
+
+func (z *Uint256le) Equal(x *Uint256le) bool {
+	return subtle.ConstantTimeCompare(x[:], z[:]) == 1
+}
+
+// Prune performs the pruning operation in-place.
+func (z *Uint256le) Prune() {
+	z[0] &= 248
+	z[31] &= 127
+	z[31] |= 64
+}
+
+// Reduce takes a 512-bit scalar and reduces it mod L, placing the
+// result in z and returning that.
+func (z *Uint256le) Reduce(x *[64]byte) *Uint256le {
+	edwards25519.ScReduce((*[32]byte)(z), x)
+	return z
+}

--- a/crypto/ed25519/math/scalar.go
+++ b/crypto/ed25519/math/scalar.go
@@ -1,8 +1,9 @@
 package math
 
 import (
-	"chain-stealth/crypto/ed25519/edwards25519"
 	"crypto/subtle"
+
+	"chain/crypto/ed25519/internal/edwards25519"
 )
 
 // Uint256le is a 256-bit little-endian scalar.

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2918";
+	public final String Id = "main/rev2919";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2918"
+const ID string = "main/rev2919"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2918"
+export const rev_id = "main/rev2919"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2918".freeze
+	ID = "main/rev2919".freeze
 end


### PR DESCRIPTION
A more Go-idiomatic interface to the routines in `ed25519/internal/edwards25519` for doing point and scalar (mod L) arithmetic.