### PR TITLE
cmd/cored: avoid spurious 404 responses

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3014";
+	public final String Id = "main/rev3015";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3014"
+const ID string = "main/rev3015"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3014"
+export const rev_id = "main/rev3015"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3014".freeze
+	ID = "main/rev3015".freeze
 end


### PR DESCRIPTION
The chain/core API object depends on reading a config
object during startup, and reading the config object
depends on reading from raft storage, which in turn
depends on handling HTTP requests. We previously handled
this by adding the API handler to the mux after setup.
This caused us to respond 404 to any non-raft request
received during the brief startup time.

Now, we install a handler in the mux immediately, but
synchronized with the API handler, so it blocks until
the API handler is ready. This should provide the
correct behavior for all HTTP responses at all times.

In the future, we might investigate lazily loading the
config object to avoid this awkward data dependency
sequence altogether.

Fixes #1053.