### PR TITLE
net/http/authz: match on routes, mux-style

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509/pkix"
 	"expvar"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/pprof"
 	"sync"
@@ -326,10 +325,7 @@ func webAssetsHandler(next http.Handler) http.Handler {
 	}))
 	mux.Handle("/", next)
 
-	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		log.Println("handling req: ", req.RequestURI)
-		mux.ServeHTTP(w, req)
-	})
+	return mux
 }
 
 func (a *API) leaderSignHandler(f func(context.Context, *legacy.Block) ([]byte, error)) func(context.Context, *legacy.Block) ([]byte, error) {

--- a/core/api.go
+++ b/core/api.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509/pkix"
 	"expvar"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/pprof"
 	"sync"
@@ -192,10 +193,11 @@ func (a *API) buildHandler() {
 		m.ServeHTTP(w, req)
 	})
 
-	handler := a.authzHandler(m, latencyHandler)
-	handler = a.authnHandler(handler)
-	handler = maxBytes(handler) // TODO(tessr): consider moving this to non-core specific mux
+	handler := maxBytes(latencyHandler) // TODO(tessr): consider moving this to non-core specific mux
 	handler = webAssetsHandler(handler)
+	handler = a.authzHandler(m, handler)
+	handler = a.authnHandler(handler)
+	handler = redirectHandler(handler)
 	handler = healthHandler(handler)
 	for _, l := range a.requestLimits {
 		handler = limit.Handler(handler, alwaysError(errRateLimited), l.perSecond, l.burst, l.key)
@@ -265,11 +267,7 @@ func (a *API) authzHandler(mux *http.ServeMux, handler http.Handler) http.Handle
 	auth := authz.NewAuthorizer(a.raftDB, grantPrefix, policyByRoute)
 	auth.GrantInternal(a.internalSubj)
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		// return failure early if this path isn't legit
-		if _, pat := mux.Handler(req); pat != req.URL.Path {
-			errorFormatter.Write(req.Context(), rw, errNotFound)
-			return
-		}
+		// TODO(tessr): check that this path exists; return early if this path isn't legit
 		err := auth.Authorize(req)
 		if errors.Root(err) == authz.ErrNotAuthorized {
 			// TODO(kr): remove this workaround once dashboard
@@ -310,6 +308,16 @@ func blockchainIDHandler(handler http.Handler, blockchainID string) http.Handler
 	})
 }
 
+func redirectHandler(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/" {
+			http.Redirect(w, req, "/dashboard/", http.StatusFound)
+			return
+		}
+		next.ServeHTTP(w, req)
+	})
+}
+
 func webAssetsHandler(next http.Handler) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/dashboard/", http.StripPrefix("/dashboard/", static.Handler{
@@ -319,11 +327,7 @@ func webAssetsHandler(next http.Handler) http.Handler {
 	mux.Handle("/", next)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		if req.URL.Path == "/" {
-			http.Redirect(w, req, "/dashboard/", http.StatusFound)
-			return
-		}
-
+		log.Println("handling req: ", req.RequestURI)
 		mux.ServeHTTP(w, req)
 	})
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2980";
+	public final String Id = "main/rev2981";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2980"
+const ID string = "main/rev2981"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2980"
+export const rev_id = "main/rev2981"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2980".freeze
+	ID = "main/rev2981".freeze
 end

--- a/net/http/authz/authorizer.go
+++ b/net/http/authz/authorizer.go
@@ -120,7 +120,6 @@ func (a *Authorizer) policiesByRoute(route string) ([]string, error) {
 	var (
 		n        = 0
 		policies []string
-		pat      string
 	)
 	for pattern, pol := range a.policies {
 		if !pathMatch(pattern, route) {
@@ -129,13 +128,9 @@ func (a *Authorizer) policiesByRoute(route string) ([]string, error) {
 		if len(policies) == 0 || len(pattern) > n {
 			n = len(pattern)
 			policies = pol
-			pat = pattern
 		}
 	}
-	if pat == "/" {
-		// special case, we didn't find any policy
-		return nil, errors.New("missing policy")
-	}
+
 	return policies, nil
 }
 

--- a/net/http/authz/authorizer.go
+++ b/net/http/authz/authorizer.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"crypto/x509/pkix"
 	"encoding/json"
+	"log"
 	"net/http"
-	"strings"
+	"path"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -20,18 +21,18 @@ var ErrNotAuthorized = errors.New("not authorized")
 var builtinGrants = []*Grant{{GuardType: "any", Policy: "public"}}
 
 type Authorizer struct {
-	raftDB        *raft.Service
-	raftPrefix    string
-	policyByRoute map[string][]string
-	extraGrants   map[string][]*Grant // by policy
+	raftDB      *raft.Service
+	raftPrefix  string
+	policies    map[string][]string // by route
+	extraGrants map[string][]*Grant // by policy
 }
 
 func NewAuthorizer(rdb *raft.Service, prefix string, policyMap map[string][]string) *Authorizer {
 	a := &Authorizer{
-		raftDB:        rdb,
-		raftPrefix:    prefix,
-		policyByRoute: policyMap,
-		extraGrants:   make(map[string][]*Grant),
+		raftDB:      rdb,
+		raftPrefix:  prefix,
+		policies:    policyMap,
+		extraGrants: make(map[string][]*Grant),
 	}
 	for _, g := range builtinGrants {
 		a.extraGrants[g.Policy] = append(a.extraGrants[g.Policy], g)
@@ -52,9 +53,9 @@ func (a *Authorizer) GrantInternal(subj pkix.Name) {
 }
 
 func (a *Authorizer) Authorize(req *http.Request) error {
-	policies := a.policyByRoute[strings.TrimRight(req.RequestURI, "/")]
-	if policies == nil || len(policies) == 0 {
-		return errors.New("missing policy on this route")
+	policies, err := a.policiesByRoute(req.RequestURI)
+	if err != nil {
+		return errors.Wrap(err)
 	}
 
 	grants, err := a.grantsByPolicies(policies)
@@ -114,4 +115,59 @@ func (a *Authorizer) grantsByPolicies(policies []string) ([]*Grant, error) {
 		}
 	}
 	return grants, nil
+}
+
+func (a *Authorizer) policiesByRoute(route string) ([]string, error) {
+	var (
+		n        = 0
+		policies []string
+		pat      string
+	)
+	for pattern, pol := range a.policies {
+		if !pathMatch(pattern, route) {
+			continue
+		}
+		if len(policies) == 0 || len(pattern) > n {
+			n = len(pattern)
+			policies = pol
+			pat = pattern
+		}
+	}
+	if pat == "/" {
+		// special case, we didn't find any policy
+		log.Println("whoa nelly")
+		return nil, errors.New("missing policy")
+	}
+	return policies, nil
+}
+
+// Return the canonical path for p, eliminating . and .. elements.
+// From the stdlib net/http package.
+func cleanPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if p[0] != '/' {
+		p = "/" + p
+	}
+	np := path.Clean(p)
+	// path.Clean removes trailing slash except for root;
+	// put the trailing slash back if necessary.
+	if p[len(p)-1] == '/' && np != "/" {
+		np += "/"
+	}
+	return np
+}
+
+// From the stdlib net/http package.
+func pathMatch(pattern, path string) bool {
+	if len(pattern) == 0 {
+		// should not happen
+		return false
+	}
+	n := len(pattern)
+	if pattern[n-1] != '/' {
+		return pattern == path
+	}
+	return len(path) >= n && path[0:n] == pattern
 }

--- a/net/http/authz/authorizer.go
+++ b/net/http/authz/authorizer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509/pkix"
 	"encoding/json"
-	"log"
 	"net/http"
 	"path"
 	"time"
@@ -135,7 +134,6 @@ func (a *Authorizer) policiesByRoute(route string) ([]string, error) {
 	}
 	if pat == "/" {
 		// special case, we didn't find any policy
-		log.Println("whoa nelly")
 		return nil, errors.New("missing policy")
 	}
 	return policies, nil


### PR DESCRIPTION
We need to be able to pattern match on routes when looking up policies, so that we don't need to define a route-policy mapping for every asset dashboard attempts to return.