### PR TITLE
net/http/authz: make x509 guard data de/serialization consistent

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2970";
+	public final String Id = "main/rev2971";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2970"
+const ID string = "main/rev2971"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2970"
+export const rev_id = "main/rev2971"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2970".freeze
+	ID = "main/rev2971".freeze
 end

--- a/net/http/authz/authorizer.go
+++ b/net/http/authz/authorizer.go
@@ -100,15 +100,13 @@ func x509GuardData(grant *Grant) pkix.Name {
 	// TODO(boymanjor): We should support the standard X.500 attributes for Subjects.
 	// One idea is to map the json to a pkix.Name.
 	var v struct {
-		Subject struct {
-			CommonName         string   `json:"cn"`
-			OrganizationalUnit []string `json:"ou"`
-		}
+		CommonName         string   `json:"cn"`
+		OrganizationalUnit []string `json:"ou"`
 	}
 	json.Unmarshal(grant.GuardData, &v)
 	return pkix.Name{
-		CommonName:         v.Subject.CommonName,
-		OrganizationalUnit: v.Subject.OrganizationalUnit,
+		CommonName:         v.CommonName,
+		OrganizationalUnit: v.OrganizationalUnit,
 	}
 }
 

--- a/net/http/authz/authorizer.go
+++ b/net/http/authz/authorizer.go
@@ -100,20 +100,24 @@ func x509GuardData(grant *Grant) pkix.Name {
 	// TODO(boymanjor): We should support the standard X.500 attributes for Subjects.
 	// One idea is to map the json to a pkix.Name.
 	var v struct {
-		CommonName         string   `json:"cn"`
-		OrganizationalUnit []string `json:"ou"`
+		Subject struct {
+			CommonName         string   `json:"cn"`
+			OrganizationalUnit []string `json:"ou"`
+		}
 	}
 	json.Unmarshal(grant.GuardData, &v)
 	return pkix.Name{
-		CommonName:         v.CommonName,
-		OrganizationalUnit: v.OrganizationalUnit,
+		CommonName:         v.Subject.CommonName,
+		OrganizationalUnit: v.Subject.OrganizationalUnit,
 	}
 }
 
 func encodeX509GuardData(subj pkix.Name) []byte {
 	d, _ := json.Marshal(map[string]interface{}{
-		"cn": subj.CommonName,
-		"ou": subj.OrganizationalUnit,
+		"subject": map[string]interface{}{
+			"cn": subj.CommonName,
+			"ou": subj.OrganizationalUnit,
+		},
 	})
 	return d
 }


### PR DESCRIPTION
Previously, we were serializing the subj name fields as a map while
deserializing into a nested map keyed with "subject". This was causing
unexpected, unauthorized requests during testing.

This logic will change once we introduce a subj name parser and
finalize the guard data structure but this currently impedes testing.