### PR TITLE
encoding/blockchain: guard against large mallocs

### DIFF
--- a/encoding/blockchain/blockchain.go
+++ b/encoding/blockchain/blockchain.go
@@ -122,7 +122,7 @@ func ReadVarstrList(r io.Reader) ([][]byte, int, error) {
 	if nelts == 0 {
 		return nil, n, nil
 	}
-	result := make([][]byte, 0, nelts)
+	var result [][]byte
 	for ; nelts > 0; nelts-- {
 		s, n2, err := ReadVarstr31(r)
 		n += n2

--- a/encoding/blockchain/blockchain_test.go
+++ b/encoding/blockchain/blockchain_test.go
@@ -213,6 +213,22 @@ func TestVarstrList(t *testing.T) {
 	}
 }
 
+// TestTooLongVarstrList tests decoding a VarstrList that has a leading
+// element count much longer than the actual list. Reading such a
+// varstrlist shouldn't try to allocate more memory than feasible.
+func TestTooLongVarstrList(t *testing.T) {
+	var buf bytes.Buffer
+	WriteVarint31(&buf, math.MaxInt32)
+	WriteVarstr31(&buf, []byte{0x01})
+	WriteVarstr31(&buf, []byte{0x02})
+	WriteVarstr31(&buf, []byte{0x03})
+
+	_, _, err := ReadVarstrList(bytes.NewReader(buf.Bytes()))
+	if err != io.EOF {
+		t.Errorf("got %s, expected io.EOF", err)
+	}
+}
+
 func TestExtensibleString(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		// make a string of length i+1

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2959";
+	public final String Id = "main/rev2960";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2959"
+const ID string = "main/rev2960"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2959"
+export const rev_id = "main/rev2960"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2959".freeze
+	ID = "main/rev2960".freeze
 end


### PR DESCRIPTION
Don't trust the element count when decoding VarstrLists. Allocating an
array at that size may exhaust all memory available. I found this
particular instance using fuzz testing. I think there are probably more
instances of this, like `ReadVarstring31`.

This bug seems most relevant to a multi-Core network. A bad actor could
submit a transaction to the generator with a math.MaxInt32 element in a
VarstrList to crash the generator. Because the transaction doesn't
actually encode math.MaxInt32 elements, it doesn't hit max byte request
body limits.

To fix this generally, we could:
 * read incrementally into smaller buffers rather than allocating one
   buffer that is the claimed size.
 * not use the `io.Reader` interface and instead expose the length of
   the unread buffer to decoding routines for validation.
 * implement stricter length limits than the protocol currently permits.