### PR TITLE
docs: update docs to account for authz updates

### DIFF
--- a/docs/core/learn-more/authentication.md
+++ b/docs/core/learn-more/authentication.md
@@ -14,10 +14,10 @@ For convenience, in all desktop installations of Chain Core Developer Edition **
 
 ## Authorization
 
-There are two APIs in Chain Core: the **client API** and the **network API**.
+There are two APIs in Chain Core: the **client API** and the **cross-core API**.
 
 The client API is used by the SDKs and the dashboard to communicate with Chain
-Core. The network API is used by [network operators](blockchain-operators.md).
+Core. The cross-core API allows instances of Chain Core to communicate with each other.
 
 There are four policies available to grant an individual credential
 access to one or both APIs:
@@ -27,7 +27,8 @@ access to one or both APIs:
 subset of the `client-readwrite` policy.
 * **monitoring**: Access to monitoring-specific endpoints. This is a strict
 subset of the `client-readonly` policy.
-* **network**: Access to the Network API.
+* **crosscore**: Access to the cross-core API, including fetching blocks and submitting transactions to the [generator](blockchain-operators.md), but not including block signing. A core requires access to this policy when connecting to a generator.
+* **crosscore-signblock**: Access to the cross-core API's block signing endpoint. If your blockchain network uses multiple [block signers](blockchain-operators.md), they should provide the generator with access to this policy.
 
 ## Setting Up
 

--- a/docs/core/learn-more/blockchain-operators.md
+++ b/docs/core/learn-more/blockchain-operators.md
@@ -26,12 +26,14 @@ This guide will walk you through the basic functions of the blockchain operators
 
 To create a new blockchain, the blockchain operators must coordinate to create the initial consensus program and generate the first block (at height 0). The process is as follows:
 
-1. Each block signer initializes a Chain Core as a block signer, creating a network token and a private/public keypair.
-2. Each block signer distributes their block signer URL, network token, and public key to the block generator out of band.
-3. The block generator initializes a Chain Core as a block generator, creating a private/public keypair.
-4. The block generator configures the URL, network token, and public key for each block signer in Chain Core settings.
-5. The block generator creates the initial consensus program (from its public key and the public keys and quorum of the block signers) in Chain Core settings.
-6. The block generator creates the first block, including the initial consensus program, which is automatically distributed to each block signer.
+1. Each block signer generates a public/private keypair for blocksigning, as well as access credentials that the generator can use to send messages to the block signer's core.
+2. Out of band, each block signer sends its public key, access credentials, and core URL to the block generator.
+3. In most cases, the block generator creates its own public/private keypair for block signing.
+4. The block generator configures its core with each block signer's core URL, access credentials, and public keys.
+5. The block generator creates an initial consensus program (from the public keys and quorum of the block signers), and creates the first block, including the consensus program.
+6. The block generator generates access credentials for each block signer. Block signers can use these credentials to send requests to the block generator's core.
+7. Out of band, the block generator distributes access credentials and its core URL to all block signers. It also sends the hash of the initial block, known as the blockchain ID.
+8. Using the generator's access credentials, core URL, and blockchain ID, the block signers can finish configuring their cores.
 
 Note: The Chain Core dashboard does not yet support block signer configuration. However, you can use the Chain Core command line tools to configure block generator and block signers manually. See the [block signing guide](configure-block-signers.md).
 
@@ -60,7 +62,12 @@ Once the block generator has generated a proposed block, each block signer (up t
 
 ### Network permissions
 
-A blockchain can be configured to require network tokens in order to connect to the block generator to submit transactions and receive blocks. The block generator can create a unique network token for each participant that can be revoked at any time.
+Instances of Chain Core must be configured with the correct access credentials (either access tokens or X.509 client certificates) in order to communicate with each other. In particular:
+
+- All participants must make requests to the block generator using a credential that has access to the generator's `crosscore` policy.
+- The generator must make requests to block signers using credentials that have access to each signer's `crosscore-signblock` policy, respectively.
+
+The [Authentication and Authorization guide](authentication.md) contains more detail on how to create and configure credentials and policies.
 
 ### Adding/removing blockchain operators
 

--- a/docs/core/learn-more/blockchain-operators.md
+++ b/docs/core/learn-more/blockchain-operators.md
@@ -26,7 +26,7 @@ This guide will walk you through the basic functions of the blockchain operators
 
 To create a new blockchain, the blockchain operators must coordinate to create the initial consensus program and generate the first block (at height 0). The process is as follows:
 
-1. Each block signer generates a public/private keypair for blocksigning, as well as access credentials that the generator can use to send messages to the block signer's core.
+1. Each block signer generates a public/private keypair for block signing, as well as access credentials that the generator can use to send messages to the block signer's core.
 2. Out of band, each block signer sends its public key, access credentials, and core URL to the block generator.
 3. In most cases, the block generator creates its own public/private keypair for block signing.
 4. The block generator configures its core with each block signer's core URL, access credentials, and public keys.

--- a/docs/core/learn-more/configure-block-signers.md
+++ b/docs/core/learn-more/configure-block-signers.md
@@ -2,15 +2,17 @@
 
 This guide describes how to create a blockchain network with two Chain Cores in the consensus group, one core acting as the block generator, and the other acting as a block signer. A block must contain signatures from both parties for the block to be considered valid.
 
-Configuring the two cores requires use of [corectl](corectl.md), a command-line configuration tool distributed with Chain Core Developer Edition.
+Configuring the two cores requires use of [corectl](../reference/corectl.md), a command-line configuration tool distributed with Chain Core Developer Edition.
 
 ### Signer
 
-The block signing party should start with a running, *unconfigured* instance of Chain Core. Full configuration will be completed *after* the block generator is configured, but the block generator must first receive the block signer's public key and access credentials.
+The block signer should start with a running, *unconfigured* instance of Chain Core. We can still use the unconfigured core to generate MockHSM keys and access credentials.
+
+Full configuration of this core will be completed *after* the block generator is configured, but the block generator must first receive the block signer's public key and access credentials.
 
 #### Create a block signing key
 
-The following command generates a new public/private keypair in the block signer's MockHSM:
+Use the [create-block-keypair](../reference/corectl.md#create-block-keypair) command to generate a new public/private keypair in the block signer's MockHSM:
 
 ```
 corectl create-block-keypair
@@ -29,7 +31,7 @@ cce1791bf3d8bb5e506ec7159bad6a696740712197894336c027dec9fbfb9313
 
 The generator will make requests to the block signer's block signing API, which is protected by the `crosscore-signblock` policy.
 
-The following command will generate a new access token with access to the `crosscore-signblock` policy:
+Use the [create-token](../reference/corectl.md#create-token) command to generate a new access token with access to the `crosscore-signblock` policy:
 
 ```
 corectl create-token <token ID> crosscore-signblock
@@ -55,7 +57,7 @@ Out of band, the following details should be sent to the block generator:
 
 #### Create the generator's block signing key
 
-The block generator will also sign blocks. The following command generates a new public/private keypair in the block generator's MockHSM:
+The block generator will also sign blocks. Use the [create-block-keypair](../reference/corectl.md#create-block-keypair) to generate a new public/private keypair in the block generator's MockHSM:
 
 ```
 corectl create-block-keypair
@@ -72,7 +74,7 @@ generator-host$ corectl create-block-keypair
 
 #### Configure Chain Core
 
-Now, configure Chain Core to require two signatures on each block: its own, plus one from the block signer:
+Use the [config-generator](../reference/corectl.md#config-generator) command to configure Chain Core to require two signatures on each block, one representing from the generator, and one from the other block signer:
 
 ```
 corectl config-generator \
@@ -99,7 +101,9 @@ ec95cfab939d7b8dde46e7e1dcd7cb0a7c0cea37148addd70a4a4a5aaab9616c
 
 #### Create a network token for the signer
 
-Like all other cores on the same network, the block signer will fetch blocks and submit transactions to the block generator's cross-core API, which is protected by the `crosscore-signblock` policy. To create an access token with access to this policy, run:
+Like all other cores on the same network, the block signer will fetch blocks and submit transactions to the block generator's cross-core API, which is protected by the `crosscore-signblock` policy.
+
+Use the [create-token](../reference/corectl.md#create-token) command to create an access token with access to this policy, run:
 
 ```
 corectl create-token <token ID> crosscore
@@ -126,7 +130,7 @@ Out of band, the following information should be sent to the block signer:
 
 #### Configure Chain Core
 
-The following command will configure the block signer's core to perform block signing:
+Use the [config-generator](../reference/corectl.md#config-generator) command to configure the block signer's core to perform block signing:
 
 ```
 corectl config \

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3052";
+	public final String Id = "main/rev3053";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3052"
+const ID string = "main/rev3053"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3052"
+export const rev_id = "main/rev3053"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3052".freeze
+	ID = "main/rev3053".freeze
 end


### PR DESCRIPTION
This commit is meant to be an MVP update to documentation that
addresses authentication and authorization. In particular, it updates
language around "network tokens" to account for our new worfklow around
crosscore and crosscore-signblock policies.