### PR TITLE
sdk: rename network RPC version to crosscore RPC version

### DIFF
--- a/dashboard/src/features/app/components/Sync/Sync.jsx
+++ b/dashboard/src/features/app/components/Sync/Sync.jsx
@@ -81,7 +81,7 @@ export default connect(
     replicationLag: state.core.replicationLag,
     snapshot: state.core.snapshot,
     syncEstimates: state.core.syncEstimates,
-    testnetError: testnetUtils.isBlockchainMismatch(state) || testnetUtils.isNetworkMismatch(state),
+    testnetError: testnetUtils.isBlockchainMismatch(state) || testnetUtils.isCrosscoreRpcMismatch(state),
     testnetNextReset: state.testnet.nextReset,
   })
 )(Sync)

--- a/dashboard/src/features/core/components/CoreIndex/CoreIndex.jsx
+++ b/dashboard/src/features/core/components/CoreIndex/CoreIndex.jsx
@@ -100,7 +100,7 @@ class CoreIndex extends React.Component {
                 </tr>}
               {!this.props.core.generator &&
                 <tr>
-                  <td className={styles.row_label}>Network Access Token:</td>
+                  <td className={styles.row_label}>Generator Access Token:</td>
                   <td><code>{this.props.core.generatorAccessToken}</code></td>
                 </tr>}
               <tr>
@@ -205,7 +205,7 @@ const mapStateToProps = (state) => ({
   core: state.core,
   onTestnet: state.core.onTestnet,
   testnetBlockchainMismatch: testnetUtils.isBlockchainMismatch(state),
-  testnetNetworkMismatch: testnetUtils.isNetworkMismatch(state),
+  testnetNetworkMismatch: testnetUtils.isCrosscoreRpcMismatch(state),
   testnetNextReset: state.testnet.nextReset,
 })
 

--- a/dashboard/src/features/core/reducers.js
+++ b/dashboard/src/features/core/reducers.js
@@ -63,8 +63,8 @@ export const generatorAccessToken = (state, action) =>
   coreConfigReducer('generatorAccessToken', state, false, action)
 export const blockchainId = (state, action) =>
   coreConfigReducer('blockchainId', state, 0, action)
-export const networkRpcVersion = (state, action) =>
-  coreConfigReducer('networkRpcVersion', state, 0, action)
+export const crosscoreRpcVersion = (state, action) =>
+  coreConfigReducer('crosscoreRpcVersion', state, 0, action)
 
 export const coreType = (state = '', action) => {
   if (action.type == 'UPDATE_CORE_INFO') {
@@ -219,7 +219,7 @@ export default combineReducers({
   generatorUrl,
   loopback,
   mockhsm,
-  networkRpcVersion,
+  crosscoreRpcVersion,
   onTestnet,
   replicationLag,
   replicationLagClass,

--- a/dashboard/src/features/testnet/reducers.js
+++ b/dashboard/src/features/testnet/reducers.js
@@ -20,9 +20,9 @@ export const blockchainId = (state = 0, action) => {
   return state
 }
 
-export const rpcVersion = (state = 0, action) => {
+export const crosscoreRpcVersion = (state = 0, action) => {
   if (action.type == 'TESTNET_CONFIG') {
-    return action.data.network_rpc_version
+    return action.data.crosscore_rpc_version || action.data.network_rpc_version
   }
   return state
 }
@@ -37,6 +37,6 @@ export const testnetInfo = (state = { loading: true }, action) => {
 export default combineReducers({
   blockchainId,
   nextReset,
-  rpcVersion,
+  crosscoreRpcVersion,
   testnetInfo,
 })

--- a/dashboard/src/features/testnet/utils.js
+++ b/dashboard/src/features/testnet/utils.js
@@ -12,8 +12,8 @@ const isNetworkMismatch = (state) => {
     return false
   }
 
-  return !!state.core.networkRpcVersion && !!state.testnet.rpcVersion &&
-    state.core.networkRpcVersion != state.testnet.rpcVersion
+  return !!state.core.crosscoreRpcVersion && !!state.testnet.crosscoreRpcVersion &&
+    state.core.crosscoreRpcVersion != state.testnet.crosscoreRpcVersion
 }
 
 export default {

--- a/dashboard/src/features/testnet/utils.js
+++ b/dashboard/src/features/testnet/utils.js
@@ -7,7 +7,7 @@ const isBlockchainMismatch = (state) => {
     state.core.blockchainId != state.testnet.blockchainId
 }
 
-const isNetworkMismatch = (state) => {
+const isCrosscoreRpcMismatch = (state) => {
   if (!state.core.onTestnet) {
     return false
   }
@@ -18,5 +18,5 @@ const isNetworkMismatch = (state) => {
 
 export default {
   isBlockchainMismatch,
-  isNetworkMismatch,
+  isCrosscoreRpcMismatch,
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3050";
+	public final String Id = "main/rev3051";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3050"
+const ID string = "main/rev3051"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3050"
+export const rev_id = "main/rev3051"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3050".freeze
+	ID = "main/rev3051".freeze
 end

--- a/sdk/java/src/main/java/com/chain/api/CoreConfig.java
+++ b/sdk/java/src/main/java/com/chain/api/CoreConfig.java
@@ -41,8 +41,8 @@ public class CoreConfig {
     @SerializedName("generator_block_height_fetched_at")
     public Date generatorBlockHeightFetchedAt;
 
-    @SerializedName("network_rpc_version")
-    public int networkRpcVersion;
+    @SerializedName("crosscore_rpc_version")
+    public int crosscoreRpcVersion;
 
     @SerializedName("core_id")
     public String coreId;

--- a/sdk/node/src/api/config.js
+++ b/sdk/node/src/api/config.js
@@ -47,8 +47,11 @@ const shared = require('../shared')
  * @property {Boolean} isProduction
  * Whether the core is running in production mode.
  *
+ * @property {Number} crosscoreRpcVersion
+ * The cross-core API version supported by this core.
+ *
  * @property {Number} networkRpcVersion
- * The network version supported by this core.
+ * DEPRECATED. Do not use in 1.2 or greater. Superseded by {@link crosscoreRpcVersion}.
  *
  * @property {String} coreId
  * A random identifier for the core, generated during configuration.

--- a/sdk/ruby/lib/chain/config.rb
+++ b/sdk/ruby/lib/chain/config.rb
@@ -71,8 +71,14 @@ module Chain
       # @return [Boolean]
       attrib :is_production
 
+      # @!attribute [r] crosscore_rpc_version
+      # @return [Integer]
+      attrib :crosscore_rpc_version
+
+      # @deprecated
       # @!attribute [r] network_rpc_version
       # @return [Integer]
+      # Ignore in 1.2 or greater. Superseded by crosscore_rpc_version.
       attrib :network_rpc_version
 
       # @!attribute [r] core_id


### PR DESCRIPTION
SDKs maintain backward compatibility with network RPC version, but this
field is deprecated in favor of the equivalently-valued crosscore RPC
version.

Also includes dashboard updates. The dashboard assumes the
presence of a 1.2 Core.