### PR TITLE
core: enforce consistent language for authorization grants

### DIFF
--- a/core/access_tokens.go
+++ b/core/access_tokens.go
@@ -93,7 +93,7 @@ func (a *API) deleteAccessToken(ctx context.Context, x struct{ ID string }) erro
 		return err
 	}
 
-	err = a.revokeGrantsByAccessToken(ctx, x.ID)
+	err = a.deleteGrantsByAccessToken(ctx, x.ID)
 	if err != nil {
 		// well, technically we did delete the access token, so don't return the error
 		// TODO(tessr): make this whole operation atomic, such that we either delete

--- a/core/api.go
+++ b/core/api.go
@@ -170,9 +170,9 @@ func (a *API) buildHandler() {
 		}
 	}))
 
-	m.Handle("/list-acl-grants", jsonHandler(a.listGrants))
-	m.Handle("/create-acl-grant", jsonHandler(a.createGrant))
-	m.Handle("/revoke-acl-grant", jsonHandler(a.revokeGrant))
+	m.Handle("/list-authorization-grant", jsonHandler(a.listGrants))
+	m.Handle("/create-authorization-grant", jsonHandler(a.createGrant))
+	m.Handle("/delete-authorization-grant", jsonHandler(a.deleteGrant))
 	m.Handle("/create-access-token", jsonHandler(a.createAccessToken))
 	m.Handle("/list-access-tokens", jsonHandler(a.listAccessTokens))
 	m.Handle("/delete-access-token", jsonHandler(a.deleteAccessToken))

--- a/core/authz.go
+++ b/core/authz.go
@@ -44,14 +44,14 @@ var policyByRoute = map[string][]string{
 	networkRPCPrefix + "signer/sign-block": {"network"},
 	networkRPCPrefix + "block-height":      {"network"},
 
-	"/list-acl-grants":     {"client-readwrite", "client-readonly"},
-	"/create-acl-grant":    {"client-readwrite"},
-	"/revoke-acl-grant":    {"client-readwrite"},
-	"/create-access-token": {"client-readwrite"},
-	"/list-access-tokens":  {"client-readwrite", "client-readonly"},
-	"/delete-access-token": {"client-readwrite"},
-	"/configure":           {"client-readwrite"},
-	"/info":                {"client-readwrite", "client-readonly", "network", "monitoring"},
+	"/list-authorization-grant":   {"client-readwrite", "client-readonly"},
+	"/create-authorization-grant": {"client-readwrite"},
+	"/delete-authorization-grant": {"client-readwrite"},
+	"/create-access-token":        {"client-readwrite"},
+	"/list-access-tokens":         {"client-readwrite", "client-readonly"},
+	"/delete-access-token":        {"client-readwrite"},
+	"/configure":                  {"client-readwrite"},
+	"/info":                       {"client-readwrite", "client-readonly", "network", "monitoring"},
 
 	"/debug/vars":          {"client-readwrite", "client-readonly", "monitoring"}, // should monitoring endpoints also be available to any other policy-holders?
 	"/debug/pprof":         {"client-readwrite", "client-readonly", "monitoring"},

--- a/core/grants.go
+++ b/core/grants.go
@@ -150,7 +150,7 @@ func (a *API) listGrants(ctx context.Context) (map[string]interface{}, error) {
 	}, nil
 }
 
-func (a *API) revokeGrant(ctx context.Context, x apiGrant) error {
+func (a *API) deleteGrant(ctx context.Context, x apiGrant) error {
 	guardData, err := json.Marshal(x.GuardData)
 	if err != nil {
 		return errors.Wrap(err)
@@ -160,7 +160,7 @@ func (a *API) revokeGrant(ctx context.Context, x apiGrant) error {
 	if err != nil {
 		return errors.Wrap(err)
 	}
-	// If there's nothing to revoke, return success
+	// If there's nothing to delete, return success
 	if data == nil {
 		return nil
 	}
@@ -196,7 +196,7 @@ func (a *API) revokeGrant(ctx context.Context, x apiGrant) error {
 	return nil
 }
 
-func (a *API) revokeGrantsByAccessToken(ctx context.Context, token string) error {
+func (a *API) deleteGrantsByAccessToken(ctx context.Context, token string) error {
 	for _, p := range policies {
 		data, err := a.raftDB.Get(ctx, grantPrefix+p)
 		if err != nil {

--- a/dashboard/src/features/accessControl/actions.js
+++ b/dashboard/src/features/accessControl/actions.js
@@ -10,7 +10,7 @@ const baseActions = baseListActions('accessControl', {
 })
 
 // Given a list of policies, create a grant for
-// all policies that are truthy, and revoke any
+// all policies that are truthy, and delete any
 // outstanding grants for policies that are not.
 const setPolicies = (body, policies) => {
   const promises = []
@@ -105,7 +105,7 @@ export default {
     }
   },
 
-  revokeGrant: grant => {
+  deleteGrant: grant => {
     if (!window.confirm('Really delete access grant?')) {
       return
     }
@@ -115,7 +115,7 @@ export default {
         dispatch({
           type: 'DELETE_ACCESSCONTROL',
           id: grant.id,
-          message: 'Grant revoked.'
+          message: 'Grant deleted.'
         })
       }).catch(err => dispatch({
         type: 'ERROR', payload: err

--- a/dashboard/src/features/accessControl/components/AccessControlList.jsx
+++ b/dashboard/src/features/accessControl/components/AccessControlList.jsx
@@ -74,7 +74,7 @@ const mapStateToProps = (state, ownProps) => {
 }
 
 const mapDispatchToProps = (dispatch) => ({
-  delete: (grant) => dispatch(actions.revokeGrant(grant)),
+  delete: (grant) => dispatch(actions.deleteGrant(grant)),
   showTokens: () => dispatch(replace('/access-control?type=token')),
   showCertificates: () => dispatch(replace('/access-control?type=certificate')),
   showTokenCreate: () => dispatch(push('/access-control/create-token')),

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2964";
+	public final String Id = "main/rev2965";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2964"
+const ID string = "main/rev2965"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2964"
+export const rev_id = "main/rev2965"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2964".freeze
+	ID = "main/rev2965".freeze
 end

--- a/sdk/node/src/api/accessControl.js
+++ b/sdk/node/src/api/accessControl.js
@@ -72,7 +72,7 @@ const accessControl = (client) => ({
    * @returns {Promise<Object>} Success message or error.
    */
   create: (params , cb) =>
-    shared.create(client, '/create-acl-grant', params, {skipArray: true, cb}),
+    shared.create(client, '/create-authorization-grant', params, {skipArray: true, cb}),
 
   /**
    * Delete the specfiied access grant.
@@ -85,7 +85,7 @@ const accessControl = (client) => ({
    * @returns {Promise<Object>} Success message or error.
    */
   delete: (params, cb) => shared.tryCallback(
-    client.request('/revoke-acl-grant', params),
+    client.request('/delete-authorization-grant', params),
     cb
   ),
 
@@ -96,7 +96,7 @@ const accessControl = (client) => ({
    * @returns {Promise<Array<Grant>>} Requested page of results.
    */
   list: (cb) =>
-    shared.query(client, 'accessTokens', '/list-acl-grants', {}, {cb}),
+    shared.query(client, 'accessTokens', '/list-authorization-grant', {}, {cb}),
 })
 
 module.exports = accessControl

--- a/sdk/node/test/callbacks.js
+++ b/sdk/node/test/callbacks.js
@@ -749,7 +749,7 @@ describe('Callback style', () => {
     })
 
 
-    it('can revoke access grants', (done) => {
+    it('can delete access grants', (done) => {
       async.series([
         (next) => client.accessControl.create(tokenGrant, () => next()),
         (next) => client.accessControl.delete(tokenGrant, () => next()),

--- a/sdk/node/test/promises.js
+++ b/sdk/node/test/promises.js
@@ -844,7 +844,7 @@ describe('Promise style', () => {
       })
     })
 
-    it('can revoke access grants', () => {
+    it('can delete access grants', () => {
       return Promise.resolve().then(() =>
         expect(client.accessControl.create(tokenGrant)).to.be.fulfilled
       ).then(() =>


### PR DESCRIPTION
- use "authorization grant" instead of "ACL grant"
- use "delete grant" instead of "revoke grant" ("delete" is the opposite
  of "create")

To avoid conflicts with large ongoing PRs, identifiers in the Node SDK
and dashboard have not been updated, but a future PR will clean those
up.