### PR TITLE
sdk/java: new Client.Builder constructor

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2960";
+	public final String Id = "main/rev2961";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2960"
+const ID string = "main/rev2961"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2960"
+export const rev_id = "main/rev2961"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2960".freeze
+	ID = "main/rev2961".freeze
 end

--- a/sdk/java/src/main/java/com/chain/api/MockHsm.java
+++ b/sdk/java/src/main/java/com/chain/api/MockHsm.java
@@ -27,11 +27,11 @@ public class MockHsm {
    */
   public static Client getSignerClient(Client client) throws BadURLException {
     try {
-      URL signerUrl = new URL(client.url().toString() + "/mockhsm");
-      if (client.hasAccessToken()) {
-        return new Client(signerUrl, client.accessToken());
+      List<URL> urls = new ArrayList<>();
+      for (URL url : client.urls()) {
+        urls.add(new URL(url.toString() + "/mockhsm"));
       }
-      return new Client(signerUrl);
+      return new Client.Builder(client).setURLs(urls).build();
     } catch (MalformedURLException e) {
       throw new BadURLException(e.getMessage());
     }

--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -379,8 +379,7 @@ public class Client {
   }
 
   private OkHttpClient buildHttpClient(Builder builder) {
-    OkHttpClient httpClient = builder.httpClient.clone();
-    httpClient.setFollowRedirects(false);
+    OkHttpClient httpClient = builder.baseHttpClient.clone();
 
     if (builder.sslSocketFactory != null) {
       httpClient.setSslSocketFactory(builder.sslSocketFactory);
@@ -531,7 +530,7 @@ public class Client {
    * A builder class for creating client objects
    */
   public static class Builder {
-    private OkHttpClient httpClient;
+    private OkHttpClient baseHttpClient;
     private List<URL> urls;
     private String accessToken;
     private CertificatePinner cp;
@@ -548,13 +547,14 @@ public class Client {
     private LoggingInterceptor.Level logLevel;
 
     public Builder() {
-      this.httpClient = new OkHttpClient();
+      this.baseHttpClient = new OkHttpClient();
+      this.baseHttpClient.setFollowRedirects(false);
       this.urls = new ArrayList<>();
       this.setDefaults();
     }
 
     public Builder(Client client) {
-      this.httpClient = client.httpClient.clone();
+      this.baseHttpClient = client.httpClient.clone();
       this.urls = new ArrayList<>(client.urls);
       this.accessToken = client.accessToken;
     }


### PR DESCRIPTION
The new constructor takes a Client object as an argument. The private
members of the Client are copied into the resulting builder.
To facilitate this change, a private OkHttpClient member was added to
the builder (no setter method was provided). A new builder method was
also added to allow a user to set a list of URLs.

The impetus for this change was a bug I found when adding client cert
authn to the SDK. Our current method of creating a Client for the MockHsm
(`getSignerClient`) does not persist any configurations set on the httpClient.
The user can get around this by creating a separate Client with the appended
"/mockhsm" string but our provided mechanism is broken as is.