### PR TITLE
core: use Set instead of Insert when storing grants

### DIFF
--- a/core/grants.go
+++ b/core/grants.go
@@ -60,7 +60,9 @@ func (a *API) createGrant(ctx context.Context, x apiGrant) error {
 		if err != nil {
 			return errors.Wrap(err)
 		}
-		err = a.raftDB.Insert(ctx, grantPrefix+x.Policy, val)
+		// TODO(tessr): Make this safe for concurrent updates. Will likely require a
+		// conditional write operation for raftDB
+		err = a.raftDB.Set(ctx, grantPrefix+x.Policy, val)
 		if err != nil {
 			return errors.Wrap(err)
 		}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2937";
+	public final String Id = "main/rev2938";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2937"
+const ID string = "main/rev2938"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2937"
+export const rev_id = "main/rev2938"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2937".freeze
+	ID = "main/rev2938".freeze
 end


### PR DESCRIPTION
Policy keys are occasionally getting set without any data, which leads us to this situation where we try to fetch the policy's grant list, see nothing, and then try to conditionally write (`Insert`) a new grant list--which fails, because the key has already been set. 

In the future, we will have more safe conditional writes, but this will fix it for now. 