### PR TITLE
sdk/node: new Client constructor

### DIFF
--- a/dashboard/src/utility/environment.js
+++ b/dashboard/src/utility/environment.js
@@ -15,10 +15,10 @@ if (process.env.NODE_ENV === 'production') {
   basename = ''
 }
 
-export const chainClient = () => new chainSdk.Client(
-  apiHost,
-  store.getState().core.clientToken
-)
+export const chainClient = () => new chainSdk.Client({
+  baseUrl: apiHost,
+  token: store.getState().core.clientToken
+})
 
 export const chainSigner = () => new chainSdk.HsmSigner(
   apiHost,

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2949";
+	public final String Id = "main/rev2950";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2949"
+const ID string = "main/rev2950"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2949"
+export const rev_id = "main/rev2950"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2949".freeze
+	ID = "main/rev2950".freeze
 end

--- a/sdk/node/src/client.js
+++ b/sdk/node/src/client.js
@@ -21,13 +21,26 @@ class Client {
    * constructor - create a new Chain client object capable of interacting with
    * the specified Chain Core.
    *
-   * @param {String} baseUrl - Chain Core URL.
-   * @param {String} token - Chain Core client token for API access.
+   * Passing a configuration object is the preferred way of calling this constructor.
+   * However, to support code written for 1.1 and older, the constructor supports passing
+   * in a string URL and an optional string token as the first and second parameter, respectively.
+   *
+   * @param {Object} opts - Plain JS object containing configuration options.
+   * @param {String} opts.baseUrl - Chain Core URL.
+   * @param {String} opts.token - Chain Core client token for API access.
    * @returns {Client}
    */
-  constructor(baseUrl, token = '') {
-    baseUrl = baseUrl || 'http://localhost:1999'
-    this.connection = new Connection(baseUrl, token)
+  constructor(opts = {}) {
+    // If the first argument is a string,
+    // support the deprecated constructor params.
+    if (typeof opts === 'string') {
+      opts = {
+        baseUrl: arguments[0],
+        token: arguments[1] || ''
+      }
+    }
+    opts.baseUrl = opts.baseUrl || 'http://localhost:1999'
+    this.connection = new Connection(opts.baseUrl, opts.token)
 
     /**
      * API actions for access tokens
@@ -71,7 +84,7 @@ class Client {
      */
     this.mockHsm = {
       keys: mockHsmKeysAPI(this),
-      signerConnection: new Connection(`${baseUrl}/mockhsm`, token)
+      signerConnection: new Connection(`${opts.baseUrl}/mockhsm`, opts.token)
     }
 
     /**


### PR DESCRIPTION
The Client constructor now accepts an opts object as its only argument.
The baseUrl and optional token should be passed as attributes.
The original constructor is now deprecated, but still supported.