### PR TITLE
core: remove authz workaround

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -264,11 +264,6 @@ func AuthHandler(handler http.Handler, rDB *raft.Service, accessTokens *accessto
 		}
 
 		err = authorizer.Authorize(req)
-		if errors.Root(err) == authz.ErrNotAuthorized {
-			// TODO(kr): remove this workaround once dashboard
-			// knows how to handle ErrNotAuthorized (CH011).
-			err = errors.Sub(errNotAuthenticated, err)
-		}
 		if err != nil {
 			errorFormatter.Write(req.Context(), rw, err)
 			return

--- a/core/authz_test.go
+++ b/core/authz_test.go
@@ -173,5 +173,5 @@ func tryRPC(t testing.TB, baseURL, path string, token *accesstoken.Token) bool {
 		t.Fatal("unexpected 500 error")
 	}
 
-	return resp.StatusCode != http.StatusUnauthorized
+	return resp.StatusCode != http.StatusForbidden
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3015";
+	public final String Id = "main/rev3016";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3015"
+const ID string = "main/rev3016"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3015"
+export const rev_id = "main/rev3016"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3015".freeze
+	ID = "main/rev3016".freeze
 end


### PR DESCRIPTION
This workaround, returning HTTP 401 instead of 403,
turns out not to be ideal, since dashboard has behavior
for 401 we don't want here. We decided to update
dashboard in a followup, but for now we can remove
this so at least we're returning the correct status.