### PR TITLE
database/raft: create the allowed members list

### DIFF
--- a/database/raft/membership.go
+++ b/database/raft/membership.go
@@ -2,19 +2,18 @@ package raft
 
 import "context"
 
-const potentialMemberPrefix = "potential"
+const allowedMemberPrefix = "/raft/allowed"
 
-// AddPotentialMember adds an address for a potential new member to the
-// list of potential cluster members.
-// An address must be listed as a potential cluster member before the node
+// AddAllowedMember adds an address for a member to the list of allowed cluster members.
+// An address must be listed as a allowed cluster member before the node
 // listening on that address can join the cluster.
-func (sv *Service) AddPotentialMember(ctx context.Context, addr string) error {
+func (sv *Service) AddAllowedMember(ctx context.Context, addr string) error {
 	dummyData := []byte{0x01}
-	return sv.Set(ctx, potentialMemberPrefix+"/"+addr, dummyData)
+	return sv.Set(ctx, allowedMemberPrefix+"/"+addr, dummyData)
 }
 
-func (sv *Service) isPotentialMember(ctx context.Context, addr string) bool {
-	data, err := sv.Get(ctx, potentialMemberPrefix+"/"+addr)
+func (sv *Service) isAllowedMember(ctx context.Context, addr string) bool {
+	data, err := sv.Get(ctx, allowedMemberPrefix+"/"+addr)
 	if err != nil {
 		return false
 	}

--- a/database/raft/membership.go
+++ b/database/raft/membership.go
@@ -1,0 +1,22 @@
+package raft
+
+import "context"
+
+const potentialMemberPrefix = "potential"
+
+// AddPotentialMember adds an address for a potential new member to the
+// list of potential cluster members.
+// An address must be listed as a potential cluster member before the node
+// listening on that address can join the cluster.
+func (sv *Service) AddPotentialMember(ctx context.Context, addr string) error {
+	dummyData := []byte{0x01}
+	return sv.Set(ctx, potentialMemberPrefix+"/"+addr, dummyData)
+}
+
+func (sv *Service) isPotentialMember(ctx context.Context, addr string) bool {
+	data, err := sv.Get(ctx, potentialMemberPrefix+"/"+addr)
+	if err != nil {
+		return false
+	}
+	return len(data) > 0
+}

--- a/database/raft/membership_test.go
+++ b/database/raft/membership_test.go
@@ -1,0 +1,41 @@
+package raft
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPotentialMember(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raftDir := filepath.Join(currentDir, "/.testraft")
+	err = os.Mkdir(raftDir, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(raftDir)
+
+	raftDB, err := Start("", raftDir, "", new(http.Client))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = raftDB.AddPotentialMember(context.Background(), "1234")
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+
+	if !raftDB.isPotentialMember(context.Background(), "1234") {
+		t.Fatal("expected 1234 to be a potential member")
+	}
+
+	if raftDB.isPotentialMember(context.Background(), "5678") {
+		t.Fatal("expected 5678 to not be a potential member")
+	}
+}

--- a/database/raft/membership_test.go
+++ b/database/raft/membership_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestPotentialMember(t *testing.T) {
+func TestAllowedMember(t *testing.T) {
 	currentDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -26,16 +26,16 @@ func TestPotentialMember(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = raftDB.AddPotentialMember(context.Background(), "1234")
+	err = raftDB.AddAllowedMember(context.Background(), "1234")
 	if err != nil {
 		t.Fatal("unexpected error", err)
 	}
 
-	if !raftDB.isPotentialMember(context.Background(), "1234") {
+	if !raftDB.isAllowedMember(context.Background(), "1234") {
 		t.Fatal("expected 1234 to be a potential member")
 	}
 
-	if raftDB.isPotentialMember(context.Background(), "5678") {
+	if raftDB.isAllowedMember(context.Background(), "5678") {
 		t.Fatal("expected 5678 to not be a potential member")
 	}
 }

--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -594,6 +594,8 @@ func (sv *Service) serveJoin(w http.ResponseWriter, req *http.Request) {
 
 	log.Printkv(req.Context(), "at", "join-id", "addr", x.Addr, "id", newID)
 
+	// TODO(tessr): confirm that this addr exists in the potential member list
+
 	err = sv.raftNode.ProposeConfChange(req.Context(), raftpb.ConfChange{
 		ID:      atomic.AddUint64(&sv.confChangeID, 1),
 		Type:    raftpb.ConfChangeAddNode,

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3039";
+	public final String Id = "main/rev3040";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3039"
+const ID string = "main/rev3040"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3039"
+export const rev_id = "main/rev3040"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3039".freeze
+	ID = "main/rev3040".freeze
 end


### PR DESCRIPTION
When a new cored joins a raft cluster, there must be an associated grant stored in that cluster in order for this new cored to talk to the other members of the cluster. 

We'd like the existence of this grant to be a prerequisite for a new member joining the cluster. Similarly, we'd like it to be impossible to delete a grant that is associated with a cluster member, unless that member is also removed from the cluster. In order to keep track of this, we're creating a list of "allowed members"--that is, addresses associated with nodes that are allowed to become members. 

This commit creates that list, but doesn't hook it up to the rest of the code managing cluster membership. 