### PR TITLE
core: trust the current process cert

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/x509"
 	"encoding/hex"
 	"flag"
 	"fmt"
@@ -361,16 +360,6 @@ func mustRPCClient() *rpc.Client {
 	} else if err != nil {
 		fatalln("error: loading TLS cert:", err)
 	}
-
-	// We require the server to present the same cert as us,
-	// so pin to our own cert.
-	// For some reason, LoadX509KeyPair doesn't keep a copy of the leaf cert.
-	// We need to parse it again so we can trust it.
-	x509Cert, err := x509.ParseCertificate(config.Certificates[0].Certificate[0])
-	if err != nil {
-		fatalln("error: loading TLS cert:", err)
-	}
-	config.RootCAs.AddCert(x509Cert)
 
 	t := &http.Transport{
 		DialContext: (&net.Dialer{

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -252,7 +252,6 @@ func maybeUseTLS(ln net.Listener) (net.Listener, *tls.Config, error) {
 	} else if err != nil {
 		return nil, nil, err
 	}
-
 	ln = tls.NewListener(ln, config)
 	return ln, config, nil
 }

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -252,6 +252,7 @@ func maybeUseTLS(ln net.Listener) (net.Listener, *tls.Config, error) {
 	} else if err != nil {
 		return nil, nil, err
 	}
+
 	ln = tls.NewListener(ln, config)
 	return ln, config, nil
 }

--- a/core/tls.go
+++ b/core/tls.go
@@ -65,8 +65,8 @@ func TLSConfig(certFile, keyFile, rootCAs string) (*tls.Config, error) {
 		return nil, errors.Wrap(err)
 	}
 
-	// This TLS config is used by cored peers to talk to each other,
-	// and by corectl to talk to cored.
+	// This TLS config is used by cored peers to dial each other,
+	// and by corectl to dial cored.
 	// All those processes have the same identity,
 	// so we automatically trust the local cert,
 	// with the expectation that the peer will also be using it.

--- a/core/tls.go
+++ b/core/tls.go
@@ -71,7 +71,7 @@ func TLSConfig(certFile, keyFile, rootCAs string) (*tls.Config, error) {
 	// so we automatically trust the local cert,
 	// with the expectation that the peer will also be using it.
 	// This makes misconfiguation impossible.
-	// (For some reason, LoadX509KeyPair doesn't keep a copy of the leaf cert,
+	// (For some reason, X509KeyPair doesn't keep a copy of the leaf cert,
 	// so we need to parse it again here.)
 	x509Cert, err := x509.ParseCertificate(config.Certificates[0].Certificate[0])
 	if err != nil {

--- a/core/tls.go
+++ b/core/tls.go
@@ -60,15 +60,34 @@ func TLSConfig(certFile, keyFile, rootCAs string) (*tls.Config, error) {
 		return nil, errors.Wrap(err)
 	}
 
-	if rootCAs != "" {
-		config.RootCAs, err = loadRootCAs(rootCAs)
+	config.RootCAs, err = loadRootCAs(rootCAs)
+	if err != nil {
+		return nil, errors.Wrap(err)
 	}
+
+	// This TLS config is used by cored peers to talk to each other,
+	// and by corectl to talk to cored.
+	// All those processes have the same identity,
+	// so we automatically trust the local cert,
+	// with the expectation that the peer will also be using it.
+	// This makes misconfiguation impossible.
+	// (For some reason, LoadX509KeyPair doesn't keep a copy of the leaf cert,
+	// so we need to parse it again here.)
+	x509Cert, err := x509.ParseCertificate(config.Certificates[0].Certificate[0])
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+	config.RootCAs.AddCert(x509Cert)
 	config.ClientCAs = config.RootCAs
 	return config, err
 }
 
-// loadRootCAs reads a list of PEM-encoded X.509 certificates from name
+// loadRootCAs reads a list of PEM-encoded X.509 certificates from name.
+// If name is the empty string, it returns a new, empty cert pool.
 func loadRootCAs(name string) (*x509.CertPool, error) {
+	if name == "" {
+		return x509.NewCertPool(), nil
+	}
 	pem, err := ioutil.ReadFile(name)
 	if err != nil {
 		return nil, errors.Wrap(err)

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2955";
+	public final String Id = "main/rev2956";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2955"
+const ID string = "main/rev2956"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2955"
+export const rev_id = "main/rev2956"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2955".freeze
+	ID = "main/rev2956".freeze
 end


### PR DESCRIPTION
A Chain Core TLS config is used by cored peers to talk
to each other, and by corectl to talk to cored. All
those processes have the same identity, so now we
automatically trust the local cert, with the expectation
that the peer will also be using it. This makes
authn misconfiguation impossible as long as the cert and
key files are loaded successfully.