### PR TITLE
desktop/windows: override home dir

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2996";
+	public final String Id = "main/rev2997";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2996"
+const ID string = "main/rev2997"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2996"
+export const rev_id = "main/rev2997"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2996".freeze
+	ID = "main/rev2997".freeze
 end


### PR DESCRIPTION
As of 338f54eb2dda298fcf3d6d0baa2c1f0d40c088b1, the
default home dir for cored is simply $HOME/.chaincore.
For a windows desktop install, it's better to use
LOCALAPPDATA.
    
This change also moves the Postgres data dir inside the
Chain Core home dir and improves support for older
versions of Windows.
