### PR TITLE
cmd/cored: handle / redirect outside authz

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -193,8 +193,8 @@ func main() {
 	mux.Handle("/", &coreHandler)
 
 	var handler http.Handler = mux
-	handler = core.RedirectHandler(handler)
 	handler = core.AuthHandler(handler, raftDB, accessTokens, internalDN)
+	handler = core.RedirectHandler(handler)
 	handler = reqid.Handler(handler)
 
 	secureheader.DefaultConfig.PermitClearLoopback = true

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3022";
+	public final String Id = "main/rev3023";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3022"
+const ID string = "main/rev3023"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3022"
+export const rev_id = "main/rev3023"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3022".freeze
+	ID = "main/rev3023".freeze
 end


### PR DESCRIPTION
Commit 9cadcdc68e9933cb8be17fd4232e982b0d48756f meant to
put the redirect handler outside of (before) authz, but
didn't.