### PR TITLE
protocol/prottest: use option funcs

### DIFF
--- a/core/account/reserve_test.go
+++ b/core/account/reserve_test.go
@@ -8,7 +8,6 @@ import (
 	"chain/database/pg/pgtest"
 	"chain/protocol/bc"
 	"chain/protocol/prottest"
-	"chain/protocol/prottest/memstore"
 )
 
 const sampleAccountUTXOs = `
@@ -37,7 +36,7 @@ func TestCancelReservation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c := prottest.NewChainWithStorage(t, memstore.New(), outid)
+	c := prottest.NewChain(t, prottest.WithOutputIDs(outid))
 
 	utxoDB := newReserver(db, c, nil)
 	res, err := utxoDB.ReserveUTXO(ctx, outid, nil, time.Now())

--- a/core/recovery_test.go
+++ b/core/recovery_test.go
@@ -41,7 +41,7 @@ func TestRecovery(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	dbURL, db := pgtest.NewDB(t, pgtest.SchemaPath)
 	store := txdb.NewStore(db)
-	c := prottest.NewChainWithStorage(t, store)
+	c := prottest.NewChain(t, prottest.WithStore(store))
 	g := generator.New(c, nil, db)
 	pinStore := pin.NewStore(db)
 	coretest.CreatePins(ctx, t, pinStore)

--- a/core/rpc_test.go
+++ b/core/rpc_test.go
@@ -15,7 +15,7 @@ func TestGetBlock(t *testing.T) {
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
 	ctx := context.Background()
 	store := txdb.NewStore(db)
-	chain := prottest.NewChainWithStorage(t, store)
+	chain := prottest.NewChain(t, prottest.WithStore(store))
 	api := &API{chain: chain, store: store}
 
 	block, err := api.getBlockRPC(ctx, 1)

--- a/core/txbuilder/finalize_test.go
+++ b/core/txbuilder/finalize_test.go
@@ -19,7 +19,6 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/bc/legacy"
 	"chain/protocol/prottest"
-	"chain/protocol/prottest/memstore"
 	"chain/protocol/state"
 	"chain/protocol/vm"
 	"chain/testutil"
@@ -345,7 +344,7 @@ func benchGenBlock(b *testing.B) {
 	b.StopTimer()
 
 	ctx := context.Background()
-	c := prottest.NewChainWithStorage(b, memstore.New())
+	c := prottest.NewChain(b)
 	g := generator.New(c, nil, pgtest.NewTx(b))
 
 	var tx1, tx2 legacy.Tx

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3020";
+	public final String Id = "main/rev3021";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3020"
+const ID string = "main/rev3021"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3020"
+export const rev_id = "main/rev3021"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3020".freeze
+	ID = "main/rev3021".freeze
 end

--- a/protocol/prottest/block.go
+++ b/protocol/prottest/block.go
@@ -19,30 +19,47 @@ var (
 	states = make(map[*protocol.Chain]*state.Snapshot)
 )
 
-// NewChain makes a new Chain using memstore for storage,
-// along with an initial block using a 0/0 multisig program.
-// It commits the initial block before returning the Chain.
-func NewChain(tb testing.TB) *protocol.Chain {
-	return NewChainWithStorage(tb, memstore.New())
+type Option func(*config)
+
+func WithStore(store protocol.Store) Option {
+	return func(conf *config) { conf.store = store }
 }
 
-// NewChainWithStorage makes a new Chain using store for storage, along
-// with an initial block using a 0/0 multisig program.
+func WithOutputIDs(outputIDs ...bc.Hash) Option {
+	return func(conf *config) {
+		conf.outputIDs = append(conf.outputIDs, outputIDs...)
+	}
+}
+
+type config struct {
+	store     protocol.Store
+	outputIDs []bc.Hash
+}
+
+// NewChain makes a new Chain. By default it uses a memstore for
+// storage and creates an initial block using a 0/0 multisig program.
 // It commits the initial block before returning the Chain.
-func NewChainWithStorage(tb testing.TB, store protocol.Store, outputIDs ...bc.Hash) *protocol.Chain {
+//
+// Its defaults may be overriden by providing Options.
+func NewChain(tb testing.TB, opts ...Option) *protocol.Chain {
+	conf := config{store: memstore.New()}
+	for _, opt := range opts {
+		opt(&conf)
+	}
+
 	ctx := context.Background()
 	b1, err := protocol.NewInitialBlock(nil, 0, time.Now())
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
-	c, err := protocol.NewChain(ctx, b1.Hash(), store, nil)
+	c, err := protocol.NewChain(ctx, b1.Hash(), conf.store, nil)
 	if err != nil {
 		testutil.FatalErr(tb, err)
 	}
 	c.MaxIssuanceWindow = 48 * time.Hour // TODO(tessr): consider adding MaxIssuanceWindow to NewChain
 
 	s := state.Empty()
-	for _, outputID := range outputIDs {
+	for _, outputID := range conf.outputIDs {
 		s.Tree.Insert(outputID.Bytes())
 	}
 


### PR DESCRIPTION
Use option functions for configuration in NewChain.
In #1046, I'd like to add an Option for configuring the
initial block program's quorum.