### PR TITLE
core: use Chain.State to retrieve latest bc state

### DIFF
--- a/core/generator/block.go
+++ b/core/generator/block.go
@@ -44,6 +44,7 @@ func (g *Generator) makeBlock(ctx context.Context) (err error) {
 	t0 := time.Now()
 	defer recordSince(t0)
 
+	latestBlock, latestSnapshot := g.chain.State()
 	var b *legacy.Block
 	var s *state.Snapshot
 
@@ -54,8 +55,8 @@ func (g *Generator) makeBlock(ctx context.Context) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "retrieving the pending block")
 	}
-	if b != nil && (g.latestBlock == nil || b.Height == g.latestBlock.Height+1) {
-		s = state.Copy(g.latestSnapshot)
+	if b != nil && (latestBlock == nil || b.Height == latestBlock.Height+1) {
+		s = state.Copy(latestSnapshot)
 		err = s.ApplyBlock(legacy.MapBlock(b))
 		if err != nil {
 			log.Fatalkv(ctx, log.KeyError, err)
@@ -67,7 +68,7 @@ func (g *Generator) makeBlock(ctx context.Context) (err error) {
 		g.poolHashes = make(map[bc.Hash]bool)
 		g.mu.Unlock()
 
-		b, s, err = g.chain.GenerateBlock(ctx, g.latestBlock, g.latestSnapshot, time.Now(), txs)
+		b, s, err = g.chain.GenerateBlock(ctx, latestBlock, latestSnapshot, time.Now(), txs)
 		if err != nil {
 			return errors.Wrap(err, "generate")
 		}
@@ -79,13 +80,11 @@ func (g *Generator) makeBlock(ctx context.Context) (err error) {
 			return errors.Wrap(err, "saving pending block")
 		}
 	}
-
-	// g.commitBlock will update g.latestBlock and g.latestSnapshot.
-	return g.commitBlock(ctx, b, s)
+	return g.commitBlock(ctx, b, s, latestBlock)
 }
 
-func (g *Generator) commitBlock(ctx context.Context, b *legacy.Block, s *state.Snapshot) error {
-	err := g.getAndAddBlockSignatures(ctx, b, g.latestBlock)
+func (g *Generator) commitBlock(ctx context.Context, b *legacy.Block, s *state.Snapshot, latestBlock *legacy.Block) error {
+	err := g.getAndAddBlockSignatures(ctx, b, latestBlock)
 	if err != nil {
 		return errors.Wrap(err, "sign")
 	}
@@ -94,9 +93,6 @@ func (g *Generator) commitBlock(ctx context.Context, b *legacy.Block, s *state.S
 	if err != nil {
 		return errors.Wrap(err, "commit")
 	}
-
-	g.latestBlock = b
-	g.latestSnapshot = s
 	return nil
 }
 

--- a/core/generator/block.go
+++ b/core/generator/block.go
@@ -83,8 +83,8 @@ func (g *Generator) makeBlock(ctx context.Context) (err error) {
 	return g.commitBlock(ctx, b, s, latestBlock)
 }
 
-func (g *Generator) commitBlock(ctx context.Context, b *legacy.Block, s *state.Snapshot, latestBlock *legacy.Block) error {
-	err := g.getAndAddBlockSignatures(ctx, b, latestBlock)
+func (g *Generator) commitBlock(ctx context.Context, b *legacy.Block, s *state.Snapshot, prevBlock *legacy.Block) error {
+	err := g.getAndAddBlockSignatures(ctx, b, prevBlock)
 	if err != nil {
 		return errors.Wrap(err, "sign")
 	}

--- a/core/generator/generator.go
+++ b/core/generator/generator.go
@@ -14,7 +14,6 @@ import (
 	"chain/protocol"
 	"chain/protocol/bc"
 	"chain/protocol/bc/legacy"
-	"chain/protocol/state"
 )
 
 // A BlockSigner signs blocks.
@@ -36,13 +35,6 @@ type Generator struct {
 	mu         sync.Mutex
 	pool       []*legacy.Tx // in topological order
 	poolHashes map[bc.Hash]bool
-
-	// latestBlock and latestSnapshot are current as long as this
-	// process remains the leader process. If the process is demoted,
-	// generator.Generate() should return and this struct should be
-	// garbage collected.
-	latestBlock    *legacy.Block
-	latestSnapshot *state.Snapshot
 }
 
 // New creates and initializes a new Generator.
@@ -93,11 +85,7 @@ func (g *Generator) Generate(
 	ctx context.Context,
 	period time.Duration,
 	health func(error),
-	recoveredBlock *legacy.Block,
-	recoveredSnapshot *state.Snapshot,
 ) {
-	g.latestBlock, g.latestSnapshot = recoveredBlock, recoveredSnapshot
-
 	ticks := time.Tick(period)
 	for {
 		select {

--- a/core/run.go
+++ b/core/run.go
@@ -239,7 +239,7 @@ func (a *API) lead(ctx context.Context) {
 
 	// This process just became leader, so it's responsible
 	// for recovering after the previous leader's exit.
-	recoveredBlock, recoveredSnapshot, err := a.chain.Recover(ctx)
+	_, _, err := a.chain.Recover(ctx)
 	if err != nil {
 		log.Fatalkv(ctx, log.KeyError, err)
 	}
@@ -258,7 +258,7 @@ func (a *API) lead(ctx context.Context) {
 	}
 
 	if a.config.IsGenerator {
-		go a.generator.Generate(ctx, blockPeriod, a.healthSetter("generator"), recoveredBlock, recoveredSnapshot)
+		go a.generator.Generate(ctx, blockPeriod, a.healthSetter("generator"))
 	} else {
 		// Remove the downloading snapshot if there was one. The core
 		// has recovered and will now start syncing blocks.
@@ -266,7 +266,7 @@ func (a *API) lead(ctx context.Context) {
 		a.downloadingSnapshot = nil
 		a.downloadingSnapshotMu.Unlock()
 
-		go fetch.Fetch(ctx, a.chain, a.remoteGenerator, a.healthSetter("fetch"), recoveredBlock, recoveredSnapshot)
+		go fetch.Fetch(ctx, a.chain, a.remoteGenerator, a.healthSetter("fetch"))
 	}
 	go a.accounts.ProcessBlocks(ctx)
 	go a.assets.ProcessBlocks(ctx)

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3033";
+	public final String Id = "main/rev3034";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3033"
+const ID string = "main/rev3034"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3033"
+export const rev_id = "main/rev3034"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3033".freeze
+	ID = "main/rev3034".freeze
 end


### PR DESCRIPTION
Previously, core/generator and core/fetch had their own local pointers
to the latest block and latest snapshot. We already need to store and
expose blockchain state on the Chain struct for the /sign-block RPC.
To address #519 without too invasive of changes, I think we'll need to
pull the state from the shared Chain struct.