### PR TITLE
core: support request forwarding over TLS

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -295,6 +295,9 @@ func launchConfiguredCore(ctx context.Context, raftDB *raft.Service, db *sql.DB,
 
 	opts = append(opts, core.IndexTransactions(*indexTxs))
 	opts = append(opts, enableMockHSM(db)...)
+	if *tlsCrt != "" {
+		opts = append(opts, core.ForwardUsingTLS)
+	}
 	// Add any configured API request rate limits.
 	if *rpsToken > 0 {
 		opts = append(opts, core.RateLimit(limit.AuthUserID, 2*(*rpsToken), *rpsToken))

--- a/core/api.go
+++ b/core/api.go
@@ -76,6 +76,8 @@ type API struct {
 	generator       *generator.Generator
 	remoteGenerator *rpc.Client
 	indexTxs        bool
+	forwardUsingTLS bool
+	internalClient  *http.Client
 
 	downloadingSnapshotMu sync.Mutex
 	downloadingSnapshot   *fetch.SnapshotProgress
@@ -350,9 +352,12 @@ func (a *API) forwardToLeader(ctx context.Context, path string, body interface{}
 		return errLeaderElection
 	}
 
-	// TODO(jackson): If using TLS, use https:// here.
 	l := &rpc.Client{
 		BaseURL: "http://" + addr,
+		Client:  a.internalClient,
+	}
+	if a.forwardUsingTLS {
+		l.BaseURL = "https://" + addr
 	}
 
 	// Forward the request credentials if we have them.

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"chain/core/config"
+	"chain/core/leader"
+	"chain/net/http/httpjson"
+	"chain/testutil"
+)
+
+func TestForwardToLeader(t *testing.T) {
+	// Create a test http server with TLS to be a fake leader process.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/info" {
+			t.Fatalf("unexpected call to %s", req.URL.Path)
+		}
+		username, password, ok := req.BasicAuth()
+		if !ok || username != "example" || password != "password" {
+			t.Fatalf("Got basic auth %s:%s, want example:password", username, password)
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(rw, `{
+			"state": "leading",
+			"is_configured": true
+		}`)
+	}))
+	defer ts.Close()
+
+	// TODO(jackson): In Go 1.9+ use ts.Client():
+	// https://go-review.googlesource.com/c/34639/
+	cert, err := x509.ParseCertificate(ts.TLS.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	certpool := x509.NewCertPool()
+	certpool.AddCert(cert)
+
+	// Setup a core.API so that it's a follower and leader.Address will
+	// return the fake HTTPS server created above. Also, include its
+	// certs in an internalClient so that it trusts the test server's
+	// certs.
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := &API{
+		config:          &config.Config{},
+		leader:          alwaysFollower{leaderAddress: u.Host},
+		forwardUsingTLS: true,
+		internalClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: certpool,
+				},
+			},
+		},
+	}
+
+	// Create a fake incoming request so that forwardToLeader can propagate
+	// the basic auth credentials.
+	fakeRequest, err := http.NewRequest("POST", "http://localhost:1999/info", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeRequest.SetBasicAuth("example", "password")
+	ctx := context.Background()
+	ctx = httpjson.WithRequest(ctx, fakeRequest)
+	got, err := api.info(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]interface{}{
+		"state":         "leading",
+		"is_configured": true,
+	}
+	if !testutil.DeepEqual(got, want) {
+		t.Errorf("Got response %#v, want %#v", got, want)
+	}
+}
+
+type alwaysFollower struct {
+	leaderAddress string
+}
+
+func (af alwaysFollower) State() leader.ProcessState { return leader.Following }
+func (af alwaysFollower) Address(context.Context) (string, error) {
+	return af.leaderAddress, nil
+}

--- a/core/run.go
+++ b/core/run.go
@@ -34,6 +34,10 @@ const (
 // RunOption describes a runtime configuration option.
 type RunOption func(*API)
 
+// ForwardUsingTLS configures the Core to use TLS when communicating between
+// Core processes.
+var ForwardUsingTLS RunOption = func(a *API) { a.forwardUsingTLS = true }
+
 // BlockSigner configures the Core to use signFn to handle block-signing
 // requests. In production, this will be a function to call out to signerd
 // and its HSM. In development, it'll use the MockHSM.


### PR DESCRIPTION
@boymanjor does this seem right? Or should it default to https and be set to http in cmd/cored/plain_http.go?

Also slightly tangential and it might be covered as part of the authorization work, but we could probably pin the certificate here? Instead of using one ROOT_CAS for all RPCs (internal & external), we could propagate a certpool and configure the chain/core/rpc.Client with it?

For #674.