### PR TITLE
core/generator: handle commit block failures

### DIFF
--- a/core/generator/generator.go
+++ b/core/generator/generator.go
@@ -98,27 +98,6 @@ func (g *Generator) Generate(
 ) {
 	g.latestBlock, g.latestSnapshot = recoveredBlock, recoveredSnapshot
 
-	// Check to see if we already have a pending, generated block.
-	// This can happen if the leader process exits between generating
-	// the block and committing the signed block to the blockchain.
-	b, err := getPendingBlock(ctx, g.db)
-	if err != nil {
-		log.Fatalkv(ctx, log.KeyError, err)
-	}
-	if b != nil && (g.latestBlock == nil || b.Height == g.latestBlock.Height+1) {
-		s := state.Copy(g.latestSnapshot)
-		err := s.ApplyBlock(legacy.MapBlock(b))
-		if err != nil {
-			log.Fatalkv(ctx, log.KeyError, err)
-		}
-
-		// g.commitBlock will update g.latestBlock and g.latestSnapshot.
-		err = g.commitBlock(ctx, b, s)
-		if err != nil {
-			log.Fatalkv(ctx, log.KeyError, err)
-		}
-	}
-
 	ticks := time.Tick(period)
 	for {
 		select {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3023";
+	public final String Id = "main/rev3024";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3023"
+const ID string = "main/rev3024"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3023"
+export const rev_id = "main/rev3024"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3023".freeze
+	ID = "main/rev3024".freeze
 end

--- a/protocol/prottest/block.go
+++ b/protocol/prottest/block.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"chain/crypto/ed25519"
 	"chain/protocol"
 	"chain/protocol/bc"
 	"chain/protocol/bc/legacy"
@@ -15,20 +16,36 @@ import (
 )
 
 var (
-	mutex  sync.Mutex // protects the following
-	states = make(map[*protocol.Chain]*state.Snapshot)
+	mutex         sync.Mutex // protects the following
+	states        = make(map[*protocol.Chain]*state.Snapshot)
+	blockPubkeys  = make(map[*protocol.Chain][]ed25519.PublicKey)
+	blockPrivkeys = make(map[*protocol.Chain][]ed25519.PrivateKey)
 )
 
-type Option func(*config)
+type Option func(testing.TB, *config)
 
 func WithStore(store protocol.Store) Option {
-	return func(conf *config) { conf.store = store }
+	return func(_ testing.TB, conf *config) { conf.store = store }
 }
 
 func WithOutputIDs(outputIDs ...bc.Hash) Option {
-	return func(conf *config) {
+	return func(_ testing.TB, conf *config) {
 		for _, oid := range outputIDs {
 			conf.initialState.Tree.Insert(oid.Bytes())
+		}
+	}
+}
+
+func WithBlockSigners(quorum, n int) Option {
+	return func(tb testing.TB, conf *config) {
+		conf.quorum = quorum
+		for i := 0; i < n; i++ {
+			pubkey, privkey, err := ed25519.GenerateKey(nil)
+			if err != nil {
+				testutil.FatalErr(tb, err)
+			}
+			conf.pubkeys = append(conf.pubkeys, pubkey)
+			conf.privkeys = append(conf.privkeys, privkey)
 		}
 	}
 }
@@ -36,6 +53,9 @@ func WithOutputIDs(outputIDs ...bc.Hash) Option {
 type config struct {
 	store        protocol.Store
 	initialState *state.Snapshot
+	pubkeys      []ed25519.PublicKey
+	privkeys     []ed25519.PrivateKey
+	quorum       int
 }
 
 // NewChain makes a new Chain. By default it uses a memstore for
@@ -46,11 +66,11 @@ type config struct {
 func NewChain(tb testing.TB, opts ...Option) *protocol.Chain {
 	conf := config{store: memstore.New(), initialState: state.Empty()}
 	for _, opt := range opts {
-		opt(&conf)
+		opt(tb, &conf)
 	}
 
 	ctx := context.Background()
-	b1, err := protocol.NewInitialBlock(nil, 0, time.Now())
+	b1, err := protocol.NewInitialBlock(conf.pubkeys, conf.quorum, time.Now())
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
@@ -64,6 +84,13 @@ func NewChain(tb testing.TB, opts ...Option) *protocol.Chain {
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
+
+	// save block-signing keys in global state
+	mutex.Lock()
+	blockPubkeys[c] = conf.pubkeys
+	blockPrivkeys[c] = conf.privkeys
+	mutex.Unlock()
+
 	return c
 }
 
@@ -75,6 +102,14 @@ func Initial(tb testing.TB, c *protocol.Chain) *legacy.Block {
 		testutil.FatalErr(tb, err)
 	}
 	return b1
+}
+
+// BlockKeyPairs returns the configured block-signing key-pairs
+// for the provided Chain.
+func BlockKeyPairs(c *protocol.Chain) ([]ed25519.PublicKey, []ed25519.PrivateKey) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	return blockPubkeys[c], blockPrivkeys[c]
 }
 
 // MakeBlock makes a new block from txs, commits it, and returns it.


### PR DESCRIPTION
Handle failures to commit blocks gracefully. Previously, the generator
could get stuck requiring a restart to make progress.

Fix #1034.