### PR TITLE
core: work around existing auth response handling

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -262,6 +262,11 @@ func (a *API) authzHandler(handler http.Handler) http.Handler {
 	auth := authz.NewAuthorizer(a.raftDB, grantPrefix, policyByRoute)
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		err := auth.Authorize(req)
+		if errors.Root(err) == authz.ErrNotAuthorized {
+			// TODO(kr): remove this workaround once dashboard
+			// knows how to handle ErrNotAuthorized (CH011).
+			err = errors.Sub(errNotAuthenticated, err)
+		}
 		if err != nil {
 			errorFormatter.Write(req.Context(), rw, err)
 			return

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2936";
+	public final String Id = "main/rev2937";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2936"
+const ID string = "main/rev2937"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2936"
+export const rev_id = "main/rev2937"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2936".freeze
+	ID = "main/rev2937".freeze
 end


### PR DESCRIPTION
Dashboard knows how to interpret errNotAuthenticated
(CH009) but not the new authz.ErrNotAuthorized (CH011).
For now, just return the authn error even for authz
failures. We can remove this workaround once dashboard
is updated.