### PR TITLE
cmd/cored: allow intra-node client auth

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -166,6 +166,7 @@ func main() {
 	// That is the second phase.
 	mux := http.NewServeMux()
 	// TODO(tessr): authenticate raft endpoints
+	mux.Handle("/raft/", raftDB)
 
 	var handler http.Handler = mux
 	handler = reqid.Handler(handler)

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -193,6 +193,10 @@ func main() {
 
 	if useTLS {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+			// This is the default set of protocols for package http.
+			// DefaultTransport sets this automatically if TLSClientConfig
+			// is null. Since we are defining our own config, we must set it.
+			NextProtos:   []string{"http/1.1", "h2"},
 			Certificates: []tls.Certificate{*cert},
 			RootCAs:      loadRootCAs(*rootCAs),
 		}
@@ -279,7 +283,6 @@ func maybeUseTLS(ln net.Listener) (net.Listener, *tls.Certificate, error) {
 		return nil, nil, errors.Wrap(err)
 	}
 
-	config.Certificates = []tls.Certificate{cert}
 	if *rootCAs != "" {
 		config.ClientAuth = tls.VerifyClientCertIfGiven
 		config.ClientCAs = loadRootCAs(*rootCAs)

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -193,10 +193,6 @@ func main() {
 
 	if useTLS {
 		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
-			// This is the default set of protocols for package http.
-			// DefaultTransport sets this automatically if TLSClientConfig
-			// is null. Since we are defining our own config, we must set it.
-			NextProtos:   []string{"http/1.1", "h2"},
 			Certificates: []tls.Certificate{*cert},
 			RootCAs:      loadRootCAs(*rootCAs),
 		}

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -239,8 +239,12 @@ func main() {
 	if conf != nil {
 		h = launchConfiguredCore(ctx, raftDB, db, conf, processID)
 	} else {
+		var opts []core.RunOption
+		if useTLS {
+			opts = append(opts, core.ForwardUsingTLS)
+		}
 		chainlog.Printf(ctx, "Launching as unconfigured Core.")
-		h = core.RunUnconfigured(ctx, db, raftDB)
+		h = core.RunUnconfigured(ctx, db, raftDB, opts...)
 	}
 	mux.Handle("/", h)
 	chainlog.Printf(ctx, "Chain Core online and listening at %s", *listenAddr)

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -237,12 +237,8 @@ func main() {
 	if conf != nil {
 		h = launchConfiguredCore(ctx, raftDB, db, conf, processID)
 	} else {
-		var opts []core.RunOption
-		if useTLS {
-			opts = append(opts, core.ForwardUsingTLS)
-		}
 		chainlog.Printf(ctx, "Launching as unconfigured Core.")
-		h = core.RunUnconfigured(ctx, db, raftDB, opts...)
+		h = core.RunUnconfigured(ctx, db, raftDB, core.ForwardUsingTLS(useTLS))
 	}
 	mux.Handle("/", h)
 	chainlog.Printf(ctx, "Chain Core online and listening at %s", *listenAddr)
@@ -309,9 +305,7 @@ func launchConfiguredCore(ctx context.Context, raftDB *raft.Service, db *sql.DB,
 
 	opts = append(opts, core.IndexTransactions(*indexTxs))
 	opts = append(opts, enableMockHSM(db)...)
-	if useTLS {
-		opts = append(opts, core.ForwardUsingTLS)
-	}
+	opts = append(opts, core.ForwardUsingTLS(useTLS))
 	// Add any configured API request rate limits.
 	if *rpsToken > 0 {
 		opts = append(opts, core.RateLimit(limit.AuthUserID, 2*(*rpsToken), *rpsToken))

--- a/core/api.go
+++ b/core/api.go
@@ -77,7 +77,7 @@ type API struct {
 	remoteGenerator *rpc.Client
 	indexTxs        bool
 	forwardUsingTLS bool
-	internalClient  *http.Client
+	httpClient      *http.Client // normally nil; only set in tests
 
 	downloadingSnapshotMu sync.Mutex
 	downloadingSnapshot   *fetch.SnapshotProgress
@@ -356,7 +356,7 @@ func (a *API) forwardToLeader(ctx context.Context, path string, body interface{}
 		BaseURL: "http://" + addr,
 		// If internalClient is nil,
 		// http.DefaultClient will be used.
-		Client: a.internalClient,
+		Client: a.httpClient,
 	}
 	if a.forwardUsingTLS {
 		l.BaseURL = "https://" + addr

--- a/core/api.go
+++ b/core/api.go
@@ -76,6 +76,7 @@ type API struct {
 	generator       *generator.Generator
 	remoteGenerator *rpc.Client
 	indexTxs        bool
+	forwardUsingTLS bool
 
 	downloadingSnapshotMu sync.Mutex
 	downloadingSnapshot   *fetch.SnapshotProgress
@@ -350,9 +351,11 @@ func (a *API) forwardToLeader(ctx context.Context, path string, body interface{}
 		return errLeaderElection
 	}
 
-	// TODO(jackson): If using TLS, use https:// here.
 	l := &rpc.Client{
 		BaseURL: "http://" + addr,
+	}
+	if a.forwardUsingTLS {
+		l.BaseURL = "https://" + addr
 	}
 
 	// Forward the request credentials if we have them.

--- a/core/api.go
+++ b/core/api.go
@@ -77,6 +77,7 @@ type API struct {
 	remoteGenerator *rpc.Client
 	indexTxs        bool
 	forwardUsingTLS bool
+	internalClient  *http.Client
 
 	downloadingSnapshotMu sync.Mutex
 	downloadingSnapshot   *fetch.SnapshotProgress
@@ -353,6 +354,9 @@ func (a *API) forwardToLeader(ctx context.Context, path string, body interface{}
 
 	l := &rpc.Client{
 		BaseURL: "http://" + addr,
+		// If internalClient is nil,
+		// http.DefaultClient will be used.
+		Client: a.internalClient,
 	}
 	if a.forwardUsingTLS {
 		l.BaseURL = "https://" + addr

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -45,7 +45,7 @@ func TestForwardToLeader(t *testing.T) {
 
 	// Setup a core.API so that it's a follower and leader.Address will
 	// return the fake HTTPS server created above. Also, include its
-	// certs in an internalClient so that it trusts the test server's
+	// certs in an internal httpClient so that it trusts the test server's
 	// certs.
 	u, err := url.Parse(ts.URL)
 	if err != nil {
@@ -55,7 +55,7 @@ func TestForwardToLeader(t *testing.T) {
 		config:          &config.Config{},
 		leader:          alwaysFollower{leaderAddress: u.Host},
 		forwardUsingTLS: true,
-		internalClient: &http.Client{
+		httpClient: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{
 					RootCAs: certpool,

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,0 +1,96 @@
+package core
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"chain/core/config"
+	"chain/core/leader"
+	"chain/net/http/httpjson"
+	"chain/testutil"
+)
+
+func TestForwardToLeader(t *testing.T) {
+	// Create a test http server with TLS to be a fake leader process.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/info" {
+			t.Fatalf("unexpected call to %s", req.URL.Path)
+		}
+		username, password, ok := req.BasicAuth()
+		if !ok || username != "example" || password != "password" {
+			t.Fatalf("Got basic auth %s:%s, want example:password", username, password)
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(rw, `{
+            "state": "leading",
+            "is_configured": true
+        }`)
+	}))
+	defer ts.Close()
+
+	// TODO(jackson): In Go 1.9+ use ts.Client():
+	// https://go-review.googlesource.com/c/34639/
+	cert, err := x509.ParseCertificate(ts.TLS.Certificates[0].Certificate[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	certpool := x509.NewCertPool()
+	certpool.AddCert(cert)
+
+	// Setup a core.API so that it's a follower and leader.Address will
+	// return the fake HTTPS server created above. Also, include its
+	// certs in an internalClient so that it trusts the test server's
+	// certs.
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := &API{
+		config:          &config.Config{},
+		leader:          alwaysFollower{leaderAddress: u.Host},
+		forwardUsingTLS: true,
+		internalClient: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs: certpool,
+				},
+			},
+		},
+	}
+
+	// Create a fake incoming request so that forwardToLeader can propagate
+	// the basic auth credentials.
+	fakeRequest, err := http.NewRequest("POST", "http://localhost:1999/info", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeRequest.SetBasicAuth("example", "password")
+	ctx := context.Background()
+	ctx = httpjson.WithRequest(ctx, fakeRequest)
+	got, err := api.info(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]interface{}{
+		"state":         "leading",
+		"is_configured": true,
+	}
+	if !testutil.DeepEqual(got, want) {
+		t.Errorf("Got response %#v, want %#v", got, want)
+	}
+}
+
+type alwaysFollower struct {
+	leaderAddress string
+}
+
+func (af alwaysFollower) State() leader.ProcessState { return leader.Following }
+func (af alwaysFollower) Address(context.Context) (string, error) {
+	return af.leaderAddress, nil
+}

--- a/core/run.go
+++ b/core/run.go
@@ -34,6 +34,10 @@ const (
 // RunOption describes a runtime configuration option.
 type RunOption func(*API)
 
+// ForwardUsingTLS configures the Core to use TLS when communicating between
+// Core processes.
+var ForwardUsingTLS RunOption = func(a *API) { a.forwardUsingTLS = true }
+
 // BlockSigner configures the Core to use signFn to handle block-signing
 // requests. In production, this will be a function to call out to signerd
 // and its HSM. In development, it'll use the MockHSM.

--- a/core/run.go
+++ b/core/run.go
@@ -36,7 +36,9 @@ type RunOption func(*API)
 
 // ForwardUsingTLS configures the Core to use TLS when communicating between
 // Core processes.
-var ForwardUsingTLS RunOption = func(a *API) { a.forwardUsingTLS = true }
+func ForwardUsingTLS(useTLS bool) RunOption {
+	return func(a *API) { a.forwardUsingTLS = useTLS }
+}
 
 // BlockSigner configures the Core to use signFn to handle block-signing
 // requests. In production, this will be a function to call out to signerd

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2943";
+	public final String Id = "main/rev2944";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2943"
+const ID string = "main/rev2944"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2943"
+export const rev_id = "main/rev2944"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2943".freeze
+	ID = "main/rev2944".freeze
 end


### PR DESCRIPTION
`cored` can now authenticate itself during client calls
to other cored's using a tls certificate.