### PR TITLE
cmd: rename CORED_DATA_DIR to DATA_DIR

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -31,7 +31,7 @@ import (
 
 // config vars
 var (
-	dataDir = env.String("CORED_DATA_DIR", fileutil.DefaultDir())
+	dataDir = env.String("DATA_DIR", fileutil.DefaultDir())
 	dbURL   = env.String("DATABASE_URL", "postgres:///core?sslmode=disable")
 	coreURL = env.String("CORE_URL", "http://localhost:1999")
 

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -65,7 +65,7 @@ var (
 	rpsToken      = env.Int("RATELIMIT_TOKEN", 0)       // reqs/sec
 	rpsRemoteAddr = env.Int("RATELIMIT_REMOTE_ADDR", 0) // reqs/sec
 	indexTxs      = env.Bool("INDEX_TRANSACTIONS", true)
-	dataDir       = env.String("CORED_DATA_DIR", fileutil.DefaultDir())
+	dataDir       = env.String("DATA_DIR", fileutil.DefaultDir())
 	bootURL       = env.String("BOOTURL", "")
 
 	// build vars; initialized by the linker

--- a/database/raft/Makefile
+++ b/database/raft/Makefile
@@ -9,20 +9,20 @@ build:
 
 run0:
 	LISTEN=127.0.0.1:1999 \
-	CORED_DATA_DIR=$(HOME)/Library/Application\ Support/Chain\ Core/.cored0 \
+	DATA_DIR=$(HOME)/Library/Application\ Support/Chain\ Core/.cored0 \
 	DATABASE_URL=postgres:///core0?sslmode=disable \
 	cored
 
 run1:
 	LISTEN=127.0.0.1:1998 \
-	CORED_DATA_DIR=$(HOME)/Library/Application\ Support/Chain\ Core/.cored1 \	
+	DATA_DIR=$(HOME)/Library/Application\ Support/Chain\ Core/.cored1 \	
 	BOOTURL=http://127.0.0.1:1999/ \
 	DATABASE_URL=postgres:///core0?sslmode=disable \
 	cored
 
 run2:
 	LISTEN=127.0.0.1:1997 \
-	CORED_DATA_DIR=$(HOME)/Library/Application\ Support/Chain\ Core/.cored2 \	
+	DATA_DIR=$(HOME)/Library/Application\ Support/Chain\ Core/.cored2 \	
 	BOOTURL=http://127.0.0.1:1999/ \
 	DATABASE_URL=postgres:///core0?sslmode=disable \
 	cored


### PR DESCRIPTION
@jeffomatic asked why we named this environment variable CORED_DATA_DIR instead of simply DATA_DIR. I couldn't think of anything other than I tend to over-specify things. 