### PR TITLE
core/leader: handle missing leader

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -347,7 +347,7 @@ func (a *API) forwardToLeader(ctx context.Context, path string, body interface{}
 	// This is possible if we just became the leader. The client should
 	// just retry.
 	if addr == a.addr {
-		return errLeaderElection
+		return leader.ErrNoLeader
 	}
 
 	l := &rpc.Client{

--- a/core/api.go
+++ b/core/api.go
@@ -49,7 +49,6 @@ const crosscoreRPCPrefix = "/rpc/"
 var (
 	errNotFound         = errors.New("not found")
 	errRateLimited      = errors.New("request limit exceeded")
-	errLeaderElection   = errors.New("no leader; pending election")
 	errNotAuthenticated = errors.New("not authenticated")
 )
 

--- a/core/errors.go
+++ b/core/errors.go
@@ -8,6 +8,7 @@ import (
 	"chain/core/asset"
 	"chain/core/blocksigner"
 	"chain/core/config"
+	"chain/core/leader"
 	"chain/core/query"
 	"chain/core/query/filter"
 	"chain/core/rpc"
@@ -58,7 +59,7 @@ var errorFormatter = httperror.Formatter{
 		httpjson.ErrBadRequest:     {400, "CH003", "Invalid request body"},
 		errNotFound:                {404, "CH006", "Not found"},
 		errRateLimited:             {429, "CH007", "Request limit exceeded"},
-		errLeaderElection:          {503, "CH008", "Electing a new leader for the core; try again soon"},
+		leader.ErrNoLeader:         {503, "CH008", "Electing a new leader for the core; try again soon"},
 		errNotAuthenticated:        {401, "CH009", "Request could not be authenticated"},
 		txbuilder.ErrMissingFields: {400, "CH010", "One or more fields are missing"},
 		authz.ErrNotAuthorized:     {403, "CH011", "Request is unauthorized"},

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3055";
+	public final String Id = "main/rev3056";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3055"
+const ID string = "main/rev3056"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3055"
+export const rev_id = "main/rev3056"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3055".freeze
+	ID = "main/rev3056".freeze
 end


### PR DESCRIPTION
If there's no leader process yet, respond with a 503 status code
from leader-only endpoints.

Fix #1064.