### PR TITLE
crypto/ed25519/math: Rename math.Uint256le to ecmath.Scalar for brevity

### DIFF
--- a/crypto/ed25519/ecmath/point.go
+++ b/crypto/ed25519/ecmath/point.go
@@ -1,4 +1,4 @@
-package math
+package ecmath
 
 import (
 	"crypto/subtle"
@@ -40,20 +40,20 @@ func (z *Point) Sub(x, y *Point) *Point {
 
 // ScMul multiplies the EC point x by the scalar y, placing the result
 // in z and returning that. X and z may be the same pointer.
-func (z *Point) ScMul(x *Point, y *Uint256le) *Point {
+func (z *Point) ScMul(x *Point, y *Scalar) *Point {
 	return z.ScMulAdd(x, y, &Zero)
 }
 
 // ScMulBase multiplies the ed25519 base point by x and places the
 // result in z, returning that.
-func (z *Point) ScMulBase(x *Uint256le) *Point {
+func (z *Point) ScMulBase(x *Scalar) *Point {
 	edwards25519.GeScalarMultBase((*edwards25519.ExtendedGroupElement)(z), (*[32]byte)(x))
 	return z
 }
 
 // ScMulAdd computes xa+yB, where B is the ed25519 base point, and
 // places the result in z, returning that.
-func (z *Point) ScMulAdd(a *Point, x, y *Uint256le) *Point {
+func (z *Point) ScMulAdd(a *Point, x, y *Scalar) *Point {
 	// TODO: replace with constant-time implementation to avoid
 	// sidechannel attacks
 

--- a/crypto/ed25519/ecmath/point_test.go
+++ b/crypto/ed25519/ecmath/point_test.go
@@ -1,4 +1,4 @@
-package math
+package ecmath
 
 import "testing"
 

--- a/crypto/ed25519/ecmath/scalar.go
+++ b/crypto/ed25519/ecmath/scalar.go
@@ -1,4 +1,4 @@
-package math
+package ecmath
 
 import (
 	"crypto/subtle"
@@ -6,18 +6,18 @@ import (
 	"chain/crypto/ed25519/internal/edwards25519"
 )
 
-// Uint256le is a 256-bit little-endian scalar.
-type Uint256le [32]byte
+// Scalar is a 256-bit little-endian scalar.
+type Scalar [32]byte
 
 var (
 	// Zero is the number 0.
-	Zero Uint256le
+	Zero Scalar
 
 	// One is the number 1.
-	One = Uint256le{1}
+	One = Scalar{1}
 
 	// NegOne is the number -1 mod L
-	NegOne = Uint256le{
+	NegOne = Scalar{
 		0xec, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
 		0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -26,7 +26,7 @@ var (
 
 	// L is the subgroup order:
 	// 2^252 + 27742317777372353535851937790883648493
-	L = Uint256le{
+	L = Scalar{
 		0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
 		0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -36,35 +36,35 @@ var (
 
 // Add computes x+y (mod L) and places the result in z, returning
 // that. Any or all of x, y, and z may be the same pointer.
-func (z *Uint256le) Add(x, y *Uint256le) *Uint256le {
+func (z *Scalar) Add(x, y *Scalar) *Scalar {
 	return z.MulAdd(x, &One, y)
 }
 
 // Sub computes x-y (mod L) and places the result in z, returning
 // that. Any or all of x, y, and z may be the same pointer.
-func (z *Uint256le) Sub(x, y *Uint256le) *Uint256le {
+func (z *Scalar) Sub(x, y *Scalar) *Scalar {
 	return z.MulAdd(y, &NegOne, x)
 }
 
 // Neg negates x (mod L) and places the result in z, returning that. X
 // and z may be the same pointer.
-func (z *Uint256le) Neg(x *Uint256le) *Uint256le {
+func (z *Scalar) Neg(x *Scalar) *Scalar {
 	return z.MulAdd(x, &NegOne, &Zero)
 }
 
 // MulAdd computes ab+c (mod L) and places the result in z, returning
 // that. Any or all of the pointers may be the same.
-func (z *Uint256le) MulAdd(a, b, c *Uint256le) *Uint256le {
+func (z *Scalar) MulAdd(a, b, c *Scalar) *Scalar {
 	edwards25519.ScMulAdd((*[32]byte)(z), (*[32]byte)(a), (*[32]byte)(b), (*[32]byte)(c))
 	return z
 }
 
-func (z *Uint256le) Equal(x *Uint256le) bool {
+func (z *Scalar) Equal(x *Scalar) bool {
 	return subtle.ConstantTimeCompare(x[:], z[:]) == 1
 }
 
 // Prune performs the pruning operation in-place.
-func (z *Uint256le) Prune() {
+func (z *Scalar) Prune() {
 	z[0] &= 248
 	z[31] &= 127
 	z[31] |= 64
@@ -72,7 +72,7 @@ func (z *Uint256le) Prune() {
 
 // Reduce takes a 512-bit scalar and reduces it mod L, placing the
 // result in z and returning that.
-func (z *Uint256le) Reduce(x *[64]byte) *Uint256le {
+func (z *Scalar) Reduce(x *[64]byte) *Scalar {
 	edwards25519.ScReduce((*[32]byte)(z), x)
 	return z
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2919";
+	public final String Id = "main/rev2920";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2919"
+const ID string = "main/rev2920"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2919"
+export const rev_id = "main/rev2920"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2919".freeze
+	ID = "main/rev2920".freeze
 end


### PR DESCRIPTION
This renames `Uint256le` to `Scalar` since it's easier to read. Consequently, to avoid the spelling of `math.Scalar` as deceivingly abstract, the package is renamed to `ecmath`.

PTAL @bobg @kr @danrobinson 