### PR TITLE
core/rpc: let the caller provide an HTTP client

### DIFF
--- a/core/rpc/rpc.go
+++ b/core/rpc/rpc.go
@@ -37,6 +37,9 @@ type Client struct {
 	BuildTag     string
 	BlockchainID string
 	CoreID       string
+
+	// If set, Client is used for outgoing requests.
+	Client *http.Client
 }
 
 func (c Client) userAgent() string {
@@ -117,7 +120,11 @@ func (c *Client) CallRaw(ctx context.Context, path string, request interface{}) 
 		req.Header.Set(HeaderTimeout, deadline.Sub(time.Now()).String())
 	}
 
-	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
+	client := c.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil && ctx.Err() != nil { // check if it timed out
 		return nil, errors.Wrap(ctx.Err())
 	} else if err != nil {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2940";
+	public final String Id = "main/rev2941";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2940"
+const ID string = "main/rev2941"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2940"
+export const rev_id = "main/rev2941"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2940".freeze
+	ID = "main/rev2941".freeze
 end


### PR DESCRIPTION
This will be used to supply a TLS client cert for requests across corectl and cored.