### PR TITLE
core/authz: add endpoints used by corectl to the internal policy

### DIFF
--- a/core/authz.go
+++ b/core/authz.go
@@ -35,7 +35,7 @@ var policyByRoute = map[string][]string{
 	"/list-transactions":      {"client-readwrite", "client-readonly"},
 	"/list-balances":          {"client-readwrite", "client-readonly"},
 	"/list-unspent-outputs":   {"client-readwrite", "client-readonly"},
-	"/reset":                  {"client-readwrite"},
+	"/reset":                  {"client-readwrite", "internal"},
 	"/submit":                 {"client-readwrite"},
 
 	networkRPCPrefix + "get-block":         {"network"},
@@ -50,7 +50,7 @@ var policyByRoute = map[string][]string{
 	"/create-access-token":        {"client-readwrite"},
 	"/list-access-tokens":         {"client-readwrite", "client-readonly"},
 	"/delete-access-token":        {"client-readwrite"},
-	"/configure":                  {"client-readwrite"},
+	"/configure":                  {"client-readwrite", "internal"},
 	"/info":                       {"client-readwrite", "client-readonly", "network", "monitoring"},
 
 	"/debug/vars":          {"client-readwrite", "client-readonly", "monitoring"}, // should monitoring endpoints also be available to any other policy-holders?

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2968";
+	public final String Id = "main/rev2969";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2968"
+const ID string = "main/rev2969"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2968"
+export const rev_id = "main/rev2969"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2968".freeze
+	ID = "main/rev2969".freeze
 end


### PR DESCRIPTION
This will allow a `corectl` configured with the same TLS certificate as
its remote `cored` to make authenticated requests. This is a part of
the work to make `corectl` use the `cored` API exclusively.

