### PR TITLE
docker/ci: Add Rust tools to Dockerfile

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -25,6 +25,7 @@ RUN yum -y update \
     && install-java && rm -f /usr/bin/install-java \
     && install-maven && rm -f /usr/bin/install-maven \
     && install-ruby && rm -f /usr/bin/install-ruby \
+    && install-rust && rm -f /usr/bin/install-rust \
     && install-protobuf && rm -f /usr/bin/install-protobuf \
     && install-gas && rm -f /usr/bin/install-gas \
     && go get -u google.golang.org/grpc \

--- a/docker/ci/install/install-rust
+++ b/docker/ci/install/install-rust
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Pin to a specific nightly until we can get off nightly entirely
+RUST_VERSION="nightly-2017-04-16"
+
+curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION}
+
+~/.cargo/bin/cargo install rustfmt
+~/.cargo/bin/cargo install clippy
+~/.cargo/bin/cargo install cargo-audit

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2938";
+	public final String Id = "main/rev2939";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2938"
+const ID string = "main/rev2939"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2938"
+export const rev_id = "main/rev2939"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2938".freeze
+	ID = "main/rev2939".freeze
 end

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20170412
+box: chaindev/ci:20170417
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 


### PR DESCRIPTION
Installs Rust nightly (locked to 2017-04-16 snapshot) systemwide via rustup.sh:

https://github.com/rust-lang/rustup.sh

(Note that rustup.sh is technically deprecated, but presently the only way to
install Rust systemwide)

Also installs the following development tools:

- rustfmt: Lint syntax to ensure it follows standard style (ala gofmt)
- clippy: Lint for non-idiomatic Rust or other minor mistakes
- cargo-audit: Audit Cargo.lock for crates containing security vulnerabilities