### PR TITLE
core: remove req path / from policy public

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -193,6 +193,7 @@ func main() {
 	mux.Handle("/", &coreHandler)
 
 	var handler http.Handler = mux
+	handler = core.RedirectHandler(handler)
 	handler = core.AuthHandler(handler, raftDB, accessTokens, internalDN)
 	handler = reqid.Handler(handler)
 

--- a/core/api.go
+++ b/core/api.go
@@ -194,7 +194,6 @@ func (a *API) buildHandler() {
 
 	handler := maxBytes(latencyHandler) // TODO(tessr): consider moving this to non-core specific mux
 	handler = webAssetsHandler(handler)
-	handler = redirectHandler(handler)
 	handler = healthHandler(handler)
 	for _, l := range a.requestLimits {
 		handler = limit.Handler(handler, alwaysError(errRateLimited), l.perSecond, l.burst, l.key)
@@ -298,7 +297,8 @@ func blockchainIDHandler(handler http.Handler, blockchainID string) http.Handler
 	})
 }
 
-func redirectHandler(next http.Handler) http.Handler {
+// RedirectHandler redirects / to /dashboard/.
+func RedirectHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/" {
 			http.Redirect(w, req, "/dashboard/", http.StatusFound)

--- a/core/authz.go
+++ b/core/authz.go
@@ -64,7 +64,6 @@ var policyByRoute = map[string][]string{
 	"/raft/join": {"internal"},
 	"/raft/msg":  {"internal"},
 
-	"/":           {"public"}, // TODO(kr): remove this line dashboard redirect happens outside authz
 	"/dashboard":  {"public"},
 	"/dashboard/": {"public"},
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3017";
+	public final String Id = "main/rev3018";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3017"
+const ID string = "main/rev3018"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3017"
+export const rev_id = "main/rev3018"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3017".freeze
+	ID = "main/rev3018".freeze
 end


### PR DESCRIPTION
The matching rules for policies are the same as for
ServeMux: it treats a pattern ending in / as a prefix.
Adding / to the table not only matches the exact request
path /, but any other path not reflected in the table.
Putting policy public on that pattern therefore allows
any unauthenticated request to any path we may have
inadvertently left out of the table. It is safer to
"fail closed" -- to reject missing paths.

Redirecting / to /dashboard/ entirely outside of authz
lets us avoid adding this pattern to the policy table.