### PR TITLE
sdk/node: remove MAX_BLOCK_HEIGHT from documentation

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2916";
+	public final String Id = "main/rev2917";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2916"
+const ID string = "main/rev2917"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2916"
+export const rev_id = "main/rev2917"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2916".freeze
+	ID = "main/rev2917".freeze
 end

--- a/sdk/node/src/api/transactionFeeds.js
+++ b/sdk/node/src/api/transactionFeeds.js
@@ -5,6 +5,7 @@ const uuid = require('uuid')
 /**
  * Hardcoding value of (2 ** 63) - 1 since JavaScript rounds this value up,
  * which causes issues when attempting to query TransactionFeed.
+ * @ignore
  */
 const MAX_BLOCK_HEIGHT = '9223372036854775807'
 


### PR DESCRIPTION
It is an internal value that doesn't need to be exposed to users
developing with the SDK.