### PR TITLE
core: use more specific type for health errors

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -84,7 +84,7 @@ type API struct {
 	downloadingSnapshot   *fetch.SnapshotProgress
 
 	healthMu     sync.Mutex
-	healthErrors map[string]interface{}
+	healthErrors map[string]string
 }
 
 func (a *API) ServeHTTP(rw http.ResponseWriter, req *http.Request) {

--- a/core/health.go
+++ b/core/health.go
@@ -11,19 +11,19 @@ func (a *API) setHealth(name string, err error) {
 	a.healthMu.Lock()
 	defer a.healthMu.Unlock()
 	if a.healthErrors == nil {
-		a.healthErrors = make(map[string]interface{})
+		a.healthErrors = make(map[string]string)
 	}
 	if err == nil {
-		a.healthErrors[name] = nil
+		delete(a.healthErrors, name)
 	} else {
 		a.healthErrors[name] = err.Error() // convert to immutable string
 	}
 }
 
 func (a *API) health() (x struct {
-	Errors map[string]interface{} `json:"errors"`
+	Errors map[string]string `json:"errors"`
 }) {
-	x.Errors = make(map[string]interface{})
+	x.Errors = make(map[string]string)
 	a.healthMu.Lock()
 	defer a.healthMu.Unlock()
 	for name, s := range a.healthErrors {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3043";
+	public final String Id = "main/rev3044";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3043"
+const ID string = "main/rev3044"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3043"
+export const rev_id = "main/rev3044"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3043".freeze
+	ID = "main/rev3044".freeze
 end


### PR DESCRIPTION
The only reason we used interface{} as the value type in
map healthErrors was so we could include nil values (to
show up as JSON null). If we delete entries instead, we
don't need to show null and we can type check the values.