### PR TITLE
core/txbuilder: remove the AssetAmount from a SigningInstruction

### DIFF
--- a/core/account/builder.go
+++ b/core/account/builder.go
@@ -154,12 +154,7 @@ func utxoToInputs(ctx context.Context, account *signers.Signer, u *utxo, refData
 ) {
 	txInput := legacy.NewSpendInput(nil, u.SourceID, u.AssetID, u.Amount, u.SourcePos, u.ControlProgram, u.RefDataHash, refData)
 
-	sigInst := &txbuilder.SigningInstruction{
-		AssetAmount: bc.AssetAmount{
-			AssetId: &u.AssetID,
-			Amount:  u.Amount,
-		},
-	}
+	sigInst := &txbuilder.SigningInstruction{}
 
 	path := signers.Path(account, signers.AccountKeySpace, u.ControlProgramIndex)
 	sigInst.AddWitnessKeys(account.XPubs, path, account.Quorum)

--- a/core/asset/builder.go
+++ b/core/asset/builder.go
@@ -58,7 +58,7 @@ func (a *issueAction) Build(ctx context.Context, builder *txbuilder.TemplateBuil
 
 	txin := legacy.NewIssuanceInput(nonce[:], a.Amount, a.ReferenceData, asset.InitialBlockHash, asset.IssuanceProgram, nil, assetdef)
 
-	tplIn := &txbuilder.SigningInstruction{AssetAmount: a.AssetAmount}
+	tplIn := &txbuilder.SigningInstruction{}
 	path := signers.Path(asset.Signer, signers.AssetKeySpace)
 	tplIn.AddWitnessKeys(asset.Signer.XPubs, path, asset.Signer.Quorum)
 

--- a/core/txbuilder/types.go
+++ b/core/txbuilder/types.go
@@ -36,14 +36,12 @@ func (t *Template) Hash(idx uint32) bc.Hash {
 
 // SigningInstruction gives directions for signing inputs in a TxTemplate.
 type SigningInstruction struct {
-	Position uint32 `json:"position"`
-	bc.AssetAmount
+	Position           uint32              `json:"position"`
 	SignatureWitnesses []*signatureWitness `json:"witness_components,omitempty"`
 }
 
 func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 	var pre struct {
-		bc.AssetAmount
 		Position           uint32 `json:"position"`
 		SignatureWitnesses []struct {
 			Type string
@@ -55,7 +53,6 @@ func (si *SigningInstruction) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	si.AssetAmount = pre.AssetAmount
 	si.Position = pre.Position
 	si.SignatureWitnesses = make([]*signatureWitness, 0, len(pre.SignatureWitnesses))
 	for i, w := range pre.SignatureWitnesses {

--- a/core/txbuilder/witness_test.go
+++ b/core/txbuilder/witness_test.go
@@ -47,12 +47,7 @@ func TestInferConstraints(t *testing.T) {
 }
 
 func TestWitnessJSON(t *testing.T) {
-	assetID := bc.NewAssetID([32]byte{0xff})
 	si := &SigningInstruction{
-		AssetAmount: bc.AssetAmount{
-			AssetId: &assetID,
-			Amount:  21,
-		},
 		Position: 17,
 		SignatureWitnesses: []*signatureWitness{
 			&signatureWitness{

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3002";
+	public final String Id = "main/rev3003";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3002"
+const ID string = "main/rev3003"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3002"
+export const rev_id = "main/rev3003"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3002".freeze
+	ID = "main/rev3003".freeze
 end

--- a/sdk/java/src/main/java/com/chain/api/Transaction.java
+++ b/sdk/java/src/main/java/com/chain/api/Transaction.java
@@ -390,17 +390,6 @@ public class Transaction {
      */
     public static class SigningInstruction {
       /**
-       * The id of the asset being issued or spent.
-       */
-      @SerializedName("asset_id")
-      public String assetID;
-
-      /**
-       * The number of units of the asset being issued or spent.
-       */
-      public long amount;
-
-      /**
        * The input's position in a transaction's list of inputs.
        */
       public int position;


### PR DESCRIPTION
Can it really be that we've had an unneeded `AssetAmount` in the `SigningInstruction` structure all this time?