### PR TITLE
protocol/bc/legacy: remove TxData db methods

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2986";
+	public final String Id = "main/rev2987";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2986"
+const ID string = "main/rev2987"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2986"
+export const rev_id = "main/rev2987"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2986".freeze
+	ID = "main/rev2987".freeze
 end

--- a/protocol/bc/legacy/transaction.go
+++ b/protocol/bc/legacy/transaction.go
@@ -2,7 +2,6 @@ package legacy
 
 import (
 	"bytes"
-	"database/sql/driver"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -125,25 +124,6 @@ func (tx *TxData) UnmarshalText(p []byte) error {
 		return err
 	}
 	return tx.readFrom(blockchain.NewReader(b))
-}
-
-func (tx *TxData) Scan(val interface{}) error {
-	driverBuf, ok := val.([]byte)
-	if !ok {
-		return errors.New("Scan must receive a byte slice")
-	}
-	buf := make([]byte, len(driverBuf))
-	copy(buf[:], driverBuf)
-	return tx.readFrom(blockchain.NewReader(buf))
-}
-
-func (tx *TxData) Value() (driver.Value, error) {
-	b := new(bytes.Buffer)
-	_, err := tx.WriteTo(b)
-	if err != nil {
-		return nil, err
-	}
-	return b.Bytes(), nil
 }
 
 func (tx *TxData) readFrom(r *blockchain.Reader) error {


### PR DESCRIPTION
Remove TxData.Scan and TxData.Value. We never store individual
blockchain transactions in the database any more.