### PR TITLE
sdk/node: sanitize X509 guard data

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3024";
+	public final String Id = "main/rev3025";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3024"
+const ID string = "main/rev3025"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3024"
+export const rev_id = "main/rev3025"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3024".freeze
+	ID = "main/rev3025".freeze
 end

--- a/sdk/node/src/api/authorizationGrants.js
+++ b/sdk/node/src/api/authorizationGrants.js
@@ -1,4 +1,5 @@
 const shared = require('../shared')
+const util = require('../util')
 
 /**
  * Authorization grants provide a mapping from guard objects (access tokens or X509
@@ -13,16 +14,16 @@ const shared = require('../shared')
  * @typedef {Object} AuthorizationGrant
  * @global
  *
- * @property {String} guard_type
+ * @property {String} guardType
  * Type of credential, either 'access_token' or 'x509'.
  *
- * @property {Object} guard_data
+ * @property {Object} guardData
  * Data used by the guard to identity incoming credentials.
  *
- * If guard_type is 'access_token', you should provide an instance of
+ * If guardType is 'access_token', you should provide an instance of
  * {@link module:AuthorizationGrantsApi~AccessTokenGuardData}, which identifies access tokens by ID.
  *
- * If guard_type is 'x509', you should provide an instance of {@link module:AuthorizationGrantsApi~X509GuardData},
+ * If guardType is 'x509', you should provide an instance of {@link module:AuthorizationGrantsApi~X509GuardData},
  * which identifies x509 certificates based on kev-value pairs in specified
  * certificate fields.
  *
@@ -49,40 +50,54 @@ const authorizationGrants = (client) => ({
 
   /**
    * @typedef {Object} X509GuardData
-   * x509 certificates can be identified by any field. As an example, the
-   * properties on this type document the `subject` field below:
-   *
-   * ```
-   * CN=Alice, OU=Engineering
-   * ```
-   *
-   * Fields other than `subject`, and keys other than `cn` and `ou`, can
-   * be addressed in a similar manner.
+   * x509 certificates are identified by their Subject attribute. You can
+   * configure the guard by specifying values for the Subject's sub-attributes,
+   * such as CN or OU. If a certificate's Subject contains all of the
+   * sub-attribute values specified in the guard, the guard will produce a
+   * positive match.
    *
    * @property {Object} subject - Object identifying key-value pairs in the subject field.
-   * @property {String} subject.cn - "Common Name" to match against.
-   * @property {String} subject.ou - "Organizational Unit" to match against.
+   * @property {(String|Array)} subject.C - Country attribute
+   * @property {(String|Array)} subject.O - Organization attribute
+   * @property {(String|Array)} subject.OU - Organizational Unit attribute
+   * @property {(String|Array)} subject.L - Locality attribute
+   * @property {(String|Array)} subject.ST - State/Province attribute
+   * @property {(String|Array)} subject.STREET - Street Address attribute
+   * @property {(String|Array)} subject.POSTALCODE - Postal Code attribute
+   * @property {String} subject.SERIALNUMBER - Serial Number attribute
+   * @property {String} subject.CN - Common Name attribute
    */
 
   /**
    * Create a new access grant.
    *
    * @param {Object} params - Parameters for access grant creation.
-   * @param {String} params.guard_type - Type of credential to guard with, either 'access_token' or 'x509'.
-   * @param {Object} params.guard_data - Object containing data needed to identify the incoming credential.
+   * @param {String} params.guardType - Type of credential to guard with, either 'access_token' or 'x509'.
+   * @param {Object} params.guardData - Object containing data needed to identify the incoming credential.
    * @param {String} params.policy - Authorization polciy to attach to specific grant. See {@link AuthorizationGrant} for a list of available policiies.
    * @param {objectCallback} [callback] - Optional callback. Use instead of Promise return value as desired.
    * @returns {Promise<Object>} Success message or error.
    */
-  create: (params , cb) =>
-    shared.create(client, '/create-authorization-grant', params, {skipArray: true, cb}),
+  create: (params, cb) => {
+    params = Object.assign({}, params)
+    if (params.guardType == 'x509') {
+      params.guardData = util.sanitizeX509GuardData(params.guardData)
+    }
+
+    return shared.create(
+      client,
+      '/create-authorization-grant',
+      params,
+      {skipArray: true, cb}
+    )
+  },
 
   /**
    * Delete the specfiied access grant.
    *
    * @param {Object} params - Parameters for access grant deletion.
-   * @param {String} params.guard_type - Type of credential to delete, either 'access_token' or 'x509'.
-   * @param {Object} params.guard_data - Object containing data needed to identify the credential to be removed.
+   * @param {String} params.guardType - Type of credential to delete, either 'access_token' or 'x509'.
+   * @param {Object} params.guardData - Object containing data needed to identify the credential to be removed.
    * @param {String} params.policy - Authorization policy to remove. See {@link AuthorizationGrant} for a list of available policiies.
    * @param {objectCallback} [callback] - Optional callback. Use instead of Promise return value as desired.
    * @returns {Promise<Object>} Success message or error.

--- a/sdk/node/src/connection.js
+++ b/sdk/node/src/connection.js
@@ -20,6 +20,11 @@ const snakeize = (object) => {
     let value = object[key]
     let newKey = key
 
+    // Skip all-caps keys
+    if (/^[A-Z]+$/.test(key)) {
+      continue
+    }
+
     if (/[A-Z]/.test(key)) {
       newKey = key.replace(/([A-Z])/g, v => `_${v.toLowerCase()}`)
       delete object[key]

--- a/sdk/node/src/util.js
+++ b/sdk/node/src/util.js
@@ -1,0 +1,42 @@
+const x509SubjectAttributes = {
+  C: {array: true},
+  O: {array: true},
+  OU: {array: true},
+  L: {array: true},
+  ST: {array: true},
+  STREET: {array: true},
+  POSTALCODE: {array: true},
+  SERIALNUMBER: {array: false},
+  CN: {array: false},
+}
+
+const sanitizeX509GuardData = guardData => {
+  const keys = Object.keys(guardData)
+  if (keys.length !== 1 || keys[0].toLowerCase() !== 'subject') {
+    throw new Error('X509 guard data must contain exactly one key, "subject"')
+  }
+
+  const newSubject = {}
+  const oldSubject = Object.values(guardData)[0]
+  for (let k in oldSubject) {
+    const attrib = x509SubjectAttributes[k.toUpperCase()]
+    if (!attrib) {
+      throw new Error(`X509 guard data contains invalid subject attribute: ${k}`)
+    }
+
+    let v = oldSubject[k]
+    if (!attrib.array && Array.isArray(v)) {
+      throw new Error(`X509 guard data contains invalid array for attribute ${k}: ${v.toString()}`)
+    } else if (attrib.array && !Array.isArray(v)) {
+      newSubject[k] = [v]
+    } else {
+      newSubject[k] = v
+    }
+  }
+
+  return {subject: newSubject}
+}
+
+module.exports = {
+  sanitizeX509GuardData,
+}

--- a/sdk/node/test/camelSnake.js
+++ b/sdk/node/test/camelSnake.js
@@ -35,6 +35,18 @@ describe('camelizer', () => {
     expect(camelized.referenceData.dont_convert).equals(2)
     expect(camelized.referenceData.dontConvert).equals(undefined)
   })
+
+  it('does not convert all-caps keys', () => {
+    expect(
+      Connection.camelize({
+        convert_me: 1,
+        DONTCONVERTME: 1,
+      })
+    ).deep.equals({
+      convertMe: 1,
+      DONTCONVERTME: 1,
+    })
+  })
 })
 
 describe('snakeizer', () => {
@@ -66,5 +78,17 @@ describe('snakeizer', () => {
     expect(snakeized.test_leaf).equals(1)
     expect(snakeized.reference_data.dontConvert).equals(2)
     expect(snakeized.reference_data.dont_Convert).equals(undefined)
+  })
+
+  it('does not convert all-caps keys', () => {
+    expect(
+      Connection.snakeize({
+        convertMe: 1,
+        DONTCONVERTME: 1,
+      })
+    ).deep.equals({
+      convert_me: 1,
+      DONTCONVERTME: 1,
+    })
   })
 })

--- a/sdk/node/test/promises.js
+++ b/sdk/node/test/promises.js
@@ -861,5 +861,34 @@ describe('Promise style', () => {
         assert(missing)
       })
     })
+
+    it('sanitizes X509 guard data', () =>
+      expect(
+        client.authorizationGrants.create({
+          guardType: 'x509',
+          guardData: {
+            subject: {
+              cn: tokenName,
+              ou: 'test-ou',
+            },
+          },
+          policy: 'client-readwrite'
+        })
+      ).to.be.fulfilled
+      .then(g => {
+        delete g.createdAt // ignore timestamp
+
+        expect(g).deep.equals({
+          guardType: 'x509',
+          guardData: {
+            subject: {
+              cn: tokenName,
+              ou: ['test-ou'],
+            }
+          },
+          policy: 'client-readwrite'
+        })
+      })
+    )
   })
 })

--- a/sdk/node/test/util.js
+++ b/sdk/node/test/util.js
@@ -1,0 +1,86 @@
+/* eslint-env mocha */
+
+const expect = require('chai').expect
+const util = require('../dist/util')
+
+describe('util package', () => {
+
+  describe('sanitizeX509GuardData', () => {
+
+    it('arrayifies attributes', () => {
+      expect(
+        util.sanitizeX509GuardData({
+          subject: {
+            C: 'foo',
+            O: 'foo',
+            OU: 'foo',
+            L: 'foo',
+            ST: 'foo',
+            STREET: 'foo',
+            POSTALCODE: 'foo',
+            SERIALNUMBER: 'foo',
+            CN: 'foo',
+          }
+        })
+      ).deep.equals(
+        {
+          subject: {
+            C: ['foo'],
+            O: ['foo'],
+            OU: ['foo'],
+            L: ['foo'],
+            ST: ['foo'],
+            STREET: ['foo'],
+            POSTALCODE: ['foo'],
+            SERIALNUMBER: 'foo',
+            CN: 'foo',
+          }
+        }
+      )
+    })
+
+    describe('error cases', () => {
+
+      it('throws an error if there are multiple top-level attributes', () => {
+        expect(() => {
+          util.sanitizeX509GuardData({
+            subject: {},
+            foobar: {},
+          })
+        }).to.throw(Error)
+      })
+
+      it('throws an error if there is a top-level field that is not "subject"', () => {
+        expect(() => {
+          util.sanitizeX509GuardData({
+            foobar: {},
+          })
+        }).to.throw(Error)
+      })
+
+      it('throws an error if there are invalid subject attributes', () => {
+        expect(() => {
+          util.sanitizeX509GuardData({
+            subject: {
+              C: 'valid',
+              Foo: 'invalid',
+            },
+          })
+        }).to.throw(Error)
+      })
+
+      it('throws an error if there are invalid array attributes', () => {
+        expect(() => {
+          util.sanitizeX509GuardData({
+            subject: {
+              CN: ['invalid'],
+            },
+          })
+        }).to.throw(Error)
+      })
+
+    })
+
+  })
+
+})


### PR DESCRIPTION
This commit enforces consistency of behavior and language for the Node
SDK's auth grant interface. Most significantly, the Node SDK will now
arrayify X509 Subject attributes where necessary.