### PR TITLE
cmd/corectl: fix grant/revoke request body

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3029";
+	public final String Id = "main/rev3030";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3029"
+const ID string = "main/rev3030"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3029"
+export const rev_id = "main/rev3030"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3029".freeze
+	ID = "main/rev3030".freeze
 end


### PR DESCRIPTION
This fixes a 400 HTTP response from cored.

The fields 'guard_type' and 'guard_data' are defining
a guard, not a grant (which is the overall request).
With this change, editAuthz reuses the type definition
from createToken, factored out into a package-level
named type.