### PR TITLE
core: fix x509 guard data validation

### DIFF
--- a/core/grants.go
+++ b/core/grants.go
@@ -29,10 +29,14 @@ func (a *API) createGrant(ctx context.Context, x apiGrant) error {
 			return errMissingTokenID
 		}
 	} else if x.GuardType == "x509" {
-		for k := range x.GuardData {
-			if !authz.ValidX509SubjectField(k) {
-				return errors.WithDetail(httpjson.ErrBadRequest, "bad subject field "+k)
+		if subj, ok := x.GuardData["subject"].(map[string]interface{}); ok {
+			for k := range subj {
+				if !authz.ValidX509SubjectField(k) {
+					return errors.WithDetail(httpjson.ErrBadRequest, "bad subject field "+k)
+				}
 			}
+		} else {
+			return errors.WithDetail(httpjson.ErrBadRequest, "map of subject fields required")
 		}
 	}
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2997";
+	public final String Id = "main/rev2998";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2997"
+const ID string = "main/rev2998"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2997"
+export const rev_id = "main/rev2998"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2997".freeze
+	ID = "main/rev2998".freeze
 end


### PR DESCRIPTION
Previously, the check for bad subject fields was iterating through
the top-level "guard_data" object. We expect these fields to be
wrapped in a nested "subject" map.