### PR TITLE
protocol/validation: check for missing fields

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2990";
+	public final String Id = "main/rev2991";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2990"
+const ID string = "main/rev2991"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2990"
+export const rev_id = "main/rev2991"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2990".freeze
+	ID = "main/rev2991".freeze
 end

--- a/protocol/bc/asset.go
+++ b/protocol/bc/asset.go
@@ -67,5 +67,8 @@ func (a AssetAmount) WriteTo(w io.Writer) (int64, error) {
 }
 
 func (a AssetAmount) Equal(other *AssetAmount) bool {
+	if a.AssetId == nil || other.AssetId == nil {
+		return false
+	}
 	return a.Amount == other.Amount && *a.AssetId == *other.AssetId
 }

--- a/protocol/bc/asset.go
+++ b/protocol/bc/asset.go
@@ -2,6 +2,7 @@ package bc
 
 import (
 	"database/sql/driver"
+	"errors"
 	"io"
 
 	"chain/crypto/sha3pool"
@@ -66,9 +67,12 @@ func (a AssetAmount) WriteTo(w io.Writer) (int64, error) {
 	return n + int64(n2), err
 }
 
-func (a AssetAmount) Equal(other *AssetAmount) bool {
-	if a.AssetId == nil || other.AssetId == nil {
-		return false
+func (a *AssetAmount) Equal(other *AssetAmount) (eq bool, err error) {
+	if a == nil || other == nil {
+		return false, errors.New("empty asset amount")
 	}
-	return a.Amount == other.Amount && *a.AssetId == *other.AssetId
+	if a.AssetId == nil || other.AssetId == nil {
+		return false, errors.New("empty asset id")
+	}
+	return a.Amount == other.Amount && *a.AssetId == *other.AssetId, nil
 }

--- a/protocol/bc/tx.go
+++ b/protocol/bc/tx.go
@@ -36,7 +36,7 @@ var (
 
 func (tx *Tx) TimeRange(id Hash) (*TimeRange, error) {
 	e, ok := tx.Entries[id]
-	if !ok {
+	if !ok || e == nil {
 		return nil, errors.Wrapf(ErrMissingEntry, "id %x", id.Bytes())
 	}
 	tr, ok := e.(*TimeRange)
@@ -48,7 +48,7 @@ func (tx *Tx) TimeRange(id Hash) (*TimeRange, error) {
 
 func (tx *Tx) Output(id Hash) (*Output, error) {
 	e, ok := tx.Entries[id]
-	if !ok {
+	if !ok || e == nil {
 		return nil, errors.Wrapf(ErrMissingEntry, "id %x", id.Bytes())
 	}
 	o, ok := e.(*Output)
@@ -60,7 +60,7 @@ func (tx *Tx) Output(id Hash) (*Output, error) {
 
 func (tx *Tx) Spend(id Hash) (*Spend, error) {
 	e, ok := tx.Entries[id]
-	if !ok {
+	if !ok || e == nil {
 		return nil, errors.Wrapf(ErrMissingEntry, "id %x", id.Bytes())
 	}
 	sp, ok := e.(*Spend)
@@ -72,7 +72,7 @@ func (tx *Tx) Spend(id Hash) (*Spend, error) {
 
 func (tx *Tx) Issuance(id Hash) (*Issuance, error) {
 	e, ok := tx.Entries[id]
-	if !ok {
+	if !ok || e == nil {
 		return nil, errors.Wrapf(ErrMissingEntry, "id %x", id.Bytes())
 	}
 	iss, ok := e.(*Issuance)

--- a/protocol/validation/fuzz_test.go
+++ b/protocol/validation/fuzz_test.go
@@ -1,0 +1,29 @@
+package validation
+
+import (
+	"testing"
+
+	"chain/protocol/bc"
+	"chain/protocol/bc/legacy"
+)
+
+func TestFuzzAssetIdNilPointer(t *testing.T) {
+	const (
+		blockchainID = `50935a092ffad7ec9fbac4f4486db6c3b8cd5b9f51cf697248584dde286a7220`
+		input        = `07300730303030303030000001302b3030303030303030303030303030303030303030303030303030303030303030303030303030303030303000253030303030303030303030303030303030303030303030303030303030303030303030303000`
+	)
+
+	var testBlockchainID bc.Hash
+	err := testBlockchainID.UnmarshalText([]byte(blockchainID))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tx legacy.Tx
+	err = tx.UnmarshalText([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ValidateTx(tx.Tx, testBlockchainID)
+}

--- a/protocol/validation/validation.go
+++ b/protocol/validation/validation.go
@@ -39,6 +39,7 @@ var (
 	errMismatchedValue       = errors.New("mismatched value")
 	errMisorderedBlockHeight = errors.New("misordered block height")
 	errMisorderedBlockTime   = errors.New("misordered block time")
+	errMissingField          = errors.New("missing required field")
 	errNoPrevBlock           = errors.New("no previous block")
 	errNoSource              = errors.New("no source for value")
 	errNonemptyExtHash       = errors.New("non-empty extension hash")
@@ -78,7 +79,7 @@ func checkValid(vs *validationState, e bc.Entry) error {
 				return errEmptyResults
 			}
 
-			if !e.ExtHash.IsZero() {
+			if e.ExtHash != nil && !e.ExtHash.IsZero() {
 				return errNonemptyExtHash
 			}
 		}
@@ -97,7 +98,6 @@ func checkValid(vs *validationState, e bc.Entry) error {
 				return errors.Wrapf(err, "checking mux source %d", i)
 			}
 		}
-
 		for i, dest := range e.WitnessDestinations {
 			vs2 := *vs
 			vs2.destPos = uint64(i)
@@ -135,7 +135,7 @@ func checkValid(vs *validationState, e bc.Entry) error {
 			}
 		}
 
-		if vs.tx.Version == 1 && !e.ExtHash.IsZero() {
+		if vs.tx.Version == 1 && e.ExtHash != nil && !e.ExtHash.IsZero() {
 			return errNonemptyExtHash
 		}
 
@@ -159,7 +159,7 @@ func checkValid(vs *validationState, e bc.Entry) error {
 			return errZeroTime
 		}
 
-		if vs.tx.Version == 1 && !e.ExtHash.IsZero() {
+		if vs.tx.Version == 1 && e.ExtHash != nil && !e.ExtHash.IsZero() {
 			return errNonemptyExtHash
 		}
 
@@ -171,7 +171,7 @@ func checkValid(vs *validationState, e bc.Entry) error {
 			return errors.Wrap(err, "checking output source")
 		}
 
-		if vs.tx.Version == 1 && !e.ExtHash.IsZero() {
+		if vs.tx.Version == 1 && e.ExtHash != nil && !e.ExtHash.IsZero() {
 			return errNonemptyExtHash
 		}
 
@@ -183,7 +183,7 @@ func checkValid(vs *validationState, e bc.Entry) error {
 			return errors.Wrap(err, "checking retirement source")
 		}
 
-		if vs.tx.Version == 1 && !e.ExtHash.IsZero() {
+		if vs.tx.Version == 1 && e.ExtHash != nil && !e.ExtHash.IsZero() {
 			return errNonemptyExtHash
 		}
 
@@ -194,7 +194,7 @@ func checkValid(vs *validationState, e bc.Entry) error {
 		if e.MaxTimeMs > 0 && e.MaxTimeMs < vs.tx.MaxTimeMs {
 			return errBadTimeRange
 		}
-		if vs.tx.Version == 1 && !e.ExtHash.IsZero() {
+		if vs.tx.Version == 1 && e.ExtHash != nil && !e.ExtHash.IsZero() {
 			return errNonemptyExtHash
 		}
 
@@ -251,11 +251,14 @@ func checkValid(vs *validationState, e bc.Entry) error {
 			return errors.Wrap(err, "checking issuance destination")
 		}
 
-		if vs.tx.Version == 1 && !e.ExtHash.IsZero() {
+		if vs.tx.Version == 1 && e.ExtHash != nil && !e.ExtHash.IsZero() {
 			return errNonemptyExtHash
 		}
 
 	case *bc.Spend:
+		if e.SpentOutputId == nil {
+			return errors.Wrap(errMissingField, "spend without spent output ID")
+		}
 		spentOutput, err := vs.tx.Output(*e.SpentOutputId)
 		if err != nil {
 			return errors.Wrap(err, "getting spend prevout")
@@ -283,7 +286,7 @@ func checkValid(vs *validationState, e bc.Entry) error {
 			return errors.Wrap(err, "checking spend destination")
 		}
 
-		if vs.tx.Version == 1 && !e.ExtHash.IsZero() {
+		if vs.tx.Version == 1 && e.ExtHash != nil && !e.ExtHash.IsZero() {
 			return errNonemptyExtHash
 		}
 
@@ -295,13 +298,23 @@ func checkValid(vs *validationState, e bc.Entry) error {
 }
 
 func checkValidBlockHeader(bh *bc.BlockHeader) error {
-	if bh.Version == 1 && !bh.ExtHash.IsZero() {
+	if bh.Version == 1 && bh.ExtHash != nil && !bh.ExtHash.IsZero() {
 		return errNonemptyExtHash
 	}
 	return nil
 }
 
 func checkValidSrc(vstate *validationState, vs *bc.ValueSource) error {
+	if vs == nil {
+		return errors.Wrap(errMissingField, "empty value source")
+	}
+	if vs.Ref == nil {
+		return errors.Wrap(errMissingField, "missing ref on value source")
+	}
+	if vs.Value == nil || vs.Value.AssetId == nil {
+		return errors.Wrap(errMissingField, "missing value on value source")
+	}
+
 	e, ok := vstate.tx.Entries[*vs.Ref]
 	if !ok {
 		return errors.Wrapf(bc.ErrMissingEntry, "entry for value source %x not found", vs.Ref.Bytes())
@@ -337,7 +350,7 @@ func checkValidSrc(vstate *validationState, vs *bc.ValueSource) error {
 		return errors.Wrapf(bc.ErrEntryType, "value source is %T, should be issuance, spend, or mux", e)
 	}
 
-	if *dest.Ref != vstate.entryID {
+	if dest.Ref == nil || *dest.Ref != vstate.entryID {
 		return errors.Wrapf(errMismatchedReference, "value source for %x has disagreeing destination %x", vstate.entryID.Bytes(), dest.Ref.Bytes())
 	}
 
@@ -353,6 +366,16 @@ func checkValidSrc(vstate *validationState, vs *bc.ValueSource) error {
 }
 
 func checkValidDest(vs *validationState, vd *bc.ValueDestination) error {
+	if vd == nil {
+		return errors.Wrap(errMissingField, "empty value destination")
+	}
+	if vd.Ref == nil {
+		return errors.Wrap(errMissingField, "missing ref on value destination")
+	}
+	if vd.Value == nil || vd.Value.AssetId == nil {
+		return errors.Wrap(errMissingField, "missing value on value source")
+	}
+
 	e, ok := vs.tx.Entries[*vd.Ref]
 	if !ok {
 		return errors.Wrapf(bc.ErrMissingEntry, "entry for value destination %x not found", vd.Ref.Bytes())
@@ -381,7 +404,7 @@ func checkValidDest(vs *validationState, vd *bc.ValueDestination) error {
 		return errors.Wrapf(bc.ErrEntryType, "value destination is %T, should be output, retirement, or mux", e)
 	}
 
-	if *src.Ref != vs.entryID {
+	if src.Ref == nil || *src.Ref != vs.entryID {
 		return errors.Wrapf(errMismatchedReference, "value destination for %x has disagreeing source %x", vs.entryID.Bytes(), src.Ref.Bytes())
 	}
 

--- a/protocol/validation/validation.go
+++ b/protocol/validation/validation.go
@@ -268,7 +268,11 @@ func checkValid(vs *validationState, e bc.Entry) error {
 			return errors.Wrap(err, "checking control program")
 		}
 
-		if !spentOutput.Source.Value.Equal(e.WitnessDestination.Value) {
+		eq, err := spentOutput.Source.Value.Equal(e.WitnessDestination.Value)
+		if err != nil {
+			return err
+		}
+		if !eq {
 			return errors.WithDetailf(
 				errMismatchedValue,
 				"previous output is for %d unit(s) of %x, spend wants %d unit(s) of %x",
@@ -358,7 +362,11 @@ func checkValidSrc(vstate *validationState, vs *bc.ValueSource) error {
 		return errors.Wrapf(errMismatchedPosition, "value source position %d disagrees with %d", dest.Position, vstate.sourcePos)
 	}
 
-	if !dest.Value.Equal(vs.Value) {
+	eq, err := dest.Value.Equal(vs.Value)
+	if err != nil {
+		return errors.Sub(errMissingField, err)
+	}
+	if !eq {
 		return errors.Wrapf(errMismatchedValue, "source value %v disagrees with %v", dest.Value, vs.Value)
 	}
 
@@ -412,7 +420,11 @@ func checkValidDest(vs *validationState, vd *bc.ValueDestination) error {
 		return errors.Wrapf(errMismatchedPosition, "value destination position %d disagrees with %d", src.Position, vs.destPos)
 	}
 
-	if !src.Value.Equal(vd.Value) {
+	eq, err := src.Value.Equal(vd.Value)
+	if err != nil {
+		return errors.Sub(errMissingField, err)
+	}
+	if !eq {
 		return errors.Wrapf(errMismatchedValue, "destination value %v disagrees with %v", src.Value, vd.Value)
 	}
 


### PR DESCRIPTION
Guard against nil pointer dereferences.

Currently, the protocol/bc protos are only created from legacy.MapTx so
not all fields may be nil. There are probably more, but these are the
ones that the fuzz tester or I found.

Fix #983.