### PR TITLE
core/blocksigner: always lock block height

### DIFF
--- a/core/blocksigner/blocksigner.go
+++ b/core/blocksigner/blocksigner.go
@@ -50,6 +50,9 @@ func New(pub ed25519.PublicKey, hsm Signer, db pg.DB, c *protocol.Chain) *BlockS
 
 // SignBlock computes the signature for the block using
 // the private key in s.  It does not validate the block.
+//
+// This function fails if this node has ever signed a different
+// block at the same height as b.
 func (s *BlockSigner) SignBlock(ctx context.Context, b *legacy.Block) ([]byte, error) {
 	err := lockBlockHeight(ctx, s.db, b)
 	if err != nil {
@@ -69,9 +72,6 @@ func (s *BlockSigner) String() string {
 // ValidateAndSignBlock validates the given block against the current blockchain
 // and, if valid, computes and returns a signature for the block.  It
 // is used as the httpjson handler for /rpc/signer/sign-block.
-//
-// This function fails if this node has ever signed a different block at the
-// same height as b.
 func (s *BlockSigner) ValidateAndSignBlock(ctx context.Context, b *legacy.Block) ([]byte, error) {
 	err := <-s.c.BlockSoonWaiter(ctx, b.Height-1)
 	if err != nil {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2998";
+	public final String Id = "main/rev2999";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2998"
+const ID string = "main/rev2999"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2998"
+export const rev_id = "main/rev2999"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2998".freeze
+	ID = "main/rev2999".freeze
 end


### PR DESCRIPTION
Always lock the block height, even on the generator.
If the generator is a signer, it calls SignBlock directly instead of
ValidateAndSignBlock. Since the generator created the block, it's
safe to skip the validation. Previously, calling SignBlock directly
also skipped locking the block height in the `signed_blocks` table.

This change modifies the generator flow to also lock the block height.
The generator _should_ only generate one block at each height. Locking
the block height can help guarantee we don't violate that.

Also, currently on main there's a bug where anyone with network access
could call the sign-block RPC endpoint and get the generator to sign its
own alternative, valid next block. With this change at least that scenario
would be detected.  