### PR TITLE
cmd/corectl: present a TLS client cert if available

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2941";
+	public final String Id = "main/rev2942";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2941"
+const ID string = "main/rev2942"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2941"
+export const rev_id = "main/rev2942"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2941".freeze
+	ID = "main/rev2942".freeze
 end


### PR DESCRIPTION
Read the Chain Core TLS cert/key pair from the data dir.
This allows corectl to connect to a running local cored
even when that cored is built with loopback auth disabled.