### PR TITLE
database/raft: plumb TLS config into raft

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -152,9 +152,25 @@ func main() {
 		internalDN = &x509Cert.Subject
 	}
 
+	// TODO(kr): make core.UseTLS take just an http client
+	// and use this object in it.
+	httpClient := new(http.Client)
+	httpClient.Transport = &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSClientConfig:       tlsConfig,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
 	raftDir := filepath.Join(home, "raft") // TODO(kr): better name for this
 	// TODO(tessr): remove tls param once we have tls everywhere
-	raftDB, err := raft.Start(*listenAddr, raftDir, *bootURL, tlsConfig != nil)
+	raftDB, err := raft.Start(*listenAddr, raftDir, *bootURL, httpClient)
 	if err != nil {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -170,7 +170,6 @@ func main() {
 	}
 
 	raftDir := filepath.Join(home, "raft") // TODO(kr): better name for this
-	// TODO(tessr): remove tls param once we have tls everywhere
 	raftDB, err := raft.Start(*listenAddr, raftDir, *bootURL, httpClient)
 	if err != nil {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -156,6 +156,8 @@ func main() {
 	// and use this object in it.
 	httpClient := new(http.Client)
 	httpClient.Transport = &http.Transport{
+		TLSClientConfig: tlsConfig,
+
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
@@ -163,7 +165,6 @@ func main() {
 		}).DialContext,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
-		TLSClientConfig:       tlsConfig,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -158,6 +158,10 @@ func main() {
 	httpClient.Transport = &http.Transport{
 		TLSClientConfig: tlsConfig,
 
+		// The following fields are default values
+		// copied from DefaultTransport.
+		// (When you change them, be sure to move them
+		// above this line so this comment stays true.)
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/core/authz_test.go
+++ b/core/authz_test.go
@@ -33,7 +33,7 @@ func TestAuthz(t *testing.T) {
 	}
 	defer os.RemoveAll(raftDir)
 
-	raftDB, err := raft.Start("", raftDir, "", false)
+	raftDB, err := raft.Start("", raftDir, "", new(http.Client))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/grants_test.go
+++ b/core/grants_test.go
@@ -34,7 +34,7 @@ func TestCreatGrantValidation(t *testing.T) {
 	}
 	defer os.RemoveAll(raftDir)
 
-	raftDB, err := raft.Start("", raftDir, "", false)
+	raftDB, err := raft.Start("", raftDir, "", new(http.Client))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3031";
+	public final String Id = "main/rev3032";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3031"
+const ID string = "main/rev3032"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3031"
+export const rev_id = "main/rev3032"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3031".freeze
+	ID = "main/rev3032".freeze
 end


### PR DESCRIPTION
Both package raft and package core used to rely on a TLS
client config in DefaultTransport. We inadvertently
broke raft when core stopped using DefaultTransport and
we stopped configuring it.