### PR TITLE
core: convert info's configured_at property to RFC3339

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -92,10 +92,15 @@ func (a *API) leaderInfo(ctx context.Context) (map[string]interface{}, error) {
 		}
 	}
 
+	var (
+		configuredAtSecs  int64 = int64(a.config.ConfiguredAt / 1000)
+		configuredAtNSecs int64 = int64((a.config.ConfiguredAt % 1000) * 1e6)
+	)
+
 	m := map[string]interface{}{
 		"state":                             a.leader.State().String(),
 		"is_configured":                     true,
-		"configured_at":                     a.config.ConfiguredAt,
+		"configured_at":                     time.Unix(configuredAtSecs, configuredAtNSecs).UTC(),
 		"is_signer":                         a.config.IsSigner,
 		"is_generator":                      a.config.IsGenerator,
 		"generator_url":                     a.config.GeneratorUrl,

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3009";
+	public final String Id = "main/rev3010";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3009"
+const ID string = "main/rev3010"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3009"
+export const rev_id = "main/rev3010"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3009".freeze
+	ID = "main/rev3010".freeze
 end


### PR DESCRIPTION
The SDKs expect /info to return the `configured_at` property as an
RFC3339, but recent changes had converted it to millisecond Unixtime.
This PR restores the original format.