### PR TITLE
dashboard: coalesce authorization grants by guard data

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -43,6 +43,8 @@
     "redux": "~3.5.2",
     "redux-form": "~5.3.2",
     "redux-thunk": "~2.1.0",
+    "reselect": "^3.0.0",
+    "sha.js": "^2.4.8",
     "uuid": "~2.0.2"
   },
   "devDependencies": {

--- a/dashboard/src/actions.js
+++ b/dashboard/src/actions.js
@@ -1,4 +1,4 @@
-import { actions as accessControl } from 'features/accessControl'
+import accessControl from 'features/accessControl/actions'
 import { actions as account } from 'features/accounts'
 import { actions as app } from 'features/app'
 import { actions as asset } from 'features/assets'

--- a/dashboard/src/features/accessControl/actions.js
+++ b/dashboard/src/features/accessControl/actions.js
@@ -1,13 +1,8 @@
 import React from 'react'
 import { chainClient } from 'utility/environment'
-import { baseListActions } from 'features/shared/actions'
 import { actions as appActions } from 'features/app'
 import { push } from 'react-router-redux'
 import TokenCreateModal from './components/TokenCreateModal'
-
-const baseActions = baseListActions('accessControl', {
-  clientApi: () => chainClient().accessControl
-})
 
 // Given a list of policies, create a grant for
 // all policies that are truthy, and delete any
@@ -32,17 +27,21 @@ const setPolicies = (body, policies) => {
 
 export default {
   fetchItems: () => {
-    return (dispatch) =>
-      chainClient().accessControl.list()
-      .then(
-        (param) => dispatch({
-          type: 'RECEIVED_ACCESSCONTROL_ITEMS',
-          param,
-        })
-      )
-  },
+    return (dispatch) => {
+      const tokens = []
 
-  deleteItem: baseActions.deleteItem,
+      return Promise.all([
+        chainClient().accessControl.list(),
+        chainClient().accessTokens.queryAll({}, (token, next) => {
+          tokens.push(token)
+          next()
+        })
+      ]).then(result => {
+        const grants = result[0].items
+        return dispatch({ type: 'RECEIVED_ACCESS_GRANTS', grants, tokens })
+      })
+    }
+  },
 
   submitTokenForm: data => {
     const body = {
@@ -65,7 +64,7 @@ export default {
             appActions.hideModal
           ))
 
-          dispatch({ type: 'CREATED_ACCESSTOKEN', grantResp })
+          dispatch({ type: 'CREATED_TOKEN_WITH_GRANT', grantResp })
 
           dispatch(push({
             pathname: '/access-control',
@@ -95,7 +94,7 @@ export default {
       }
 
       return setPolicies(body, data.policies).then(resp => {
-        dispatch({ type: 'CREATED_ACCESSX509', resp })
+        dispatch({ type: 'CREATED_X509_GRANT', resp })
         dispatch(push({
           pathname: '/access-control',
           search: '?type=certificate',
@@ -105,17 +104,18 @@ export default {
     }
   },
 
-  deleteGrant: grant => {
-    if (!window.confirm('Really delete access grant?')) {
+  deleteToken: grant => {
+    const id = grant.guardData.id
+    if (!window.confirm(`Really delete access token "${id}"?`)) {
       return
     }
 
-    return dispatch => chainClient().accessControl.delete(grant)
+    return dispatch => chainClient().accessTokens.delete(id)
       .then(() => {
         dispatch({
-          type: 'DELETE_ACCESSCONTROL',
+          type: 'DELETE_ACCESS_TOKEN',
           id: grant.id,
-          message: 'Grant deleted.'
+          message: 'Token deleted.'
         })
       }).catch(err => dispatch({
         type: 'ERROR', payload: err

--- a/dashboard/src/features/accessControl/actions.js
+++ b/dashboard/src/features/accessControl/actions.js
@@ -80,7 +80,6 @@ export default {
     const body = {
       guardType: 'x509',
       guardData: {subject: {}},
-      policy: 'client-readwrite'
     }
 
     for (let index in data.subject) {
@@ -102,6 +101,24 @@ export default {
         }))
       }, err => { throw {_error: err} })
     }
+  },
+
+  editPolicies: data => {
+    const body = {
+      guardType: data.grant.guardType,
+      guardData: data.grant.guardData,
+    }
+    const policies = data.policies
+
+    return dispatch =>
+      setPolicies(body, policies).then(resp => {
+        dispatch({ type: 'EDITED_POLICIES', grant: body, policies })
+        dispatch(push({
+          pathname: '/access-control',
+          search: '?type=' + (body.guardType == 'access_token' ? 'token' : 'certificate'),
+          state: {preserveFlash: true},
+        }))
+      }, err => { throw {_error: err} })
   },
 
   deleteToken: grant => {

--- a/dashboard/src/features/accessControl/actions.js
+++ b/dashboard/src/features/accessControl/actions.js
@@ -50,10 +50,6 @@ export default {
     }
 
     return dispatch => {
-      if (!Object.values(data.policies).some(policy => policy == true)) {
-        return Promise.reject({_error: 'You must specify one or more policies'})
-      }
-
       return chainClient().accessTokens.create({
         id: body.guardData.id,
         type: 'client', // TODO: remove me when deprecated!
@@ -103,6 +99,11 @@ export default {
     }
   },
 
+  beginEditing: id => ({
+    type: 'BEGIN_POLICY_EDITING',
+    id: id
+  }),
+
   editPolicies: data => {
     const body = {
       guardType: data.grant.guardType,
@@ -111,13 +112,8 @@ export default {
     const policies = data.policies
 
     return dispatch =>
-      setPolicies(body, policies).then(resp => {
-        dispatch({ type: 'EDITED_POLICIES', grant: body, policies })
-        dispatch(push({
-          pathname: '/access-control',
-          search: '?type=' + (body.guardType == 'access_token' ? 'token' : 'certificate'),
-          state: {preserveFlash: true},
-        }))
+      setPolicies(body, policies).then(() => {
+        dispatch({ type: 'END_POLICY_EDITING', id: data.grant.id, policies })
       }, err => { throw {_error: err} })
   },
 

--- a/dashboard/src/features/accessControl/components/AccessControlList.jsx
+++ b/dashboard/src/features/accessControl/components/AccessControlList.jsx
@@ -9,7 +9,7 @@ import styles from './AccessControlList.scss'
 class AccessControlList extends React.Component {
   render() {
     const itemProps = {
-      showEdit: this.props.showEdit,
+      beginEditing: this.props.beginEditing,
       delete: this.props.delete,
     }
     const tokenList = <TableList titles={['Token Name', 'Policies']}>
@@ -83,7 +83,7 @@ const mapDispatchToProps = (dispatch) => ({
   showCertificates: () => dispatch(replace('/access-control?type=certificate')),
   showTokenCreate: () => dispatch(push('/access-control/create-token')),
   showAddCertificate: () => dispatch(push('/access-control/add-certificate')),
-  showEdit: (item) => dispatch(push(`/access-control/${item.id}/edit`)),
+  beginEditing: (id) => dispatch(actions.beginEditing(id)),
 })
 
 export default connect(

--- a/dashboard/src/features/accessControl/components/AccessControlList.jsx
+++ b/dashboard/src/features/accessControl/components/AccessControlList.jsx
@@ -3,17 +3,21 @@ import GrantListItem from './GrantListItem'
 import { connect } from 'react-redux'
 import { TableList, PageTitle, PageContent } from 'features/shared/components'
 import { push, replace } from 'react-router-redux'
-import { actions } from 'features/accessControl'
+import actions from 'features/accessControl/actions'
 import styles from './AccessControlList.scss'
 
 class AccessControlList extends React.Component {
   render() {
-    const tokenList = <TableList titles={['ID', 'Policy']}>
-      {this.props.tokens.map(item => <GrantListItem key={item.id} item={item} delete={this.props.delete} />)}
+    const itemProps = {
+      showEdit: this.props.showEdit,
+      delete: this.props.delete,
+    }
+    const tokenList = <TableList titles={['Token Name', 'Policies']}>
+      {this.props.tokens.map(item => <GrantListItem key={item.id} item={item} {...itemProps} />)}
     </TableList>
 
-    const certList = <TableList titles={['Certificate', 'Policy']}>
-      {this.props.certs.map(item => <GrantListItem key={item.id} item={item} delete={this.props.delete} />)}
+    const certList = <TableList titles={['Certificate', 'Policies']}>
+      {this.props.certs.map(item => <GrantListItem key={item.id} item={item} {...itemProps} />)}
     </TableList>
 
     return (<div>
@@ -59,7 +63,7 @@ class AccessControlList extends React.Component {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const items = Object.values(state.accessControl.items)
+  const items = state.accessControl.ids.map(id => state.accessControl.items[id])
   const tokensSelected = ownProps.location.query.type == 'token'
   const certificatesSelected = ownProps.location.query.type != 'token'
 
@@ -74,11 +78,12 @@ const mapStateToProps = (state, ownProps) => {
 }
 
 const mapDispatchToProps = (dispatch) => ({
-  delete: (grant) => dispatch(actions.deleteGrant(grant)),
+  delete: (grant) => dispatch(actions.deleteToken(grant)),
   showTokens: () => dispatch(replace('/access-control?type=token')),
   showCertificates: () => dispatch(replace('/access-control?type=certificate')),
   showTokenCreate: () => dispatch(push('/access-control/create-token')),
   showAddCertificate: () => dispatch(push('/access-control/add-certificate')),
+  showEdit: (item) => dispatch(push(`/access-control/${item.id}/edit`)),
 })
 
 export default connect(

--- a/dashboard/src/features/accessControl/components/AccessControlList.scss
+++ b/dashboard/src/features/accessControl/components/AccessControlList.scss
@@ -12,8 +12,13 @@
 .btn {
   color: $highlight-default;
 
+  &:hover {
+    text-decoration: underline;
+  }
+
   &:hover, &:active, &:hover:active, &:active:focus, &:focus {
     color: $highlight-default;
+    background: $background-color;
   }
 
   &:focus {
@@ -22,7 +27,10 @@
 }
 
 .active, .active:focus, .active:hover, .active:active:focus {
-  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 2px 3px rgba(0, 0, 0, 0.15);
   border-color: $border-strong-color;
   background: $background-emphasis-color;
+  color: $text-color;
+  cursor: default;
+  text-decoration: none;
 }

--- a/dashboard/src/features/accessControl/components/EditPolicies.jsx
+++ b/dashboard/src/features/accessControl/components/EditPolicies.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import { BaseNew, FormContainer, FormSection, TextField, CheckboxField } from 'features/shared/components'
+import { BaseNew, FormContainer, FormSection, CheckboxField } from 'features/shared/components'
 import { policyOptions } from 'features/accessControl/constants'
 import { reduxForm } from 'redux-form'
 import actions from 'features/accessControl/actions'
 
-class NewToken extends React.Component {
+class EditPolicies extends React.Component {
   render() {
     const {
-      fields: { guardData, policies },
+      fields: { policies },
       error,
       handleSubmit,
       submitting
@@ -16,13 +16,10 @@ class NewToken extends React.Component {
     return(
       <FormContainer
         error={error}
-        label='New access token'
+        label='Edit policies'
         onSubmit={handleSubmit(this.props.submitForm)}
         submitting={submitting} >
 
-        <FormSection title='Token information'>
-          <TextField title='Token Name' fieldProps={guardData.id} autoFocus={true} />
-        </FormSection>
         <FormSection title='Policy'>
           {policyOptions.map(option => {
             return <CheckboxField key={option.label}
@@ -38,30 +35,39 @@ class NewToken extends React.Component {
 }
 
 const mapDispatchToProps = (dispatch) => ({
-  submitForm: (data) => dispatch(actions.submitTokenForm(data))
+  submitForm: (data) => { /* todo */ }
 })
+
+const initialValues = (state, ownProps) => {
+  const item = state.accessControl.items[ownProps.params.id]
+  if (!item) { return {} }
+
+  const policies = item.policies
+  const fields = {
+    initialValues: {
+      policies: {
+        ['client-readwrite']: policies.indexOf('client-readwrite') >= 0,
+        ['client-readonly']: policies.indexOf('client-readonly') >= 0,
+        network: policies.indexOf('network') >= 0,
+        monitoring: policies.indexOf('monitoring') >= 0,
+      }
+    }
+  }
+  console.log(fields);
+
+  return fields
+}
 
 export default BaseNew.connect(
   BaseNew.mapStateToProps('accessControl'),
   mapDispatchToProps,
   reduxForm({
-    form: 'newAccessGrantForm',
+    form: 'editPoliciesForm',
     fields: [
-      'guardType',
-      'guardData.id',
       'policies.client-readwrite',
       'policies.client-readonly',
       'policies.network',
       'policies.monitoring',
     ],
-    validate: values => {
-      const errors = {}
-
-      if (!values.guardData.id) {
-        errors.guardData = {id: 'Token name is required'}
-      }
-
-      return errors
-    }
-  })(NewToken)
+  }, initialValues)(EditPolicies)
 )

--- a/dashboard/src/features/accessControl/components/EditPolicies.jsx
+++ b/dashboard/src/features/accessControl/components/EditPolicies.jsx
@@ -1,52 +1,31 @@
 import React from 'react'
-import { BaseNew, FormContainer, FormSection, CheckboxField } from 'features/shared/components'
+import { BaseNew, CheckboxField } from 'features/shared/components'
 import { policyOptions } from 'features/accessControl/constants'
 import { reduxForm } from 'redux-form'
 import actions from 'features/accessControl/actions'
-import { isAccessToken } from 'features/accessControl/selectors'
+import styles from './EditPolicies.scss'
 
 class EditPolicies extends React.Component {
   render() {
-    const item = this.props.item
     const {
       fields: { policies },
-      error,
       handleSubmit,
-      submitting
     } = this.props
 
-    const label = <span>Edit {isAccessToken(item) ? <code>{item.name}</code> : 'certificate'}</span>
-
     return(
-      <FormContainer
-        error={error}
-        label={label}
-        onSubmit={handleSubmit(this.props.submitForm)}
-        submitting={submitting} >
+      <div className={styles.main}>
+        {policyOptions.map(option => {
+          return <CheckboxField key={option.label}
+            title={option.label}
+            hint={option.hint}
+            fieldProps={policies[option.value]} />
+        })}
 
-        {!isAccessToken(item) && <FormSection title='Certificate Info'>
-          <pre>
-            {JSON.stringify(item.guardData, '  ', 2)}
-          </pre>
-        </FormSection>}
-
-        <FormSection title='Policy'>
-          {policyOptions.map(option => {
-            return <CheckboxField key={option.label}
-              title={option.label}
-              hint={option.hint}
-              fieldProps={policies[option.value]} />
-          })}
-        </FormSection>
-
-      </FormContainer>
+        <button className='btn btn-primary' onClick={handleSubmit(this.props.submitForm)}>Save</button>
+      </div>
     )
   }
 }
-
-const mapStateToProps = (state, ownProps) => ({
-  item: state.accessControl.items[ownProps.params.id]
-})
 
 const mapDispatchToProps = (dispatch) => ({
   submitForm: (data) => dispatch(actions.editPolicies(data))
@@ -73,7 +52,7 @@ const initialValues = (state, ownProps) => {
 }
 
 export default BaseNew.connect(
-  mapStateToProps,
+  () => ({}),
   mapDispatchToProps,
   reduxForm({
     form: 'editPoliciesForm',

--- a/dashboard/src/features/accessControl/components/EditPolicies.jsx
+++ b/dashboard/src/features/accessControl/components/EditPolicies.jsx
@@ -3,9 +3,11 @@ import { BaseNew, FormContainer, FormSection, CheckboxField } from 'features/sha
 import { policyOptions } from 'features/accessControl/constants'
 import { reduxForm } from 'redux-form'
 import actions from 'features/accessControl/actions'
+import { isAccessToken } from 'features/accessControl/selectors'
 
 class EditPolicies extends React.Component {
   render() {
+    const item = this.props.item
     const {
       fields: { policies },
       error,
@@ -13,12 +15,20 @@ class EditPolicies extends React.Component {
       submitting
     } = this.props
 
+    const label = <span>Edit {isAccessToken(item) ? <code>{item.name}</code> : 'certificate'}</span>
+
     return(
       <FormContainer
         error={error}
-        label='Edit policies'
+        label={label}
         onSubmit={handleSubmit(this.props.submitForm)}
         submitting={submitting} >
+
+        {!isAccessToken(item) && <FormSection title='Certificate Info'>
+          <pre>
+            {JSON.stringify(item.guardData, '  ', 2)}
+          </pre>
+        </FormSection>}
 
         <FormSection title='Policy'>
           {policyOptions.map(option => {
@@ -34,17 +44,22 @@ class EditPolicies extends React.Component {
   }
 }
 
+const mapStateToProps = (state, ownProps) => ({
+  item: state.accessControl.items[ownProps.params.id]
+})
+
 const mapDispatchToProps = (dispatch) => ({
-  submitForm: (data) => { /* todo */ }
+  submitForm: (data) => dispatch(actions.editPolicies(data))
 })
 
 const initialValues = (state, ownProps) => {
-  const item = state.accessControl.items[ownProps.params.id]
+  const item = ownProps.item
   if (!item) { return {} }
 
   const policies = item.policies
   const fields = {
     initialValues: {
+      grant: item,
       policies: {
         ['client-readwrite']: policies.indexOf('client-readwrite') >= 0,
         ['client-readonly']: policies.indexOf('client-readonly') >= 0,
@@ -53,17 +68,17 @@ const initialValues = (state, ownProps) => {
       }
     }
   }
-  console.log(fields);
 
   return fields
 }
 
 export default BaseNew.connect(
-  BaseNew.mapStateToProps('accessControl'),
+  mapStateToProps,
   mapDispatchToProps,
   reduxForm({
     form: 'editPoliciesForm',
     fields: [
+      'grant',
       'policies.client-readwrite',
       'policies.client-readonly',
       'policies.network',

--- a/dashboard/src/features/accessControl/components/EditPolicies.scss
+++ b/dashboard/src/features/accessControl/components/EditPolicies.scss
@@ -1,0 +1,10 @@
+.main {
+  position: relative;
+  text-align: left;
+
+  button {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+}

--- a/dashboard/src/features/accessControl/components/GrantListItem.jsx
+++ b/dashboard/src/features/accessControl/components/GrantListItem.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { isAccessToken, getPolicyNamesString } from 'features/accessControl/selectors'
 
 class GrantListItem extends React.Component {
   render() {
     const item = this.props.item
 
     let desc
-    if (item.guardType == 'access_token') {
+    if (isAccessToken(item)) {
       desc = item.guardData.id
     } else {
       desc = <div>
@@ -23,11 +24,15 @@ class GrantListItem extends React.Component {
     return(
       <tr>
         <td>{desc}</td>
-        <td>{item.policy}</td>
+        <td>{getPolicyNamesString(item)}</td>
         <td>
-          <button className='btn btn-danger btn-xs' onClick={this.props.delete.bind(this, item)}>
-            Delete
+          <button className='btn btn-link btn-sm' onClick={this.props.showEdit.bind(this, item)}>
+            Edit
           </button>
+
+          {isAccessToken(item) && <button className='btn btn-link btn-sm' onClick={this.props.delete.bind(this, item)}>
+            Delete
+          </button>}
         </td>
       </tr>
     )

--- a/dashboard/src/features/accessControl/components/GrantListItem.jsx
+++ b/dashboard/src/features/accessControl/components/GrantListItem.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { isAccessToken, getPolicyNamesString } from 'features/accessControl/selectors'
+import EditPolicies from './EditPolicies'
 
 class GrantListItem extends React.Component {
   render() {
@@ -11,29 +12,38 @@ class GrantListItem extends React.Component {
       desc = item.guardData.id
     } else {
       desc = <div>
-        {Object.keys(item.guardData).map(field => <div key={field}>
-          {field}:
-          <ul>
-            {Object.keys(item.guardData[field]).map(key => <li key={key}>
-              {key}: {item.guardData[field][key]}
-            </li>)}
-          </ul>
-        </div>)}
+        {Object.keys(item.guardData).map(field =>
+          <div key={field}>
+            {field}:
+            <ul>
+              {Object.keys(item.guardData[field]).map(key =>
+                <li key={key}>
+                  {key}: {item.guardData[field][key]}
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
       </div>
     }
     return(
       <tr>
         <td>{desc}</td>
-        <td>{getPolicyNamesString(item)}</td>
-        <td>
-          <button className='btn btn-link btn-sm' onClick={this.props.showEdit.bind(this, item)}>
+        {!item.isEditing && <td>
+          {getPolicyNamesString(item)}
+        </td>}
+        {!item.isEditing && <td>
+          <button className='btn btn-link' onClick={this.props.beginEditing.bind(this, item.id)}>
             Edit
           </button>
 
-          {isAccessToken(item) && <button className='btn btn-link btn-sm' onClick={this.props.delete.bind(this, item)}>
+          {isAccessToken(item) && <button className='btn btn-link' onClick={this.props.delete.bind(this, item)}>
             Delete
           </button>}
-        </td>
+        </td>}
+        {item.isEditing && <td colSpan='2'>
+          <EditPolicies item={item}/>
+        </td>}
       </tr>
     )
   }

--- a/dashboard/src/features/accessControl/components/NewCertificate.jsx
+++ b/dashboard/src/features/accessControl/components/NewCertificate.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { BaseNew, FormContainer, FormSection, TextField, CheckboxField } from 'features/shared/components'
 import { policyOptions } from 'features/accessControl/constants'
 import { reduxForm } from 'redux-form'
-import { actions } from 'features/accessControl'
+import actions from 'features/accessControl/actions'
 import styles from './NewCertificate.scss'
 
 class NewCertificate extends React.Component {

--- a/dashboard/src/features/accessControl/constants.js
+++ b/dashboard/src/features/accessControl/constants.js
@@ -1,22 +1,22 @@
 export const policyOptions = [
   {
-    label: 'client-readwrite',
+    label: 'Client read/write',
     value: 'client-readwrite',
-    hint: 'full access to the Client API'
+    hint: 'Full access to the Client API'
   },
   {
-    label: 'client-readonly',
+    label: 'Client read-only',
     value: 'client-readonly',
-    hint: 'access to read-only Client endpoints'
+    hint: 'Access to read-only Client endpoints'
   },
   {
-    label: 'network',
+    label: 'Network',
     value: 'network',
-    hint: 'access to the Network API'
+    hint: 'Access to the Network API'
   },
   {
-    label: 'monitoring',
+    label: 'Monitoring',
     value: 'monitoring',
-    hint: 'access to monitoring-specific endpoints'
+    hint: 'Access to monitoring-specific endpoints'
   },
 ]

--- a/dashboard/src/features/accessControl/index.js
+++ b/dashboard/src/features/accessControl/index.js
@@ -1,9 +1,0 @@
-import actions from './actions'
-import reducers from './reducers'
-import routes from './routes'
-
-export {
-  actions,
-  reducers,
-  routes,
-}

--- a/dashboard/src/features/accessControl/reducers.js
+++ b/dashboard/src/features/accessControl/reducers.js
@@ -12,6 +12,7 @@ export default (state = {ids: [], items: {}}, action) => {
       const id = createHash('sha256').update(JSON.stringify(tokenGuard), 'utf8').digest('hex')
       newObjects[id] = {
         id: id,
+        name: token.id,
         guardType: 'access_token',
         guardData: tokenGuard,
         policies: [],

--- a/dashboard/src/features/accessControl/reducers.js
+++ b/dashboard/src/features/accessControl/reducers.js
@@ -1,11 +1,66 @@
-import { combineReducers } from 'redux'
-import { reducers } from 'features/shared'
+import createHash from 'sha.js'
 
-const type = 'accessControl'
+export default (state = {ids: [], items: {}}, action) => {
+  // Grant list is always complete, so we rebuild state from scratch
+  if (action.type == 'RECEIVED_ACCESS_GRANTS') {
+    const newObjects = {}
 
-const idFunc = (item) => `${JSON.stringify(item.guardData)}-${item.policy}`
+    action.tokens.forEach(token => {
+      const tokenGuard = {
+        id: token.id
+      }
+      const id = createHash('sha256').update(JSON.stringify(tokenGuard), 'utf8').digest('hex')
+      newObjects[id] = {
+        id: id,
+        guardType: 'access_token',
+        guardData: tokenGuard,
+        policies: [],
+        latestGrant: '0000'
+      }
+    })
 
-export default combineReducers({
-  items: reducers.itemsReducer(type, idFunc),
-  queries: reducers.queriesReducer(type, idFunc),
-})
+    action.grants.forEach(grant => {
+      const id = createHash('sha256').update(JSON.stringify(grant.guardData), 'utf8').digest('hex')
+
+      if (newObjects[id]) {
+        newObjects[id].policies.push(grant.policy)
+        if (newObjects[id].latestGrant.localeCompare(grant.createdAt) < 0) {
+          newObjects[id].latestGrant = grant.createdAt
+        }
+      } else {
+        newObjects[id] = {
+          id: id,
+          guardType: grant.guardType,
+          guardData: grant.guardData,
+          policies: [grant.policy],
+          latestGrant: grant.createdAt
+        }
+      }
+    })
+
+    const newIds = Object.values(newObjects)
+      .sort((a, b) => b.latestGrant.localeCompare(a.latestGrant))
+      .map(object => object.id)
+
+    return {
+      ids: newIds,
+      items: newObjects
+    }
+  } else if (action.type == 'DELETE_ACCESS_TOKEN') {
+    const ids = [...state.ids]
+    const items = {...state.items}
+
+    const idToRemove = action.id
+    const deleteIndex = ids.indexOf(idToRemove)
+    ids.splice(deleteIndex, 1)
+
+    delete items[idToRemove]
+
+    return {
+      ids,
+      items
+    }
+  }
+
+  return state
+}

--- a/dashboard/src/features/accessControl/routes.js
+++ b/dashboard/src/features/accessControl/routes.js
@@ -1,6 +1,7 @@
 import AccessControlList from './components/AccessControlList'
 import NewToken from './components/NewToken'
 import NewCertificate from './components/NewCertificate'
+import EditPolicies from './components/EditPolicies'
 import { makeRoutes } from 'features/shared'
 import actions from './actions'
 
@@ -17,15 +18,15 @@ const checkParams = (nextState, replace) => {
 }
 
 export default (store) => {
+  const loadGrants = () => store.dispatch(actions.fetchItems())
+
   const routes = makeRoutes(store, 'accessControl', AccessControlList, null, null, null, {
     path: 'access-control',
     name: 'Access control'
   })
 
   routes.indexRoute.onEnter = (nextState, replace) => {
-    if (checkParams(nextState, replace)) {
-      store.dispatch(actions.fetchItems())
-    }
+    if (checkParams(nextState, replace)) { loadGrants() }
   }
 
   routes.indexRoute.onChange = (_, nextState, replace) => {
@@ -40,6 +41,12 @@ export default (store) => {
   routes.childRoutes.push({
     path: 'add-certificate',
     component: NewCertificate
+  })
+
+  routes.childRoutes.push({
+    path: ':id/edit',
+    component: EditPolicies,
+    onEnter: (nextState, replace) => loadGrants()
   })
 
   return routes

--- a/dashboard/src/features/accessControl/routes.js
+++ b/dashboard/src/features/accessControl/routes.js
@@ -1,7 +1,6 @@
 import AccessControlList from './components/AccessControlList'
 import NewToken from './components/NewToken'
 import NewCertificate from './components/NewCertificate'
-import EditPolicies from './components/EditPolicies'
 import { makeRoutes } from 'features/shared'
 import actions from './actions'
 
@@ -41,12 +40,6 @@ export default (store) => {
   routes.childRoutes.push({
     path: 'add-certificate',
     component: NewCertificate
-  })
-
-  routes.childRoutes.push({
-    path: ':id/edit',
-    component: EditPolicies,
-    onEnter: (nextState, replace) => loadGrants()
   })
 
   return routes

--- a/dashboard/src/features/accessControl/selectors.js
+++ b/dashboard/src/features/accessControl/selectors.js
@@ -1,0 +1,23 @@
+import { createSelector } from 'reselect'
+import { policyOptions } from './constants'
+
+export const getPolicyNames = createSelector(
+  item => item.policies,
+  policies => policies.map(
+    policy => policyOptions.find(
+      elem => elem.value == policy
+    ).label
+  )
+)
+
+export const getPolicyNamesString = createSelector(
+  getPolicyNames,
+  names => names.join(', ')
+)
+
+export const guardType = (item) => item.guardType
+
+export const isAccessToken = createSelector(
+  guardType,
+  type => type == 'access_token'
+)

--- a/dashboard/src/features/app/reducers.js
+++ b/dashboard/src/features/app/reducers.js
@@ -66,6 +66,10 @@ export const flashMessages = (state = {}, action) => {
       </p>)
     }
 
+    case 'EDITED_POLICIES': {
+      return newSuccess(state, <p>Policies successfully updated.</p>)
+    }
+
     case 'DELETE_ACCESS_TOKEN':
     case 'DELETE_TRANSACTIONFEED': {
       return newFlash(state, flash(action.message, null, 'info'))

--- a/dashboard/src/features/app/reducers.js
+++ b/dashboard/src/features/app/reducers.js
@@ -54,20 +54,19 @@ export const flashMessages = (state = {}, action) => {
       </p>)
     }
 
-    case 'CREATED_ACCESSTOKEN': {
+    case 'CREATED_TOKEN_WITH_GRANT': {
       return newSuccess(state, <p>
         Created access token. <Link to='access-control/create-token'>Create another?</Link>
       </p>)
     }
 
-    case 'CREATED_ACCESSX509': {
+    case 'CREATED_X509_GRANT': {
       return newSuccess(state, <p>
         Granted policy to X509 certificate. <Link to='access-control/add-certificate'>Create another?</Link>
       </p>)
     }
 
-    case 'DELETE_CLIENT_ACCESS_TOKEN':
-    case 'DELETE_NETWORK_ACCESS_TOKEN':
+    case 'DELETE_ACCESS_TOKEN':
     case 'DELETE_TRANSACTIONFEED': {
       return newFlash(state, flash(action.message, null, 'info'))
     }

--- a/dashboard/src/features/app/reducers.js
+++ b/dashboard/src/features/app/reducers.js
@@ -66,10 +66,6 @@ export const flashMessages = (state = {}, action) => {
       </p>)
     }
 
-    case 'EDITED_POLICIES': {
-      return newSuccess(state, <p>Policies successfully updated.</p>)
-    }
-
     case 'DELETE_ACCESS_TOKEN':
     case 'DELETE_TRANSACTIONFEED': {
       return newFlash(state, flash(action.message, null, 'info'))

--- a/dashboard/src/features/shared/components/CheckboxField/CheckboxField.jsx
+++ b/dashboard/src/features/shared/components/CheckboxField/CheckboxField.jsx
@@ -19,10 +19,10 @@ class CheckboxField extends React.Component {
       <div>
         <label className={styles.label}>
           <input type='checkbox' {...fieldProps} />
-          {this.props.title}
-        </label>
+          <span className={styles.title}>{this.props.title}</span>
 
-        {this.props.hint && <span className={styles.hint}>{this.props.hint}</span>}
+          {this.props.hint && <div className={styles.hint}>{this.props.hint}</div>}
+        </label>
       </div>
     )
   }

--- a/dashboard/src/features/shared/components/CheckboxField/CheckboxField.jsx
+++ b/dashboard/src/features/shared/components/CheckboxField/CheckboxField.jsx
@@ -7,7 +7,8 @@ const CHECKBOX_FIELD_PROPS = [
   'onBlur',
   'onChange',
   'onFocus',
-  'name'
+  'name',
+  'checked'
 ]
 
 class CheckboxField extends React.Component {
@@ -16,12 +17,12 @@ class CheckboxField extends React.Component {
 
     return (
       <div>
-        <label>
+        <label className={styles.label}>
           <input type='checkbox' {...fieldProps} />
           {this.props.title}
         </label>
 
-        {this.props.hint && <span className='help-block'>{this.props.hint}</span>}
+        {this.props.hint && <span className={styles.hint}>{this.props.hint}</span>}
       </div>
     )
   }

--- a/dashboard/src/features/shared/components/CheckboxField/CheckboxField.scss
+++ b/dashboard/src/features/shared/components/CheckboxField/CheckboxField.scss
@@ -1,3 +1,12 @@
-.base {
-  background: red;
+.label {
+  input {
+    margin-right: 8px;
+  }
+
+  user-select: none;
+}
+
+.hint {
+  color: $text-light-color;
+  margin-left: $gutter-size/2;
 }

--- a/dashboard/src/features/shared/components/CheckboxField/CheckboxField.scss
+++ b/dashboard/src/features/shared/components/CheckboxField/CheckboxField.scss
@@ -1,6 +1,9 @@
 .label {
-  input {
-    margin-right: 8px;
+  position: relative;
+
+  .title {
+    position: absolute;
+    left: 20px;
   }
 
   user-select: none;
@@ -8,5 +11,5 @@
 
 .hint {
   color: $text-light-color;
-  margin-left: $gutter-size/2;
+  margin-left: 20px;
 }

--- a/dashboard/src/features/shared/components/TableList/TableList.scss
+++ b/dashboard/src/features/shared/components/TableList/TableList.scss
@@ -17,6 +17,7 @@
     text-overflow: ellipsis;
     color: $text-color;
     line-height: 20px;
+    vertical-align: top;
   }
 
   th {
@@ -27,7 +28,7 @@
   }
 
   td, th  {
-    padding: 10px $gutter-size 10px 0;
+    padding: 13px $gutter-size 13px 0;
   }
   th, td {
 
@@ -37,6 +38,14 @@
 
     &:last-child {
       text-align: right;
+    }
+  }
+
+  :global {
+    .btn-link {
+      padding-top: 0;
+      padding-bottom: 0;
+      line-height: 1;
     }
   }
 }

--- a/dashboard/src/reducers.js
+++ b/dashboard/src/reducers.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux'
 import { routerReducer as routing} from 'react-router-redux'
 import { reducer as form } from 'redux-form'
-import { reducers as accessControl } from 'features/accessControl'
+import accessControl from 'features/accessControl/reducers'
 import { reducers as account } from 'features/accounts'
 import { reducers as app } from 'features/app'
 import { reducers as asset } from 'features/assets'

--- a/dashboard/src/routes.js
+++ b/dashboard/src/routes.js
@@ -1,6 +1,6 @@
 import { Container } from 'features/app/components'
 import { NotFound } from 'features/shared/components'
-import { routes as accessControl } from 'features/accessControl'
+import accessControl from 'features/accessControl/routes'
 import { routes as accounts } from 'features/accounts'
 import { routes as assets } from 'features/assets'
 import { routes as balances } from 'features/balances'

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2973";
+	public final String Id = "main/rev2974";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2973"
+const ID string = "main/rev2974"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2973"
+export const rev_id = "main/rev2974"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2973".freeze
+	ID = "main/rev2974".freeze
 end

--- a/sdk/node/src/api/accessControl.js
+++ b/sdk/node/src/api/accessControl.js
@@ -28,6 +28,9 @@ const shared = require('../shared')
  *
  * @property {String} policy
  * Authorization single polciy to attach to specific grant.
+ *
+ * @property {String} createdAt
+ * Time of grant creation, RFC3339 formatted.
  */
 
 /**


### PR DESCRIPTION
When rendering access control objects, we merge multiple 
authorization grants into a single table row. Policies for
the merged row can be edited inline.