### PR TITLE
cmd/cored: enforce TLS without build tag plain_http

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,7 @@ There are four build tags that change the behavior of the resulting binary:
   - `reset`: allows the core database to be reset through the api
   - `loopback_auth`: allows unauthenticated requests on the loopback device
   - `no_mockhsm`: disables the MockHSM provided for development
-  - `plain_http`: allows plain HTTP requests (not yet implemented)
+  - `plain_http`: allows plain HTTP requests
 
 ```
 $ git clone https://github.com/chain/chain $CHAIN

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -76,8 +76,7 @@ var (
 	buildCommit = "?"
 	buildDate   = "?"
 
-	race          []interface{} // initialized in race.go
-	httpsRedirect = true        // initialized in plain_http.go
+	race []interface{} // initialized in race.go
 
 	// By default, a core is not able to reset its data.
 	// This feature can be turned on with the reset build tag.
@@ -121,6 +120,7 @@ func main() {
 	fmt.Printf("mockhsm: %t\n", config.BuildConfig.MockHSM)
 	fmt.Printf("loopback-auth: %t\n", config.BuildConfig.LoopbackAuth)
 	fmt.Printf("reset: %t\n", config.BuildConfig.Reset)
+	fmt.Printf("plain_http: %t\n", config.BuildConfig.PlainHTTP)
 
 	if *v {
 		return
@@ -198,7 +198,7 @@ func main() {
 	handler = reqid.Handler(handler)
 
 	secureheader.DefaultConfig.PermitClearLoopback = true
-	secureheader.DefaultConfig.HTTPSRedirect = httpsRedirect
+	secureheader.DefaultConfig.HTTPSRedirect = false
 	secureheader.DefaultConfig.Next = handler
 
 	server := &http.Server{
@@ -271,7 +271,7 @@ func maybeUseTLS(ln net.Listener) (net.Listener, *tls.Config, error) {
 		filepath.Join(home, "tls.key"),
 		*rootCAs,
 	)
-	if err == core.ErrNoTLS {
+	if err == core.ErrNoTLS && config.BuildConfig.PlainHTTP {
 		return ln, nil, nil // files & env vars don't exist; don't want TLS
 	} else if err != nil {
 		return nil, nil, err

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -266,7 +266,7 @@ func main() {
 // will be returned. Otherwise the second return arg will
 // be nil.
 func maybeUseTLS(ln net.Listener) (net.Listener, *tls.Config, error) {
-	config, err := core.TLSConfig(
+	c, err := core.TLSConfig(
 		filepath.Join(home, "tls.crt"),
 		filepath.Join(home, "tls.key"),
 		*rootCAs,
@@ -276,8 +276,8 @@ func maybeUseTLS(ln net.Listener) (net.Listener, *tls.Config, error) {
 	} else if err != nil {
 		return nil, nil, err
 	}
-	ln = tls.NewListener(ln, config)
-	return ln, config, nil
+	ln = tls.NewListener(ln, c)
+	return ln, c, nil
 }
 
 func launchConfiguredCore(ctx context.Context, raftDB *raft.Service, db *sql.DB, conf *config.Config, processID string, opts ...core.RunOption) http.Handler {

--- a/cmd/cored/plain_http.go
+++ b/cmd/cored/plain_http.go
@@ -2,16 +2,15 @@
 
 package main
 
+import "chain/core/config"
+
 /*
-
-The secureheader package redirects requests made with http to the
-equivalent https URL. This file exposes a build tag to turn
-that functionality off. The functionality will stay on by default. This
-will be useful for chain core developer edition. Users will be able to
-connect to a chain core without a needing a TLS cert.
-
+This file exposes a build tag to permit plaintext (non-TLS) HTTP.
+TLS will be required by default. Disabling TLS will be useful for
+chain core developer edition. Users will be able to connect to a
+chain core without a needing a TLS cert.
 */
 
 func init() {
-	httpsRedirect = false
+	config.BuildConfig.PlainHTTP = true
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -52,10 +52,12 @@ var (
 		LoopbackAuth bool `json:"is_loopback_auth"`
 		MockHSM      bool `json:"is_mockhsm"`
 		Reset        bool `json:"is_reset"`
+		PlainHTTP    bool `json:"is_plain_http"`
 	}{
 		LoopbackAuth: false,
 		MockHSM:      true,
 		Reset:        false,
+		PlainHTTP:    false,
 	}
 )
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3019";
+	public final String Id = "main/rev3020";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3019"
+const ID string = "main/rev3020"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3019"
+export const rev_id = "main/rev3020"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3019".freeze
+	ID = "main/rev3020".freeze
 end


### PR DESCRIPTION
With this change, TLS will be required by default, and can be made optional with build tag plain_http. Our intention is to require TLS internally during development (hence why the default build configuration is to require it) and for production, but not to require TLS for desktop builds (Mac OS X and Windows).

This change also unconditionally sets the secureheader field HTTPSRedirect to false. Chain Core never listens on both TLS and non-TLS ports simultaneously, so it is pointless to ever set this field to true. Doing so was a longstanding mistake, which we might as well fix now.

Future work: consider renaming plain_http to plain_http_ok to better reflect that TLS is optional (not prohibited) in that configuration.