### PR TITLE
net/http/authz: allow caller to add an extra grant

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2961";
+	public final String Id = "main/rev2962";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2961"
+const ID string = "main/rev2962"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2961"
+export const rev_id = "main/rev2962"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2961".freeze
+	ID = "main/rev2962".freeze
 end

--- a/net/http/authz/authorizer.go
+++ b/net/http/authz/authorizer.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 
@@ -46,6 +47,7 @@ func (a *Authorizer) GrantInternal(subj pkix.Name) {
 		Policy:    "internal",
 		GuardType: "x509",
 		GuardData: encodeX509GuardData(subj),
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
 	})
 }
 


### PR DESCRIPTION
Package chain/core will use this to authorize other
cored and corectl processes using the same Subject Name.