### PR TITLE
core: fix log statement to print tx id correctly

### DIFF
--- a/core/transact.go
+++ b/core/transact.go
@@ -142,7 +142,7 @@ func (a *API) submitSingle(ctx context.Context, tpl *txbuilder.Template, waitUnt
 
 	err := a.finalizeTxWait(ctx, tpl, waitUntil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "tx %s", tpl.Transaction.ID)
+		return nil, errors.Wrapf(err, "tx %s", tpl.Transaction.ID.String())
 	}
 
 	return map[string]string{"id": tpl.Transaction.ID.String()}, nil

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2934";
+	public final String Id = "main/rev2935";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2934"
+const ID string = "main/rev2935"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2934"
+export const rev_id = "main/rev2935"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2934".freeze
+	ID = "main/rev2935".freeze
 end


### PR DESCRIPTION
Fix the transaction rejected log line to include the transaction hex.

It was including the bc.Hash struct:
```
app=cored buildtag=? processID=chain-f2473408badf-1312-75849f6537c61139932c reqid=8e02eefc091511e1137a subreqid=8a9f632c4d23ebc7fd76 at=api.go:406 t=2017-04-17T21:29:52.208568849Z status=400 chaincode=CH738 path=/submit-transaction error="tx {%!s(uint64=9959100764939771229) %!s(uint64=15390949537693335959) %!s(uint64=18383847051763105326) %!s(uint64=11411281842560845055)}: no tx sighash attempted"
```

Should we define a `String` method on the value receiver too? I think
the protobuf type only has one on the pointer receiver.