### PR TITLE
sdk/ruby: support client cert authn

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2946";
+	public final String Id = "main/rev2947";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2946"
+const ID string = "main/rev2947"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2946"
+export const rev_id = "main/rev2947"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2946".freeze
+	ID = "main/rev2947".freeze
 end

--- a/sdk/ruby/lib/chain/connection.rb
+++ b/sdk/ruby/lib/chain/connection.rb
@@ -189,10 +189,12 @@ module Chain
         if @opts.key?(:root_ca_certs_path)
           @http.ca_file = @opts[:root_ca_certs_path]
         end
-        if @opts.key?(:client_cert_path) && opts.key?(:client_key_path)
+        if @opts.key?(:client_cert_path)
           cert = File.read(@opts[:client_cert_path])
-          key = File.read(@opts[:client_key_path])
           @http.cert = OpenSSL::X509::Certificate.new(cert)
+        end
+        if opts.key?(:client_key_path)
+          key = File.read(@opts[:client_key_path])
           @http.key = OpenSSL::PKey::RSA.new(key)
         end
       end

--- a/sdk/ruby/lib/chain/connection.rb
+++ b/sdk/ruby/lib/chain/connection.rb
@@ -186,6 +186,15 @@ module Chain
       if @url.scheme == 'https'
         @http.use_ssl = true
         @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        if @opts.key?(:root_ca_certs)
+          @http.ca_file = @opts[:root_ca_certs]
+        end
+        if @opts.key?(:cert) && opts.key?(:key)
+          cert = File.read(@opts[:cert])
+          key = File.read(@opts[:key])
+          @http.cert = OpenSSL::X509::Certificate.new(cert)
+          @http.key = OpenSSL::PKey::RSA.new(key)
+        end
       end
 
       @http

--- a/sdk/ruby/lib/chain/connection.rb
+++ b/sdk/ruby/lib/chain/connection.rb
@@ -186,12 +186,12 @@ module Chain
       if @url.scheme == 'https'
         @http.use_ssl = true
         @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        if @opts.key?(:root_ca_certs)
-          @http.ca_file = @opts[:root_ca_certs]
+        if @opts.key?(:root_ca_certs_path)
+          @http.ca_file = @opts[:root_ca_certs_path]
         end
-        if @opts.key?(:cert) && opts.key?(:key)
-          cert = File.read(@opts[:cert])
-          key = File.read(@opts[:key])
+        if @opts.key?(:client_cert_path) && opts.key?(:client_key_path)
+          cert = File.read(@opts[:client_cert_path])
+          key = File.read(@opts[:client_key_path])
           @http.cert = OpenSSL::X509::Certificate.new(cert)
           @http.key = OpenSSL::PKey::RSA.new(key)
         end


### PR DESCRIPTION
File paths to the client cert, key and trusted CAs
can be passed through the opts param of the Client
constructor.