### PR TITLE
sdk/ruby: configure client authn with ssl_params hash

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2952";
+	public final String Id = "main/rev2953";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2952"
+const ID string = "main/rev2953"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2952"
+export const rev_id = "main/rev2953"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2952".freeze
+	ID = "main/rev2953".freeze
 end

--- a/sdk/ruby/lib/chain/connection.rb
+++ b/sdk/ruby/lib/chain/connection.rb
@@ -186,16 +186,17 @@ module Chain
       if @url.scheme == 'https'
         @http.use_ssl = true
         @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        if @opts.key?(:root_ca_certs_path)
-          @http.ca_file = @opts[:root_ca_certs_path]
-        end
-        if @opts.key?(:client_cert_path)
-          cert = File.read(@opts[:client_cert_path])
-          @http.cert = OpenSSL::X509::Certificate.new(cert)
-        end
-        if opts.key?(:client_key_path)
-          key = File.read(@opts[:client_key_path])
-          @http.key = OpenSSL::PKey::RSA.new(key)
+        if @opts.key?(:ssl_params)
+          ssl_params = @opts[:ssl_params]
+          if ssl_params.key?(:ca_file)
+            @http.ca_file = ssl_params[:ca_file]
+          end
+          if ssl_params.key?(:cert)
+            @http.cert = ssl_params[:cert]
+          end
+          if ssl_params.key?(:key)
+            @http.key = ssl_params[:key]
+          end
         end
       end
 


### PR DESCRIPTION
Previously, the Client constructor accepted cert and key
data as separate attributes on its opts config parameter.
It will now accept tls options on an `ssl_params` hash.
The options supported map to `OpenSSL::SSL:Context` params.
Currently, we support `ca_file`, `cert` & `key`.