### PR TITLE
sdk/java: support client cert authn

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2994";
+	public final String Id = "main/rev2995";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2994"
+const ID string = "main/rev2995"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2994"
+export const rev_id = "main/rev2995"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2994".freeze
+	ID = "main/rev2995".freeze
 end

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -59,6 +59,11 @@
             <artifactId>gson</artifactId>
             <version>2.6.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>1.56</version>
+        </dependency>
     </dependencies>
 
     <distributionManagement>
@@ -101,6 +106,10 @@
                             <pattern>com.google</pattern>
                             <shadedPattern>com.chain.google</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>org.bouncycastle</pattern>
+                            <shadedPattern>com.chain.bouncycastle</shadedPattern>
+                        </relocation>
                     </relocations>
                     <filters>
                         <filter>
@@ -119,6 +128,20 @@
                             <artifact>com.squareup.okio:okio</artifact>
                             <excludes>
                                 <exclude>META-INF/**</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>org.bouncycastle:bcpkix-jdk15on</artifact>
+                            <excludes>
+                                <exclude>META-INF/**</exclude>
+                            </excludes>
+                        </filter>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/sdk/java/src/main/java/com/chain/api/MockHsm.java
+++ b/sdk/java/src/main/java/com/chain/api/MockHsm.java
@@ -25,7 +25,7 @@ public class MockHsm {
    * @return new client object
    * @throws BadURLException
    */
-  public static Client getSignerClient(Client client) throws BadURLException {
+  public static Client getSignerClient(Client client) throws ChainException {
     try {
       List<URL> urls = new ArrayList<>();
       for (URL url : client.urls()) {

--- a/sdk/java/src/main/java/com/chain/exception/ConfigurationException.java
+++ b/sdk/java/src/main/java/com/chain/exception/ConfigurationException.java
@@ -1,0 +1,23 @@
+package com.chain.exception;
+
+/**
+ * ConfigurationException wraps errors during client configuration.
+ */
+public class ConfigurationException extends ChainException {
+  /**
+   * Initializes exception with its message attribute.
+   * @param message error message
+   */
+  public ConfigurationException(String message) {
+    super(message);
+  }
+
+  /**
+   * Initializes new exception while storing original cause.
+   * @param message the error message
+   * @param cause the original cause
+   */
+  public ConfigurationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -67,7 +67,7 @@ public class Client {
     }
   }
 
-  public Client(Builder builder) throws HTTPException {
+  public Client(Builder builder) throws ConfigurationException {
     List<URL> urls = new ArrayList<>(builder.urls);
     if (urls.isEmpty()) {
       try {
@@ -104,7 +104,7 @@ public class Client {
    *
    * @param url the URL of the Chain Core or HSM
    */
-  public Client(URL url) throws HTTPException {
+  public Client(URL url) throws ConfigurationException {
     this(new Builder().setURL(url));
   }
 
@@ -368,7 +368,7 @@ public class Client {
         // The OkHttp library already performs retries for some
         // I/O-related errors, but we've hit this case in a leader
         // failover, so do our own retries too.
-        exception = new HTTPException(ex.getMessage());
+        exception = new ConfigurationException(ex.getMessage());
       } catch (ConnectivityException ex) {
         // This URL's process might be unhealthy; move to the next.
         this.nextURL(idx);
@@ -390,7 +390,7 @@ public class Client {
     throw exception;
   }
 
-  private OkHttpClient buildHttpClient(Builder builder) throws HTTPException {
+  private OkHttpClient buildHttpClient(Builder builder) throws ConfigurationException {
     OkHttpClient httpClient = builder.baseHttpClient.clone();
 
     try {
@@ -400,7 +400,7 @@ public class Client {
         httpClient.setSslSocketFactory(sslContext.getSocketFactory());
       }
     } catch (GeneralSecurityException ex) {
-      throw new HTTPException("Unable to configure TLS", ex);
+      throw new ConfigurationException("Unable to configure TLS", ex);
     }
     if (builder.readTimeoutUnit != null) {
       httpClient.setReadTimeout(builder.readTimeout, builder.readTimeoutUnit);
@@ -657,7 +657,7 @@ public class Client {
      * @param keyStream input stream of pem encoded private key
      */
     public Builder setX509KeyPair(InputStream certStream, InputStream keyStream)
-        throws HTTPException {
+        throws ConfigurationException {
       try (PEMParser parser = new PEMParser(new InputStreamReader(keyStream))) {
         // Extract certs from PEM-encoded input.
         CertificateFactory factory = CertificateFactory.getInstance("X.509");
@@ -674,7 +674,7 @@ public class Client {
           // PKCS#8 Private Key found.
           info = (PrivateKeyInfo) obj;
         } else {
-          throw new HTTPException("Unsupported private key provided.");
+          throw new ConfigurationException("Unsupported private key provided.");
         }
 
         // Create a new key store and input the pair.
@@ -697,7 +697,7 @@ public class Client {
         this.keyManagers = keyManagerFactory.getKeyManagers();
         return this;
       } catch (GeneralSecurityException | IOException ex) {
-        throw new HTTPException("Unable to store X.509 cert/key pair", ex);
+        throw new ConfigurationException("Unable to store X.509 cert/key pair", ex);
       }
     }
 
@@ -706,14 +706,14 @@ public class Client {
      * @param certPath file path to pem encoded X.509 certificate
      * @param keyPath file path to pem encoded private key
      */
-    public Builder setX509KeyPair(String certPath, String keyPath) throws HTTPException {
+    public Builder setX509KeyPair(String certPath, String keyPath) throws ConfigurationException {
       try (InputStream certStream =
               new ByteArrayInputStream(Files.readAllBytes(Paths.get(certPath)));
           InputStream keyStream =
               new ByteArrayInputStream(Files.readAllBytes(Paths.get(keyPath)))) {
         return setX509KeyPair(certStream, keyStream);
       } catch (IOException ex) {
-        throw new HTTPException("Unable to store X509 cert/key pair", ex);
+        throw new ConfigurationException("Unable to store X509 cert/key pair", ex);
       }
     }
 
@@ -722,7 +722,7 @@ public class Client {
      * your own CA, or are using a self-signed server certificate.
      * @param is input stream of the certificates to trust, in PEM format.
      */
-    public Builder setTrustedCerts(InputStream is) throws HTTPException {
+    public Builder setTrustedCerts(InputStream is) throws ConfigurationException {
       try {
         // Extract certs from PEM-encoded input.
         CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
@@ -757,7 +757,7 @@ public class Client {
         this.trustManagers = trustManagers;
         return this;
       } catch (GeneralSecurityException | IOException ex) {
-        throw new HTTPException("Unable to configure trusted CA certs", ex);
+        throw new ConfigurationException("Unable to configure trusted CA certs", ex);
       }
     }
 
@@ -766,11 +766,11 @@ public class Client {
      * your own CA, or are using a self-signed server certificate.
      * @param path The path of a file containing certificates to trust, in PEM format.
      */
-    public Builder setTrustedCerts(String path) throws HTTPException {
+    public Builder setTrustedCerts(String path) throws ConfigurationException {
       try (InputStream is = new FileInputStream(path)) {
         return setTrustedCerts(is);
       } catch (IOException ex) {
-        throw new HTTPException("Unable to configure trusted CA certs", ex);
+        throw new ConfigurationException("Unable to configure trusted CA certs", ex);
       }
     }
 
@@ -858,7 +858,7 @@ public class Client {
     /**
      * Builds a client with all of the provided parameters.
      */
-    public Client build() throws HTTPException {
+    public Client build() throws ConfigurationException {
       return new Client(this);
     }
   }

--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -50,13 +50,9 @@ public class Client {
   private String accessToken;
   private OkHttpClient httpClient;
 
-  private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-  private static final String PKCS1_HEADER = "-----BEGIN RSA PRIVATE KEY-----\n";
-  private static final String PKCS1_FOOTER = "-----END RSA PRIVATE KEY-----\n";
-  private static final String PKCS8_HEADER = "-----BEGIN PRIVATE KEY-----\n";
-  private static final String PKCS8_FOOTER = "-----END PRIVATE KEY-----\n";
   // Used to create empty, in-memory key stores.
   private static final char[] DEFAULT_KEYSTORE_PASSWORD = "password".toCharArray();
+  private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
   private static String version = "dev"; // updated in the static initializer
 
   private static class BuildProperties {

--- a/sdk/java/src/main/java/com/chain/http/Client.java
+++ b/sdk/java/src/main/java/com/chain/http/Client.java
@@ -653,8 +653,9 @@ public class Client {
 
     /**
      * Sets the client's certificate and key for TLS client authentication.
-     * @param certStream input stream of pem encoded X.509 certificate
-     * @param keyStream input stream of pem encoded private key
+     * PEM-encoded, RSA private keys adhering to PKCS#1 or PKCS#8 are supported.
+     * @param certStream input stream of PEM-encoded X.509 certificate
+     * @param keyStream input stream of PEM-encoded private key
      */
     public Builder setX509KeyPair(InputStream certStream, InputStream keyStream)
         throws ConfigurationException {
@@ -703,8 +704,8 @@ public class Client {
 
     /**
      * Sets the client's certificate and key for TLS client authentication.
-     * @param certPath file path to pem encoded X.509 certificate
-     * @param keyPath file path to pem encoded private key
+     * @param certPath file path to PEM-encoded X.509 certificate
+     * @param keyPath file path to PEM-encoded private key
      */
     public Builder setX509KeyPair(String certPath, String keyPath) throws ConfigurationException {
       try (InputStream certStream =

--- a/sdk/java/src/test/java/com/chain/TestUtils.java
+++ b/sdk/java/src/test/java/com/chain/TestUtils.java
@@ -1,13 +1,14 @@
 package com.chain;
 
 import com.chain.exception.BadURLException;
+import com.chain.exception.ChainException;
 import com.chain.http.Client;
 
 /**
  * TestUtils provides a simplified api for testing.
  */
 public class TestUtils {
-  public static Client generateClient() throws BadURLException {
+  public static Client generateClient() throws ChainException {
     String coreURL = System.getProperty("chain.api.url");
     String accessToken = System.getProperty("client.access.token");
     if (coreURL == null || coreURL.isEmpty()) {

--- a/sdk/java/src/test/java/com/chain/integration/FailureTest.java
+++ b/sdk/java/src/test/java/com/chain/integration/FailureTest.java
@@ -3,6 +3,7 @@ package com.chain.integration;
 import com.chain.TestUtils;
 import com.chain.api.*;
 import com.chain.exception.APIException;
+import com.chain.exception.ConfigurationException;
 import com.chain.exception.HTTPException;
 import com.chain.http.Client;
 import com.chain.signing.HsmSigner;
@@ -31,7 +32,7 @@ public class FailureTest {
   public void testCreateKey() throws Exception {
     try {
       MockHsm.Key.create(new Client(new URL("http://wrong")));
-    } catch (HTTPException e) {
+    } catch (ConfigurationException e) {
       return;
     }
     throw new Exception("expecting APIException");


### PR DESCRIPTION
File paths to the client cert and key can now be passed as `TLSCRT`
and `TLSKEY` respectively. RSA private keys adhering to both PKCS#1
and PKCS#8 are supported. The Java standard library doesn't support
PEM encoded keys so the BouncyCastle Crypto APIs library has been
added for its parsing functionality.