### PR TITLE
protocol/validation: use subtests

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3008";
+	public final String Id = "main/rev3009";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3008"
+const ID string = "main/rev3009"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3008"
+export const rev_id = "main/rev3009"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3008".freeze
+	ID = "main/rev3009".freeze
 end

--- a/protocol/validation/validation_test.go
+++ b/protocol/validation/validation_test.go
@@ -336,7 +336,7 @@ func TestTxValidation(t *testing.T) {
 		},
 	}
 
-	for i, c := range cases {
+	for _, c := range cases {
 		t.Run(c.desc, func(t *testing.T) {
 			fixture = sample(t, nil)
 			tx = legacy.NewTx(*fixture.tx).Tx
@@ -354,7 +354,7 @@ func TestTxValidation(t *testing.T) {
 			}
 			err := checkValid(vs, tx.TxHeader)
 			if rootErr(err) != c.err {
-				t.Errorf("case %d (%s): got error %s, want %s; validationState is:\n%s", i, c.desc, err, c.err, spew.Sdump(vs))
+				t.Errorf("got error %s, want %s; validationState is:\n%s", err, c.err, spew.Sdump(vs))
 			}
 		})
 	}
@@ -392,7 +392,7 @@ func TestBlockHeaderValid(t *testing.T) {
 			}
 			err := checkValidBlockHeader(&bh)
 			if err != c.err {
-				t.Errorf("case %d: got error %s, want %s; bh is:\n%s", i, err, c.err, spew.Sdump(bh))
+				t.Errorf("got error %s, want %s; bh is:\n%s", err, c.err, spew.Sdump(bh))
 			}
 		})
 	}


### PR DESCRIPTION
Use t.Run in validation tests. Most of the validation tests have
convenient descriptions in the test case struct already.