### PR TITLE
core/generator: marshal block once

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -439,11 +439,8 @@ type remoteSigner struct {
 	Key    ed25519.PublicKey
 }
 
-func (s *remoteSigner) SignBlock(ctx context.Context, b *legacy.Block) (signature []byte, err error) {
-	// TODO(kr): We might end up serializing b multiple
-	// times in multiple calls to different remoteSigners.
-	// Maybe optimize that if it makes a difference.
-	err = s.Client.Call(ctx, "/rpc/signer/sign-block", b, &signature)
+func (s *remoteSigner) SignBlock(ctx context.Context, marshalledBlock []byte) (signature []byte, err error) {
+	err = s.Client.Call(ctx, "/rpc/signer/sign-block", string(marshalledBlock), &signature)
 	return
 }
 

--- a/core/generator/generator.go
+++ b/core/generator/generator.go
@@ -21,7 +21,7 @@ type BlockSigner interface {
 	// SignBlock returns an ed25519 signature over the block's sighash.
 	// See also the Chain Protocol spec for the complete required behavior
 	// of a block signer.
-	SignBlock(context.Context, *legacy.Block) (signature []byte, err error)
+	SignBlock(ctx context.Context, marshalledBlock []byte) (signature []byte, err error)
 }
 
 // Generator collects pending transactions and produces new blocks on

--- a/core/generator/generator_test.go
+++ b/core/generator/generator_test.go
@@ -126,7 +126,6 @@ func TestGetAndAddBlockSignaturesRace(t *testing.T) {
 	}
 
 	g := New(c, []BlockSigner{testSigner{nil, pubkey, privkey}}, nil)
-	g.latestBlock, g.latestSnapshot = c.State()
 
 	ctx := context.Background()
 	tip, snapshot, err := c.Recover(ctx)

--- a/core/generator/generator_test.go
+++ b/core/generator/generator_test.go
@@ -140,11 +140,17 @@ type testSigner struct {
 	privKey ed25519.PrivateKey
 }
 
-func (s testSigner) SignBlock(ctx context.Context, b *legacy.Block) ([]byte, error) {
+func (s testSigner) SignBlock(ctx context.Context, marshalledBlock []byte) ([]byte, error) {
 	if s.before != nil {
 		if err := s.before(); err != nil {
 			return nil, err
 		}
+	}
+
+	var b legacy.Block
+	err := b.UnmarshalText(marshalledBlock)
+	if err != nil {
+		return nil, err
 	}
 
 	hash := b.Hash()

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3038";
+	public final String Id = "main/rev3039";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3038"
+const ID string = "main/rev3039"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3038"
+export const rev_id = "main/rev3039"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3038".freeze
+	ID = "main/rev3039".freeze
 end


### PR DESCRIPTION
When requesting signatures, marshal the block once. Besides avoiding the
extra work of marshalling multiple times, this resolves the data race in 
https://github.com/chain/chain/issues/988#issuecomment-296818634

Tested locally by setting up and using a 2-of-2 network.