### PR TITLE
core: return grant in create-grant API response

### DIFF
--- a/core/access_tokens.go
+++ b/core/access_tokens.go
@@ -52,7 +52,7 @@ func (a *API) createAccessToken(ctx context.Context, x struct{ ID, Type string }
 		// We've already returned if x.Type wasn't specified, so this must be a bad type.
 		return nil, accesstoken.ErrBadType
 	}
-	err = authz.StoreGrant(ctx, a.raftDB, grant, grantPrefix)
+	_, err = authz.StoreGrant(ctx, a.raftDB, grant, grantPrefix)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}

--- a/core/authz_test.go
+++ b/core/authz_test.go
@@ -61,7 +61,7 @@ func TestAuthz(t *testing.T) {
 			t.Fatal(err)
 		}
 		tokens[policies[i]] = token
-		err = api.createGrant(ctx, apiGrant{
+		_, err = api.createGrant(ctx, apiGrant{
 			GuardType: "access_token",
 			GuardData: map[string]interface{}{"id": token.ID},
 			Policy:    policies[i],

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -325,7 +325,7 @@ func migrateAccessTokens(ctx context.Context, db pg.DB, rDB *raft.Service) error
 		case "network":
 			grant.Policy = "network"
 		}
-		err = authz.StoreGrant(ctx, rDB, grant, grantPrefix)
+		_, err = authz.StoreGrant(ctx, rDB, grant, grantPrefix)
 		if err != nil {
 			return errors.Wrap(err)
 		}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev2999";
+	public final String Id = "main/rev3000";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev2999"
+const ID string = "main/rev3000"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev2999"
+export const rev_id = "main/rev3000"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev2999".freeze
+	ID = "main/rev3000".freeze
 end

--- a/net/http/authz/grant.go
+++ b/net/http/authz/grant.go
@@ -15,8 +15,7 @@ import (
 //go:generate protoc -I. -I$CHAIN/.. --go_out=. grant.proto
 
 // StoreGrant stores a new grant in the provided raft store
-func StoreGrant(ctx context.Context, raftDB *raft.Service, in Grant, grantPrefix string) (*Grant, error) {
-	grant := in
+func StoreGrant(ctx context.Context, raftDB *raft.Service, grant Grant, grantPrefix string) (*Grant, error) {
 	key := grantPrefix + grant.Policy
 	if grant.CreatedAt == "" {
 		grant.CreatedAt = time.Now().UTC().Format(time.RFC3339)

--- a/net/http/authz/grant.go
+++ b/net/http/authz/grant.go
@@ -15,14 +15,15 @@ import (
 //go:generate protoc -I. -I$CHAIN/.. --go_out=. grant.proto
 
 // StoreGrant stores a new grant in the provided raft store
-func StoreGrant(ctx context.Context, raftDB *raft.Service, grant Grant, grantPrefix string) error {
+func StoreGrant(ctx context.Context, raftDB *raft.Service, in Grant, grantPrefix string) (*Grant, error) {
+	grant := in
 	key := grantPrefix + grant.Policy
 	if grant.CreatedAt == "" {
 		grant.CreatedAt = time.Now().UTC().Format(time.RFC3339)
 	}
 	data, err := raftDB.Get(ctx, key)
 	if err != nil {
-		return errors.Wrap(err)
+		return nil, errors.Wrap(err)
 	}
 	if data == nil {
 		// if there aren't any grants associated with this policy, go ahead
@@ -32,28 +33,28 @@ func StoreGrant(ctx context.Context, raftDB *raft.Service, grant Grant, grantPre
 		}
 		val, err := proto.Marshal(gList)
 		if err != nil {
-			return errors.Wrap(err)
+			return nil, errors.Wrap(err)
 		}
 		// TODO(tessr): Make this safe for concurrent updates. Will likely require a
 		// conditional write operation for raftDB
 		err = raftDB.Set(ctx, key, val)
 		if err != nil {
-			return errors.Wrap(err)
+			return nil, errors.Wrap(err)
 		}
-		return nil
+		return &grant, nil
 	}
 
 	grantList := new(GrantList)
 	err = proto.Unmarshal(data, grantList)
 	if err != nil {
-		return errors.Wrap(err)
+		return nil, errors.Wrap(err)
 	}
 
 	grants := grantList.Grants
 	for _, existing := range grants {
 		if existing.GuardType == grant.GuardType && bytes.Equal(existing.GuardData, grant.GuardData) {
 			// this grant already exists, return for idempotency
-			return nil
+			return existing, nil
 		}
 	}
 
@@ -62,14 +63,14 @@ func StoreGrant(ctx context.Context, raftDB *raft.Service, grant Grant, grantPre
 	gList := &GrantList{Grants: grants}
 	val, err := proto.Marshal(gList)
 	if err != nil {
-		return errors.Wrap(err)
+		return nil, errors.Wrap(err)
 	}
 	// TODO(tessr): Make this safe for concurrent updates. Will likely require a
 	// conditional write operation for raftDB
 	err = raftDB.Set(ctx, grantPrefix+grant.Policy, val)
 	if err != nil {
-		return errors.Wrap(err)
+		return nil, errors.Wrap(err)
 	}
 
-	return nil
+	return &grant, nil
 }


### PR DESCRIPTION
This makes the `/create-authorization-grant` RPC consistent in behavior to all other `/create-`-prefixed endpoints.