### PR TITLE
analytics: load Config from Oracle database

### DIFF
--- a/analytics/src/main/java/com/chain/analytics/Application.java
+++ b/analytics/src/main/java/com/chain/analytics/Application.java
@@ -6,16 +6,12 @@ import com.chain.exception.ConnectivityException;
 import com.chain.exception.HTTPException;
 import com.chain.http.Client;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.beans.PropertyVetoException;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 
 /**
  * Application is the Main class for the Chain Analytics
@@ -84,7 +80,7 @@ public class Application {
         System.exit(1);
       }
 
-      importer = Importer.connect(client, ds, DEFAULT_FEED_ALIAS, config);
+      importer = Importer.connect(client, ds, config);
     } catch (BadURLException ex) {
       logger.fatal("Unable to parse the Chain Core URL provided \"{}\".", chainUrl, ex);
       System.exit(1);

--- a/analytics/src/main/java/com/chain/analytics/Config.java
+++ b/analytics/src/main/java/com/chain/analytics/Config.java
@@ -1,9 +1,17 @@
-package analytics;
+package com.chain.analytics;
 
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.sql.DataSource;
 
 public class Config {
+  private static final String SQL_SELECT_CUSTOM_COLUMNS =
+      "SELECT \"TABLE\", \"NAME\", \"TYPE\", \"PATH\" FROM custom_columns";
+
   List<CustomColumn> transactionColumns;
   List<CustomColumn> inputColumns;
   List<CustomColumn> outputColumns;
@@ -12,6 +20,54 @@ public class Config {
     transactionColumns = new ArrayList<>();
     inputColumns = new ArrayList<>();
     outputColumns = new ArrayList<>();
+  }
+
+  /**
+   * load pulls in the Chain Analytics configuration from the Oracle database.
+   * If there is no current configuration, load returns null.
+   *
+   * @param  ds the Oracle database datasource
+   * @return    the current Chain Analytics configuration
+   */
+  public static Config load(final DataSource ds) throws InvalidConfigException, SQLException {
+    final Config config = new Config();
+    try (Connection conn = ds.getConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery(SQL_SELECT_CUSTOM_COLUMNS)) {
+      while (rs.next()) {
+        final String tbl = rs.getString("TABLE");
+        final String name = rs.getString("NAME");
+        final String rawType = rs.getString("TYPE");
+        final String rawPath = rs.getString("PATH");
+
+        final Schema.SQLType type = OracleTypes.parse(rawType);
+        if (type == null) {
+          throw new InvalidConfigException(String.format("Unknown column type %s", rawType));
+        }
+        final JsonPath path = new JsonPath(rawPath);
+
+        switch (tbl.toLowerCase()) {
+          case "transactions":
+            config.transactionColumns.add(new CustomColumn(name, type, path));
+            break;
+          case "transaction_inputs":
+            config.inputColumns.add(new CustomColumn(name, type, path));
+            break;
+          case "transaction_outputs":
+            config.outputColumns.add(new CustomColumn(name, type, path));
+            break;
+          default:
+            throw new InvalidConfigException(String.format("Unknown table %s", tbl));
+        }
+      }
+    } catch (SQLException ex) {
+      if (ex.getErrorCode() == 942) {
+        // ORA-00942 table or view does not exist.
+        return null;
+      }
+      throw ex;
+    }
+    return config;
   }
 
   public static class CustomColumn {
@@ -23,6 +79,14 @@ public class Config {
       this.name = name;
       this.type = type;
       this.jsonPath = jsonPath;
+    }
+  }
+
+  public static class InvalidConfigException extends Exception {
+    private static final long serialVersionUID = 201775336232807009L;
+
+    public InvalidConfigException(String message) {
+      super(message);
     }
   }
 }

--- a/analytics/src/main/java/com/chain/analytics/Config.java
+++ b/analytics/src/main/java/com/chain/analytics/Config.java
@@ -1,22 +1,22 @@
 package com.chain.analytics;
 
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
-import java.sql.Statement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import javax.sql.DataSource;
 
 public class Config {
   private static final String SQL_SELECT_CUSTOM_COLUMNS =
       "SELECT \"TABLE\", \"NAME\", \"TYPE\", \"PATH\" FROM custom_columns";
 
-  List<CustomColumn> transactionColumns;
-  List<CustomColumn> inputColumns;
-  List<CustomColumn> outputColumns;
+  final List<CustomColumn> transactionColumns;
+  final List<CustomColumn> inputColumns;
+  final List<CustomColumn> outputColumns;
 
-  public Config() {
+  private Config() {
     transactionColumns = new ArrayList<>();
     inputColumns = new ArrayList<>();
     outputColumns = new ArrayList<>();
@@ -71,9 +71,9 @@ public class Config {
   }
 
   public static class CustomColumn {
-    String name;
-    Schema.SQLType type;
-    JsonPath jsonPath;
+    final String name;
+    final Schema.SQLType type;
+    final JsonPath jsonPath;
 
     public CustomColumn(String name, Schema.SQLType type, JsonPath jsonPath) {
       this.name = name;

--- a/analytics/src/main/java/com/chain/analytics/Importer.java
+++ b/analytics/src/main/java/com/chain/analytics/Importer.java
@@ -1,4 +1,4 @@
-package analytics;
+package com.chain.analytics;
 
 import com.chain.http.Client;
 import com.chain.api.PagedItems;
@@ -97,13 +97,13 @@ public class Importer {
     Schema.Builder transactionsBuilder =
         new Schema.Builder("transactions")
             .setPrimaryKey(Arrays.asList("id"))
-            .addColumn("id", new Schema.Varchar2(64))
-            .addColumn("block_height", new Schema.Integer())
-            .addColumn("timestamp", new Schema.Timestamp())
-            .addColumn("position", new Schema.Integer())
-            .addColumn("local", new Schema.Boolean())
-            .addColumn("reference_data", new Schema.Blob())
-            .addColumn("data", new Schema.Blob());
+            .addColumn("id", new OracleTypes.Varchar2(64))
+            .addColumn("block_height", new OracleTypes.BigInteger())
+            .addColumn("timestamp", new OracleTypes.Timestamp())
+            .addColumn("position", new OracleTypes.BigInteger())
+            .addColumn("local", new OracleTypes.Boolean())
+            .addColumn("reference_data", new OracleTypes.Blob())
+            .addColumn("data", new OracleTypes.Blob());
     for (Config.CustomColumn col : mConfig.transactionColumns) {
       transactionsBuilder.addColumn(col.name, col.type);
     }
@@ -111,22 +111,22 @@ public class Importer {
     Schema.Builder inputsBuilder =
         new Schema.Builder("transaction_inputs")
             .setPrimaryKey(Arrays.asList("transaction_id", "index"))
-            .addColumn("transaction_id", new Schema.Varchar2(64))
-            .addColumn("index", new Schema.Integer())
-            .addColumn("type", new Schema.Varchar2(64))
-            .addColumn("asset_id", new Schema.Varchar2(64))
-            .addColumn("asset_alias", new Schema.Varchar2(2000))
-            .addColumn("asset_definition", new Schema.Blob())
-            .addColumn("asset_tags", new Schema.Blob())
-            .addColumn("local_asset", new Schema.Boolean())
-            .addColumn("amount", new Schema.Integer())
-            .addColumn("account_id", new Schema.Varchar2(64))
-            .addColumn("account_alias", new Schema.Varchar2(2000))
-            .addColumn("account_tags", new Schema.Blob())
-            .addColumn("issuance_program", new Schema.Clob())
-            .addColumn("reference_data", new Schema.Blob())
-            .addColumn("local", new Schema.Boolean())
-            .addColumn("spent_output_id", new Schema.Varchar2(64));
+            .addColumn("transaction_id", new OracleTypes.Varchar2(64))
+            .addColumn("index", new OracleTypes.BigInteger())
+            .addColumn("type", new OracleTypes.Varchar2(64))
+            .addColumn("asset_id", new OracleTypes.Varchar2(64))
+            .addColumn("asset_alias", new OracleTypes.Varchar2(2000))
+            .addColumn("asset_definition", new OracleTypes.Blob())
+            .addColumn("asset_tags", new OracleTypes.Blob())
+            .addColumn("local_asset", new OracleTypes.Boolean())
+            .addColumn("amount", new OracleTypes.BigInteger())
+            .addColumn("account_id", new OracleTypes.Varchar2(64))
+            .addColumn("account_alias", new OracleTypes.Varchar2(2000))
+            .addColumn("account_tags", new OracleTypes.Blob())
+            .addColumn("issuance_program", new OracleTypes.Clob())
+            .addColumn("reference_data", new OracleTypes.Blob())
+            .addColumn("local", new OracleTypes.Boolean())
+            .addColumn("spent_output_id", new OracleTypes.Varchar2(64));
     for (Config.CustomColumn col : mConfig.inputColumns) {
       inputsBuilder.addColumn(col.name, col.type);
     }
@@ -135,24 +135,24 @@ public class Importer {
         new Schema.Builder("transaction_outputs")
             .setPrimaryKey(Arrays.asList("output_id"))
             .addUniqueConstraint(Arrays.asList("transaction_id", "index"))
-            .addColumn("transaction_id", new Schema.Varchar2(64))
-            .addColumn("index", new Schema.Integer())
-            .addColumn("output_id", new Schema.Varchar2(64))
-            .addColumn("type", new Schema.Varchar2(64))
-            .addColumn("purpose", new Schema.Varchar2(64))
-            .addColumn("asset_id", new Schema.Varchar2(64))
-            .addColumn("asset_alias", new Schema.Varchar2(2000))
-            .addColumn("asset_definition", new Schema.Blob())
-            .addColumn("asset_tags", new Schema.Blob())
-            .addColumn("local_asset", new Schema.Boolean())
-            .addColumn("amount", new Schema.Integer())
-            .addColumn("account_id", new Schema.Varchar2(64))
-            .addColumn("account_alias", new Schema.Varchar2(2000))
-            .addColumn("account_tags", new Schema.Blob())
-            .addColumn("control_program", new Schema.Clob())
-            .addColumn("reference_data", new Schema.Blob())
-            .addColumn("local", new Schema.Boolean())
-            .addColumn("spent", new Schema.Boolean());
+            .addColumn("transaction_id", new OracleTypes.Varchar2(64))
+            .addColumn("index", new OracleTypes.BigInteger())
+            .addColumn("output_id", new OracleTypes.Varchar2(64))
+            .addColumn("type", new OracleTypes.Varchar2(64))
+            .addColumn("purpose", new OracleTypes.Varchar2(64))
+            .addColumn("asset_id", new OracleTypes.Varchar2(64))
+            .addColumn("asset_alias", new OracleTypes.Varchar2(2000))
+            .addColumn("asset_definition", new OracleTypes.Blob())
+            .addColumn("asset_tags", new OracleTypes.Blob())
+            .addColumn("local_asset", new OracleTypes.Boolean())
+            .addColumn("amount", new OracleTypes.BigInteger())
+            .addColumn("account_id", new OracleTypes.Varchar2(64))
+            .addColumn("account_alias", new OracleTypes.Varchar2(2000))
+            .addColumn("account_tags", new OracleTypes.Blob())
+            .addColumn("control_program", new OracleTypes.Clob())
+            .addColumn("reference_data", new OracleTypes.Blob())
+            .addColumn("local", new OracleTypes.Boolean())
+            .addColumn("spent", new OracleTypes.Boolean());
     for (Config.CustomColumn col : mConfig.outputColumns) {
       inputsBuilder.addColumn(col.name, col.type);
     }

--- a/analytics/src/main/java/com/chain/analytics/Importer.java
+++ b/analytics/src/main/java/com/chain/analytics/Importer.java
@@ -1,31 +1,21 @@
 package com.chain.analytics;
 
-import com.chain.http.Client;
-import com.chain.api.PagedItems;
-import com.chain.api.Query;
 import com.chain.api.Transaction;
 import com.chain.api.Transaction.QueryBuilder;
 import com.chain.exception.APIException;
 import com.chain.exception.ChainException;
+import com.chain.http.Client;
 import com.google.gson.Gson;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 
+import javax.sql.DataSource;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.SQLSyntaxErrorException;
-import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import javax.sql.DataSource;
-
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.ThreadContext;
+import java.sql.*;
+import java.util.*;
 
 /**
  * Importer is responsible for reading transactions from a Chain Core
@@ -42,9 +32,9 @@ public class Importer {
   private static final Logger logger = LogManager.getLogger();
   private static final Gson gson = new Gson();
 
-  private Client mChain;
-  private Config mConfig;
-  private DataSource mDataSource;
+  private final Client mChain;
+  private final Config mConfig;
+  private final DataSource mDataSource;
   private Transaction.Feed mFeed;
   private Schema mTransactionsTbl;
   private Schema mTransactionInputsTbl;
@@ -56,15 +46,13 @@ public class Importer {
    * does not begin syncing yet.
    * @param client    a client for the Chain Core
    * @param ds        the database to populate
-   * @param feedAlias the alias of the transaction feed to use
    * @return          the initialized transaction importer
    */
-  public static Importer connect(
-      final Client client, final DataSource ds, final String feedAlias, final Config config)
+  public static Importer connect(final Client client, final DataSource ds, final Config config)
       throws ChainException, SQLException {
     // Create or load the transaction feed for the provided alias.
     try {
-      Transaction.Feed.create(client, feedAlias, "");
+      Transaction.Feed.create(client, Application.DEFAULT_FEED_ALIAS, "");
     } catch (APIException ex) {
       // CH050 means the transaction feed already existed. If that's
       // the case, ignore the exception because we'll retrieve the
@@ -73,9 +61,10 @@ public class Importer {
         logger.catching(ex);
         throw ex;
       }
-      logger.info("Transaction feed {} already exists", feedAlias);
+      logger.info("Transaction feed {} already exists", Application.DEFAULT_FEED_ALIAS);
     }
-    final Transaction.Feed feed = Transaction.Feed.getByAlias(client, feedAlias);
+    final Transaction.Feed feed =
+        Transaction.Feed.getByAlias(client, Application.DEFAULT_FEED_ALIAS);
     logger.info("Using transaction feed {} starting at cursor {}", feed.id, feed.after);
 
     // Initialize the schema based on the configuration.
@@ -92,11 +81,11 @@ public class Importer {
     mFeed = feed;
   }
 
-  void initializeSchema() throws SQLException {
+  private void initializeSchema() throws SQLException {
 
     Schema.Builder transactionsBuilder =
         new Schema.Builder("transactions")
-            .setPrimaryKey(Arrays.asList("id"))
+            .setPrimaryKey(Collections.singletonList("id"))
             .addColumn("id", new OracleTypes.Varchar2(64))
             .addColumn("block_height", new OracleTypes.BigInteger())
             .addColumn("timestamp", new OracleTypes.Timestamp())
@@ -133,7 +122,7 @@ public class Importer {
 
     Schema.Builder outputsBuilder =
         new Schema.Builder("transaction_outputs")
-            .setPrimaryKey(Arrays.asList("output_id"))
+            .setPrimaryKey(Collections.singletonList("output_id"))
             .addUniqueConstraint(Arrays.asList("transaction_id", "index"))
             .addColumn("transaction_id", new OracleTypes.Varchar2(64))
             .addColumn("index", new OracleTypes.BigInteger())
@@ -256,7 +245,7 @@ public class Importer {
   // gets trickier. We might be able to write a PL/SQL function that ignores
   // the ORA-00001 exception in Oracle instead of client-side to get around
   // that.
-  void processBatch(final List<Transaction> transactions) throws SQLException {
+  private void processBatch(final List<Transaction> transactions) throws SQLException {
     final String insertTxQ = mTransactionsTbl.getInsertStatement();
     final String insertInputQ = mTransactionInputsTbl.getInsertStatement();
     final String insertOutputQ = mTransactionOutputsTbl.getInsertStatement();

--- a/analytics/src/main/java/com/chain/analytics/JsonPath.java
+++ b/analytics/src/main/java/com/chain/analytics/JsonPath.java
@@ -12,8 +12,8 @@ import java.util.Map;
  *
  * TODO(jackson): Do we need to support indexing into arrays?
  */
-public class JsonPath {
-  private List<String> mPath;
+class JsonPath {
+  private final List<String> mPath;
 
   public JsonPath(final List<String> path) {
     mPath = Collections.unmodifiableList(path);

--- a/analytics/src/main/java/com/chain/analytics/JsonPath.java
+++ b/analytics/src/main/java/com/chain/analytics/JsonPath.java
@@ -1,7 +1,8 @@
-package analytics;
+package com.chain.analytics;
 
 import com.chain.api.Transaction;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -16,6 +17,10 @@ public class JsonPath {
 
   public JsonPath(final List<String> path) {
     mPath = Collections.unmodifiableList(path);
+  }
+
+  public JsonPath(final String serializedPath) {
+    mPath = Collections.unmodifiableList(Arrays.asList(serializedPath.split("[.]{1}")));
   }
 
   public String toString() {

--- a/analytics/src/main/java/com/chain/analytics/OracleTypes.java
+++ b/analytics/src/main/java/com/chain/analytics/OracleTypes.java
@@ -132,7 +132,7 @@ public class OracleTypes {
   }
 
   public static class Varchar2 implements Schema.SQLType {
-    private int mLength;
+    private final int mLength;
 
     public Varchar2(final int maxLength) {
       mLength = maxLength;

--- a/analytics/src/main/java/com/chain/analytics/OracleTypes.java
+++ b/analytics/src/main/java/com/chain/analytics/OracleTypes.java
@@ -1,0 +1,153 @@
+package com.chain.analytics;
+
+import java.sql.Types;
+
+public class OracleTypes {
+
+  /**
+   * parse takes a string representing a Chain Analytics type and returns
+   * the corresponding Oracle sql type. If parsing fails or any reason,
+   * this function returns null.
+   *
+   * @param  typeString the Chain Analytics type
+   * @return            the corresponding Oracle type
+   */
+  public static Schema.SQLType parse(final String typeString) {
+    String[] tokens = typeString.trim().toLowerCase().split("[()]{1}");
+    if (tokens.length == 0) {
+      return null;
+    }
+
+    switch (tokens[0]) {
+      case "bigint":
+        if (tokens.length > 1) {
+          return null;
+        }
+        return new BigInteger();
+      case "blob":
+        if (tokens.length > 1) {
+          return null;
+        }
+        return new Blob();
+      case "boolean":
+        if (tokens.length > 1) {
+          return null;
+        }
+        return new Boolean();
+      case "clob":
+        if (tokens.length > 1) {
+          return null;
+        }
+        return new Clob();
+      case "timestamp":
+        if (tokens.length > 1) {
+          return null;
+        }
+        return new Timestamp();
+      case "varchar":
+        if (tokens.length < 2) {
+          return null;
+        }
+        try {
+          final int width = Integer.parseInt(tokens[1]);
+          if (width > 4000) {
+            return null;
+          }
+          return new Varchar2(width);
+        } catch (NumberFormatException ex) {
+          return null;
+        }
+    }
+    return null;
+  }
+
+  public static class BigInteger implements Schema.SQLType {
+    public String toString() {
+      return "bigint";
+    }
+
+    public String toDDL() {
+      return "NUMBER(20)";
+    }
+
+    public int getType() {
+      return Types.BIGINT;
+    }
+  }
+
+  public static class Blob implements Schema.SQLType {
+    public String toString() {
+      return "blob";
+    }
+
+    public String toDDL() {
+      return "BLOB";
+    }
+
+    public int getType() {
+      return Types.BLOB;
+    }
+  }
+
+  public static class Boolean implements Schema.SQLType {
+    public String toString() {
+      return "boolean";
+    }
+
+    public String toDDL() {
+      return "CHAR(1)";
+    }
+
+    public int getType() {
+      return Types.CHAR;
+    }
+  }
+
+  public static class Clob implements Schema.SQLType {
+    public String toString() {
+      return "clob";
+    }
+
+    public String toDDL() {
+      return "CLOB";
+    }
+
+    public int getType() {
+      return Types.CLOB;
+    }
+  }
+
+  public static class Timestamp implements Schema.SQLType {
+    public String toString() {
+      return "timestamp";
+    }
+
+    public String toDDL() {
+      return "TIMESTAMP WITH TIME ZONE";
+    }
+
+    public int getType() {
+      return Types.TIMESTAMP_WITH_TIMEZONE;
+    }
+  }
+
+  public static class Varchar2 implements Schema.SQLType {
+    private int mLength;
+
+    public Varchar2(final int maxLength) {
+      mLength = maxLength;
+    }
+
+    public String toString() {
+      return String.format("varchar(%d)", mLength);
+    }
+
+    public String toDDL() {
+      return String.format("VARCHAR2(%d)", mLength);
+    }
+
+    public int getType() {
+      return Types.VARCHAR;
+    }
+  }
+}

--- a/analytics/src/main/java/com/chain/analytics/Schema.java
+++ b/analytics/src/main/java/com/chain/analytics/Schema.java
@@ -1,7 +1,6 @@
-package analytics;
+package com.chain.analytics;
 
 import java.util.*;
-import java.sql.Types;
 
 /**
  * Schema represents the schema of an Oracle database table. Schemas
@@ -33,6 +32,8 @@ public class Schema {
    */
   public interface SQLType {
     String toString();
+
+    String toDDL();
 
     int getType();
   }
@@ -123,7 +124,7 @@ public class Schema {
           .append(col.name.toUpperCase())
           .append("\"")
           .append(" ")
-          .append(col.type.toString());
+          .append(col.type.toDDL());
 
       // use a comma separator before every column after the first.
       sep = ",";
@@ -170,71 +171,5 @@ public class Schema {
         .append(String.join(", ", Collections.nCopies(mColumns.size(), "?")))
         .append(")");
     return sb.toString();
-  }
-
-  public static class Blob implements SQLType {
-    public String toString() {
-      return "BLOB";
-    }
-
-    public int getType() {
-      return Types.BLOB;
-    }
-  }
-
-  public static class Boolean implements SQLType {
-    public String toString() {
-      return "CHAR(1)";
-    }
-
-    public int getType() {
-      return Types.CHAR;
-    }
-  }
-
-  public static class Clob implements SQLType {
-    public String toString() {
-      return "CLOB";
-    }
-
-    public int getType() {
-      return Types.CLOB;
-    }
-  }
-
-  public static class Integer implements SQLType {
-    public String toString() {
-      return "NUMBER(20)";
-    }
-
-    public int getType() {
-      return Types.BIGINT;
-    }
-  }
-
-  public static class Timestamp implements SQLType {
-    public String toString() {
-      return "TIMESTAMP WITH TIME ZONE";
-    }
-
-    public int getType() {
-      return Types.TIMESTAMP_WITH_TIMEZONE;
-    }
-  }
-
-  public static class Varchar2 implements SQLType {
-    private int mLength;
-
-    public Varchar2(final int maxLength) {
-      mLength = maxLength;
-    }
-
-    public String toString() {
-      return String.format("VARCHAR2(%d)", mLength);
-    }
-
-    public int getType() {
-      return Types.VARCHAR;
-    }
   }
 }

--- a/analytics/src/main/java/com/chain/analytics/Schema.java
+++ b/analytics/src/main/java/com/chain/analytics/Schema.java
@@ -8,17 +8,17 @@ import java.util.*;
  * constructed, a Schema is immutable.
  */
 public class Schema {
-  String mName;
-  List<Column> mColumns;
-  List<String> mPrimaryKey;
-  List<List<String>> mUniqueConstraints;
+  private String mName;
+  private List<Column> mColumns;
+  private List<String> mPrimaryKey;
+  private List<List<String>> mUniqueConstraints;
 
   /**
    * Column represents a single column in a table.
    */
   public static class Column {
-    String name;
-    SQLType type;
+    final String name;
+    final SQLType type;
 
     public Column(final String name, final SQLType type) {
       this.name = name;
@@ -42,10 +42,10 @@ public class Schema {
    * Builder implements the builder pattern for a Schema.
    */
   public static class Builder {
-    private String mName;
-    private List<Column> mColumns;
+    private final String mName;
+    private final List<Column> mColumns;
     private List<String> mPrimaryKey;
-    private List<List<String>> mUniqueConstraints;
+    private final List<List<String>> mUniqueConstraints;
 
     /**
      * Constructor for a builder.

--- a/analytics/src/test/java/com/chain/analytics/JsonPathTest.java
+++ b/analytics/src/test/java/com/chain/analytics/JsonPathTest.java
@@ -1,4 +1,4 @@
-package analytics;
+package com.chain.analytics;
 
 import com.chain.api.Transaction;
 

--- a/analytics/src/test/java/com/chain/analytics/JsonPathTest.java
+++ b/analytics/src/test/java/com/chain/analytics/JsonPathTest.java
@@ -1,20 +1,20 @@
 package com.chain.analytics;
 
 import com.chain.api.Transaction;
+import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.TreeMap;
-import org.junit.Test;
+
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
 
 public class JsonPathTest {
 
   @Test
   public void testExtract() {
-    Map<String, Object> map = new TreeMap<String, Object>();
-    Map<String, Object> innerMap = new TreeMap<String, Object>();
+    Map<String, Object> map = new TreeMap<>();
+    Map<String, Object> innerMap = new TreeMap<>();
     innerMap.put("id", "abc");
     innerMap.put("account_number", 123);
     map.put("account", innerMap);

--- a/analytics/src/test/java/com/chain/analytics/OracleTypesTest.java
+++ b/analytics/src/test/java/com/chain/analytics/OracleTypesTest.java
@@ -1,0 +1,29 @@
+package com.chain.analytics;
+
+import org.junit.Test;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
+
+public class OracleTypesTest {
+  @Test
+  public void testParseInvalidTypes() {
+    assertNull(OracleTypes.parse("bytea"));
+    assertNull(OracleTypes.parse("integer"));
+    assertNull(OracleTypes.parse("nvarchar2(100)"));
+    assertNull(OracleTypes.parse("blob(100)"));
+    assertNull(OracleTypes.parse("blob((100))"));
+    assertNull(OracleTypes.parse("varchar((100))"));
+    assertNull(OracleTypes.parse("varchar(4001)"));
+  }
+
+  @Test
+  public void testParseToString() {
+    assertEquals("bigint", OracleTypes.parse("bigint").toString());
+    assertEquals("blob", OracleTypes.parse("blob").toString());
+    assertEquals("boolean", OracleTypes.parse("boolean").toString());
+    assertEquals("clob", OracleTypes.parse("clob").toString());
+    assertEquals("timestamp", OracleTypes.parse("timestamp").toString());
+    assertEquals("varchar(64)", OracleTypes.parse("varchar(64)").toString());
+    assertEquals("varchar(100)", OracleTypes.parse("varchar(100)").toString());
+  }
+}

--- a/analytics/src/test/java/com/chain/analytics/SchemaTest.java
+++ b/analytics/src/test/java/com/chain/analytics/SchemaTest.java
@@ -1,23 +1,26 @@
 package com.chain.analytics;
 
-import java.util.Arrays;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
 import static junit.framework.TestCase.assertEquals;
 
 public class SchemaTest {
 
-  static final Schema oneColumn =
+  private static final Schema oneColumn =
       new Schema.Builder("transactions")
           .addColumn("id", new OracleTypes.Varchar2(32))
-          .setPrimaryKey(Arrays.asList("id"))
+          .setPrimaryKey(Collections.singletonList("id"))
           .build();
-  static final Schema multipleColumns =
+  private static final Schema multipleColumns =
       new Schema.Builder("transaction_outputs")
           .addColumn("transaction_id", new OracleTypes.Varchar2(32))
           .addColumn("index", new OracleTypes.BigInteger())
           .addColumn("output_id", new OracleTypes.Varchar2(32))
           .addUniqueConstraint(Arrays.asList("transaction_id", "index"))
-          .setPrimaryKey(Arrays.asList("output_id"))
+          .setPrimaryKey(Collections.singletonList("output_id"))
           .build();
 
   @Test

--- a/analytics/src/test/java/com/chain/analytics/SchemaTest.java
+++ b/analytics/src/test/java/com/chain/analytics/SchemaTest.java
@@ -1,4 +1,4 @@
-package analytics;
+package com.chain.analytics;
 
 import java.util.Arrays;
 import org.junit.Test;
@@ -8,14 +8,14 @@ public class SchemaTest {
 
   static final Schema oneColumn =
       new Schema.Builder("transactions")
-          .addColumn("id", new Schema.Varchar2(32))
+          .addColumn("id", new OracleTypes.Varchar2(32))
           .setPrimaryKey(Arrays.asList("id"))
           .build();
   static final Schema multipleColumns =
       new Schema.Builder("transaction_outputs")
-          .addColumn("transaction_id", new Schema.Varchar2(32))
-          .addColumn("index", new Schema.Integer())
-          .addColumn("output_id", new Schema.Varchar2(32))
+          .addColumn("transaction_id", new OracleTypes.Varchar2(32))
+          .addColumn("index", new OracleTypes.BigInteger())
+          .addColumn("output_id", new OracleTypes.Varchar2(32))
           .addUniqueConstraint(Arrays.asList("transaction_id", "index"))
           .setPrimaryKey(Arrays.asList("output_id"))
           .build();


### PR DESCRIPTION
Load the configuration of custom columns from the Oracle database
on application start up. There's not yet a way to populate the
configuration besides manually through sqlplus.

Applied some of IntelliJ's static analysis suggestions too.