### PR TITLE
core: grant internal access to local subject name

### DIFF
--- a/core/run.go
+++ b/core/run.go
@@ -57,12 +57,14 @@ func UseTLS(c *tls.Config) RunOption {
 			ExpectContinueTimeout: 1 * time.Second,
 		}
 
-		// TODO(kr): set Leaf in TLSConfig and use that here.
-		x509Cert, err := x509.ParseCertificate(c.Certificates[0].Certificate[0])
-		if err != nil {
-			panic(err)
+		if c != nil {
+			// TODO(kr): set Leaf in TLSConfig and use that here.
+			x509Cert, err := x509.ParseCertificate(c.Certificates[0].Certificate[0])
+			if err != nil {
+				panic(err)
+			}
+			a.internalSubj = x509Cert.Subject
 		}
-		a.internalSubj = x509Cert.Subject
 	}
 }
 

--- a/core/run.go
+++ b/core/run.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"net"
 	"net/http"
@@ -55,6 +56,13 @@ func UseTLS(c *tls.Config) RunOption {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		}
+
+		// TODO(kr): set Leaf in TLSConfig and use that here.
+		x509Cert, err := x509.ParseCertificate(c.Certificates[0].Certificate[0])
+		if err != nil {
+			panic(err)
+		}
+		a.internalSubj = x509Cert.Subject
 	}
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2963";
+	public final String Id = "main/rev2964";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2963"
+const ID string = "main/rev2964"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2963"
+export const rev_id = "main/rev2964"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2963".freeze
+	ID = "main/rev2964".freeze
 end


### PR DESCRIPTION
A Chain Core TLS config is used by cored peers to talk
to each other, and by corectl to talk to cored. All
those processes have the same identity, so now we
automatically trust the local cert, with the expectation
that the peer will also be using it. This makes
authz misconfiguation impossible as long as the cert and
key files are loaded successfully.

(Motivation copied from
13528a40544824cffd29875e517bb80e1daeec5b.)