### PR TITLE
core/config: migrate access tokens to grants 

### DIFF
--- a/core/access_tokens.go
+++ b/core/access_tokens.go
@@ -52,7 +52,7 @@ func (a *API) createAccessToken(ctx context.Context, x struct{ ID, Type string }
 		// We've already returned if x.Type wasn't specified, so this must be a bad type.
 		return nil, accesstoken.ErrBadType
 	}
-	err = storeGrant(ctx, a.raftDB, grant)
+	err = authz.StoreGrant(ctx, a.raftDB, grant, grantPrefix)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -290,6 +290,7 @@ func tryGenerator(ctx context.Context, url, accessToken, blockchainID string) er
 
 // this almost certainly should live in another package
 func migrateAccessTokens(ctx context.Context, db pg.DB, rDB *raft.Service) error {
+	log.Printf(ctx, "MIGRATING ACCESS TOKENS")
 	const q = `SELECT id, type, created FROM access_tokens`
 	var tokens []*accesstoken.Token
 	err := pg.ForQueryRows(ctx, db, q, func(id string, maybeType libsql.NullString, created time.Time) {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -323,7 +323,7 @@ func migrateAccessTokens(ctx context.Context, db pg.DB, rDB *raft.Service) error
 		case "client":
 			grant.Policy = "client-readwrite"
 		case "network":
-			grant.Policy = "netowrk"
+			grant.Policy = "network"
 		}
 		err = authz.StoreGrant(ctx, rDB, grant, grantPrefix)
 		if err != nil {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -288,7 +288,8 @@ func tryGenerator(ctx context.Context, url, accessToken, blockchainID string) er
 	return nil
 }
 
-// this almost certainly should live in another package
+// TODO(tessr): make all of this atomic in raft, so we don't get halfway through
+// a postgres->raft migration and fail, losing the second half of the migration
 func migrateAccessTokens(ctx context.Context, db pg.DB, rDB *raft.Service) error {
 	log.Printf(ctx, "MIGRATING ACCESS TOKENS")
 	const q = `SELECT id, type, created FROM access_tokens`

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -291,7 +291,6 @@ func tryGenerator(ctx context.Context, url, accessToken, blockchainID string) er
 // TODO(tessr): make all of this atomic in raft, so we don't get halfway through
 // a postgres->raft migration and fail, losing the second half of the migration
 func migrateAccessTokens(ctx context.Context, db pg.DB, rDB *raft.Service) error {
-	log.Printf(ctx, "MIGRATING ACCESS TOKENS")
 	const q = `SELECT id, type, created FROM access_tokens`
 	var tokens []*accesstoken.Token
 	err := pg.ForQueryRows(ctx, db, q, func(id string, maybeType libsql.NullString, created time.Time) {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -308,7 +308,7 @@ func migrateAccessTokens(ctx context.Context, db pg.DB, rDB *raft.Service) error
 		}
 		guardData, err := json.Marshal(data)
 		if err != nil {
-			return errors.Wrap(err)
+			panic(err) // should never get here
 		}
 
 		var grant authz.Grant

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2995";
+	public final String Id = "main/rev2996";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2995"
+const ID string = "main/rev2996"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2995"
+export const rev_id = "main/rev2996"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2995".freeze
+	ID = "main/rev2996".freeze
 end

--- a/net/http/authz/grant.go
+++ b/net/http/authz/grant.go
@@ -1,4 +1,75 @@
 package authz
 
+import (
+	"bytes"
+	"context"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+
+	"chain/database/raft"
+	"chain/errors"
+)
+
 // Generate code for the Grant and GrantList types.
 //go:generate protoc -I. -I$CHAIN/.. --go_out=. grant.proto
+
+// StoreGrant stores a new grant in the provided raft store
+func StoreGrant(ctx context.Context, raftDB *raft.Service, grant Grant, grantPrefix string) error {
+	key := grantPrefix + grant.Policy
+	if grant.CreatedAt == "" {
+		grant.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	data, err := raftDB.Get(ctx, key)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	if data == nil {
+		// if there aren't any grants associated with this policy, go ahead
+		// and chuck this into raftdb
+		gList := &GrantList{
+			Grants: []*Grant{&grant},
+		}
+		val, err := proto.Marshal(gList)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+		// TODO(tessr): Make this safe for concurrent updates. Will likely require a
+		// conditional write operation for raftDB
+		err = raftDB.Set(ctx, key, val)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+		return nil
+	}
+
+	grantList := new(GrantList)
+	err = proto.Unmarshal(data, grantList)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	grants := grantList.Grants
+	for _, existing := range grants {
+		if existing.GuardType == grant.GuardType && bytes.Equal(existing.GuardData, grant.GuardData) {
+			// this grant already exists, return for idempotency
+			return nil
+		}
+	}
+
+	// create new grant and it append to the list of grants associated with this policy
+	grants = append(grants, &grant)
+	gList := &GrantList{Grants: grants}
+	val, err := proto.Marshal(gList)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	// TODO(tessr): Make this safe for concurrent updates. Will likely require a
+	// conditional write operation for raftDB
+	err = raftDB.Set(ctx, grantPrefix+grant.Policy, val)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
When a core migrates from 1.1 to 1.2, it will need to turn its access tokens into grants. When we start a core that needs to migrate its config table, we also migrate these access tokens. 

