### PR TITLE
sdk/node: support client cert authn

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2951";
+	public final String Id = "main/rev2952";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2951"
+const ID string = "main/rev2952"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2951"
+export const rev_id = "main/rev2952"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2951".freeze
+	ID = "main/rev2952".freeze
 end

--- a/sdk/node/src/client.js
+++ b/sdk/node/src/client.js
@@ -40,7 +40,7 @@ class Client {
       }
     }
     opts.baseUrl = opts.baseUrl || 'http://localhost:1999'
-    this.connection = new Connection(opts.baseUrl, opts.token)
+    this.connection = new Connection(opts.baseUrl, opts.token, opts.agent)
 
     /**
      * API actions for access tokens
@@ -84,7 +84,7 @@ class Client {
      */
     this.mockHsm = {
       keys: mockHsmKeysAPI(this),
-      signerConnection: new Connection(`${opts.baseUrl}/mockhsm`, opts.token)
+      signerConnection: new Connection(`${opts.baseUrl}/mockhsm`, opts.token, opts.agent)
     }
 
     /**

--- a/sdk/node/src/connection.js
+++ b/sdk/node/src/connection.js
@@ -69,10 +69,10 @@ class Connection {
    * @param {String} agent   https.Agent used to provide TLS config.
    * @returns {Client}
    */
-  constructor(baseUrl, token = '', agent = {}) {
+  constructor(baseUrl, token = '', agent) {
     this.baseUrl = baseUrl
     this.token = token || ''
-    this.agent = agent || {}
+    this.agent = agent
   }
 
   /**
@@ -115,7 +115,7 @@ class Connection {
       req.headers['Authorization'] = `Basic ${btoa(this.token)}`
     }
 
-    if (Object.keys(this.agent).length !== 0) {
+    if (this.agent) {
       req.agent = this.agent
     }
 

--- a/sdk/node/src/connection.js
+++ b/sdk/node/src/connection.js
@@ -66,11 +66,13 @@ class Connection {
    *
    * @param {String} baseUrl Chain Core URL.
    * @param {String} token   Chain Core client token for API access.
+   * @param {String} agent   https.Agent used to provide TLS config.
    * @returns {Client}
    */
-  constructor(baseUrl, token = '') {
+  constructor(baseUrl, token = '', agent = {}) {
     this.baseUrl = baseUrl
     this.token = token || ''
+    this.agent = agent || {}
   }
 
   /**
@@ -111,6 +113,10 @@ class Connection {
 
     if (this.token) {
       req.headers['Authorization'] = `Basic ${btoa(this.token)}`
+    }
+
+    if (Object.keys(this.agent).length !== 0) {
+      req.agent = this.agent
     }
 
     return fetch(this.baseUrl + path, req).catch((err) => {


### PR DESCRIPTION
The Client object can be passed an `https.Agent` with
its `ca`, `key`, and `cert` attributes set as file paths.