### PR TITLE
net/http/authz: standardize X.509 matching

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2978";
+	public final String Id = "main/rev2979";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2978"
+const ID string = "main/rev2979"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2978"
+export const rev_id = "main/rev2979"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2978".freeze
+	ID = "main/rev2979".freeze
 end

--- a/net/http/authz/tls.go
+++ b/net/http/authz/tls.go
@@ -1,0 +1,72 @@
+package authz
+
+import (
+	"crypto/x509/pkix"
+	"encoding/json"
+)
+
+// Same as crypto/x509/pkix.Name but with JSON tags.
+type pkixDN struct {
+	Country            []string `json:"C"`
+	Organization       []string `json:"O"`
+	OrganizationalUnit []string `json:"OU"`
+	Locality           []string `json:"L"`
+	Province           []string `json:"ST"`
+	StreetAddress      []string `json:"STREET"`
+	PostalCode         []string `json:"POSTALCODE"`
+	SerialNumber       string   `json:"SERIALNUMBER"`
+	CommonName         string   `json:"CN"`
+
+	Names      []pkix.AttributeTypeAndValue `json:"-"`
+	ExtraNames []pkix.AttributeTypeAndValue `json:"-"`
+}
+
+func x509GuardData(data []byte) pkix.Name {
+	var v struct{ Subject pkixDN }
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		// We should create only well-formed guard data,
+		// so this should not happen.
+		// (And if it does, it's our bug.)
+		panic(err)
+	}
+	return pkix.Name(v.Subject)
+}
+
+func encodeX509GuardData(subj pkix.Name) []byte {
+	v := struct {
+		Subject pkixDN `json:"subject"`
+	}{pkixDN(subj)}
+	d, _ := json.Marshal(v)
+	return d
+}
+
+func matchesX509(pat, x pkix.Name) bool {
+	return matchesString(pat.CommonName, x.CommonName) &&
+		matchesStrings(pat.Country, x.Country) &&
+		matchesStrings(pat.Organization, x.Organization) &&
+		matchesStrings(pat.OrganizationalUnit, x.OrganizationalUnit) &&
+		matchesStrings(pat.Locality, x.Locality) &&
+		matchesStrings(pat.Province, x.Province) &&
+		matchesStrings(pat.StreetAddress, x.StreetAddress) &&
+		matchesStrings(pat.PostalCode, x.PostalCode) &&
+		matchesString(pat.SerialNumber, x.SerialNumber)
+}
+
+func matchesStrings(pat, x []string) bool {
+	if len(pat) == 0 {
+		return true
+	} else if len(x) != len(pat) {
+		return false
+	}
+	for i, s := range x {
+		if s != pat[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesString(pat, x string) bool {
+	return pat == "" || pat == x
+}

--- a/net/http/authz/tls.go
+++ b/net/http/authz/tls.go
@@ -7,15 +7,15 @@ import (
 
 // Same as crypto/x509/pkix.Name but with JSON tags.
 type pkixDN struct {
-	Country            []string `json:"C"`
-	Organization       []string `json:"O"`
-	OrganizationalUnit []string `json:"OU"`
-	Locality           []string `json:"L"`
-	Province           []string `json:"ST"`
-	StreetAddress      []string `json:"STREET"`
-	PostalCode         []string `json:"POSTALCODE"`
-	SerialNumber       string   `json:"SERIALNUMBER"`
-	CommonName         string   `json:"CN"`
+	Country            []string `json:"C,omitempty"`
+	Organization       []string `json:"O,omitempty"`
+	OrganizationalUnit []string `json:"OU,omitempty"`
+	Locality           []string `json:"L,omitempty"`
+	Province           []string `json:"ST,omitempty"`
+	StreetAddress      []string `json:"STREET,omitempty"`
+	PostalCode         []string `json:"POSTALCODE,omitempty"`
+	SerialNumber       string   `json:"SERIALNUMBER,omitempty"`
+	CommonName         string   `json:"CN,omitempty"`
 
 	Names      []pkix.AttributeTypeAndValue `json:"-"`
 	ExtraNames []pkix.AttributeTypeAndValue `json:"-"`


### PR DESCRIPTION
Future work: update /create-authorization-grant to verify that the grant data is well-formed.