### PR TITLE
core/generator: only upsert higher pending blocks

### DIFF
--- a/core/generator/block_test.go
+++ b/core/generator/block_test.go
@@ -1,0 +1,42 @@
+package generator
+
+import (
+	"context"
+	"testing"
+
+	"chain/database/pg/pgtest"
+	"chain/protocol/bc/legacy"
+)
+
+func TestSavePendingBlock(t *testing.T) {
+	ctx := context.Background()
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+
+	// Save a pending block.
+	err := savePendingBlock(ctx, db, fakeBlock(100))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Saving another block at the same height or lower should error.
+	err = savePendingBlock(ctx, db, fakeBlock(20))
+	if err != errDuplicateBlock {
+		t.Errorf("got %s, want %s", err, errDuplicateBlock)
+	}
+	err = savePendingBlock(ctx, db, fakeBlock(100))
+	if err != errDuplicateBlock {
+		t.Errorf("got %s, want %s", err, errDuplicateBlock)
+	}
+
+	// Saving a higher block should succeed.
+	err = savePendingBlock(ctx, db, fakeBlock(101))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fakeBlock(height uint64) *legacy.Block {
+	return &legacy.Block{
+		BlockHeader: legacy.BlockHeader{Height: height},
+	}
+}

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -63,4 +63,8 @@ var migrations = []migration{
 	{Name: `2017-04-17.0.core.null-token-type.sql`, SQL: `
 		ALTER TABLE access_tokens ALTER COLUMN type DROP NOT NULL;
 	`},
+	{Name: `2017-04-27.0.generator.pending-block-height.sql`, SQL: `
+		ALTER TABLE generator_pending_block
+			ADD COLUMN height bigint;
+	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -343,6 +343,7 @@ CREATE TABLE config (
 CREATE TABLE generator_pending_block (
     singleton boolean DEFAULT true NOT NULL,
     data bytea NOT NULL,
+    height bigint,
     CONSTRAINT generator_pending_block_singleton CHECK (singleton)
 );
 
@@ -664,3 +665,4 @@ insert into migrations (filename, hash) values ('2017-03-02.0.core.add-output-so
 insert into migrations (filename, hash) values ('2017-03-09.0.core.account-utxos-change.sql', 'a99e0e41be3da126a8c47151454098669334bf7e30de6cd539ba535add4e85d1');
 insert into migrations (filename, hash) values ('2017-04-13.0.query.block-transactions-count.sql', '7cb17e05596dbfdf75e347e43ccab110e393f41ea86f70697e59cf0c32c3a564');
 insert into migrations (filename, hash) values ('2017-04-17.0.core.null-token-type.sql', '185942cec464c12a2573f19ae386153389328f8e282af071024706e105e37eeb');
+insert into migrations (filename, hash) values ('2017-04-27.0.generator.pending-block-height.sql', 'bfe4fe5eec143e4367a91fd952cb5e3879f1c311f649ec13bfe95b202e94d4ec');

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3057";
+	public final String Id = "main/rev3058";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3057"
+const ID string = "main/rev3058"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3057"
+export const rev_id = "main/rev3058"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3057".freeze
+	ID = "main/rev3058".freeze
 end


### PR DESCRIPTION
When upserting a pending block as the generator, only upsert if the
new block is at a higher height than the previous block. This wraps
up #519 for the generator.

This should land after #1079.