### PR TITLE
protocol: delete spent prevouts

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2989";
+	public final String Id = "main/rev2990";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2989"
+const ID string = "main/rev2990"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2989"
+export const rev_id = "main/rev2990"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2989".freeze
+	ID = "main/rev2990".freeze
 end

--- a/protocol/bc/legacy/map.go
+++ b/protocol/bc/legacy/map.go
@@ -31,12 +31,16 @@ func MapTx(oldTx *TxData) (txEntries *bc.Tx, err error) {
 		InputIDs: make([]bc.Hash, len(oldTx.Inputs)),
 	}
 
-	var (
-		nonceIDs       = make(map[bc.Hash]bool)
-		spentOutputIDs = make(map[bc.Hash]bool)
-		outputIDs      = make(map[bc.Hash]bool)
-	)
+	var results = make(map[bc.Hash]bool)
+	for _, h := range header.ResultIds {
+		results[*h] = true
+	}
 
+	var (
+		nonceIDs        = make(map[bc.Hash]bool)
+		spentOutputIDs  = make(map[bc.Hash]bool)
+		resultOutputIDs = make(map[bc.Hash]bool)
+	)
 	for id, e := range entries {
 		var ord uint64
 		switch e := e.(type) {
@@ -57,7 +61,9 @@ func MapTx(oldTx *TxData) (txEntries *bc.Tx, err error) {
 			// resume below after the switch
 
 		case *bc.Output:
-			outputIDs[id] = true
+			if _, ok := results[id]; ok {
+				resultOutputIDs[id] = true
+			}
 			continue
 
 		default:
@@ -75,8 +81,8 @@ func MapTx(oldTx *TxData) (txEntries *bc.Tx, err error) {
 	for id := range spentOutputIDs {
 		txEntries.SpentOutputIDs = append(txEntries.SpentOutputIDs, id)
 	}
-	for id := range outputIDs {
-		txEntries.OutputIDs = append(txEntries.OutputIDs, id)
+	for id := range resultOutputIDs {
+		txEntries.ResultOutputIDs = append(txEntries.ResultOutputIDs, id)
 	}
 
 	return txEntries, nil

--- a/protocol/bc/legacy/map.go
+++ b/protocol/bc/legacy/map.go
@@ -31,15 +31,9 @@ func MapTx(oldTx *TxData) (txEntries *bc.Tx, err error) {
 		InputIDs: make([]bc.Hash, len(oldTx.Inputs)),
 	}
 
-	var results = make(map[bc.Hash]bool)
-	for _, h := range header.ResultIds {
-		results[*h] = true
-	}
-
 	var (
-		nonceIDs        = make(map[bc.Hash]bool)
-		spentOutputIDs  = make(map[bc.Hash]bool)
-		resultOutputIDs = make(map[bc.Hash]bool)
+		nonceIDs       = make(map[bc.Hash]bool)
+		spentOutputIDs = make(map[bc.Hash]bool)
 	)
 	for id, e := range entries {
 		var ord uint64
@@ -60,12 +54,6 @@ func MapTx(oldTx *TxData) (txEntries *bc.Tx, err error) {
 			ord = e.Ordinal
 			// resume below after the switch
 
-		case *bc.Output:
-			if _, ok := results[id]; ok {
-				resultOutputIDs[id] = true
-			}
-			continue
-
 		default:
 			continue
 		}
@@ -80,9 +68,6 @@ func MapTx(oldTx *TxData) (txEntries *bc.Tx, err error) {
 	}
 	for id := range spentOutputIDs {
 		txEntries.SpentOutputIDs = append(txEntries.SpentOutputIDs, id)
-	}
-	for id := range resultOutputIDs {
-		txEntries.ResultOutputIDs = append(txEntries.ResultOutputIDs, id)
 	}
 
 	return txEntries, nil

--- a/protocol/bc/tx.go
+++ b/protocol/bc/tx.go
@@ -15,9 +15,9 @@ type Tx struct {
 	InputIDs []Hash // 1:1 correspondence with TxData.Inputs
 
 	// IDs of reachable entries of various kinds
-	NonceIDs       []Hash
-	SpentOutputIDs []Hash
-	OutputIDs      []Hash
+	NonceIDs        []Hash
+	SpentOutputIDs  []Hash
+	ResultOutputIDs []Hash
 }
 
 func (tx *Tx) SigHash(n uint32) (hash Hash) {

--- a/protocol/bc/tx.go
+++ b/protocol/bc/tx.go
@@ -5,7 +5,7 @@ import (
 	"chain/errors"
 )
 
-// TxEntries is a wrapper for the entries-based representation of a
+// Tx is a wrapper for the entries-based representation of a
 // transaction.  When we no longer need the legacy Tx and TxData
 // types, this will be renamed Tx.
 type Tx struct {
@@ -15,9 +15,8 @@ type Tx struct {
 	InputIDs []Hash // 1:1 correspondence with TxData.Inputs
 
 	// IDs of reachable entries of various kinds
-	NonceIDs        []Hash
-	SpentOutputIDs  []Hash
-	ResultOutputIDs []Hash
+	NonceIDs       []Hash
+	SpentOutputIDs []Hash
 }
 
 func (tx *Tx) SigHash(n uint32) (hash Hash) {

--- a/protocol/bc/tx.go
+++ b/protocol/bc/tx.go
@@ -5,9 +5,7 @@ import (
 	"chain/errors"
 )
 
-// Tx is a wrapper for the entries-based representation of a
-// transaction.  When we no longer need the legacy Tx and TxData
-// types, this will be renamed Tx.
+// Tx is a wrapper for the entries-based representation of a transaction.
 type Tx struct {
 	*TxHeader
 	ID       Hash

--- a/protocol/state/snapshot.go
+++ b/protocol/state/snapshot.go
@@ -89,7 +89,7 @@ func (s *Snapshot) ApplyTx(tx *bc.Tx) error {
 	}
 
 	// Add new outputs. They must not yet be present.
-	for _, o := range tx.OutputIDs {
+	for _, o := range tx.ResultOutputIDs {
 		err := s.Tree.Insert(o.Bytes())
 		if err != nil {
 			return err

--- a/protocol/state/snapshot.go
+++ b/protocol/state/snapshot.go
@@ -89,8 +89,15 @@ func (s *Snapshot) ApplyTx(tx *bc.Tx) error {
 	}
 
 	// Add new outputs. They must not yet be present.
-	for _, o := range tx.ResultOutputIDs {
-		err := s.Tree.Insert(o.Bytes())
+	for _, id := range tx.TxHeader.ResultIds {
+		// Ensure that this result is an output. It could be a retirement
+		// which should not be inserted into the state tree.
+		e := tx.Entries[*id]
+		if _, ok := e.(*bc.Output); !ok {
+			continue
+		}
+
+		err := s.Tree.Insert(id.Bytes())
 		if err != nil {
 			return err
 		}

--- a/protocol/state/snapshot_test.go
+++ b/protocol/state/snapshot_test.go
@@ -1,0 +1,48 @@
+package state
+
+import (
+	"testing"
+
+	"chain/protocol/bc"
+	"chain/protocol/bc/legacy"
+)
+
+func TestApplyTxSpend(t *testing.T) {
+	assetID := bc.AssetID{}
+	sourceID := bc.NewHash([32]byte{0x01, 0x02, 0x03})
+	sc := legacy.SpendCommitment{
+		AssetAmount:    bc.AssetAmount{AssetId: &assetID, Amount: 100},
+		SourceID:       sourceID,
+		SourcePosition: 0,
+		VMVersion:      1,
+		ControlProgram: nil,
+		RefDataHash:    bc.Hash{},
+	}
+	spentOutputID, err := legacy.ComputeOutputID(&sc)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snap := Empty()
+	snap.Tree.Insert(spentOutputID.Bytes())
+
+	tx, err := legacy.MapTx(&legacy.TxData{
+		Version: 1,
+		Inputs: []*legacy.TxInput{
+			legacy.NewSpendInput(nil, sourceID, assetID, 100, 0, nil, bc.Hash{}, nil),
+		},
+		Outputs: []*legacy.TxOutput{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Apply the spend transaction.
+	err = snap.ApplyTx(tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Tree.Contains(spentOutputID.Bytes()) {
+		t.Error("snapshot contains spent prevout")
+	}
+}


### PR DESCRIPTION
Remove spent prevouts from the state tree. Previously, we would
remove the prevouts but then immediately add them back.

Fix #1018