### PR TITLE
testnet: remove legacy testnet-info files

### DIFF
--- a/bin/upload-testnet-info
+++ b/bin/upload-testnet-info
@@ -1,2 +1,0 @@
-#!/bin/sh
-aws s3 cp $CHAIN/testnet/public-info.json s3://testnet-info.chain.com/index.json --acl public-read

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3082";
+	public final String Id = "main/rev3083";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3082"
+const ID string = "main/rev3083"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3082"
+export const rev_id = "main/rev3083"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3082".freeze
+	ID = "main/rev3083".freeze
 end

--- a/testnet/public-info.json
+++ b/testnet/public-info.json
@@ -1,6 +1,0 @@
-{
-  "generator_url": "https://testnet.chain.com",
-  "blockchain_id": "abc123",
-  "network_rpc_version": 1,
-  "next_reset": "1980-01-01T00:00:00Z"
-}


### PR DESCRIPTION
testnet-info.chain.com provides publicly-available information
that is consumed by the dashboard when configuring Chain Core DE
for testnet. Historically, there were two methods of hosting this
information:

1. via Heroku, using the server implemented in cmd/testnet-info.
   This is the current hosting solution.
2. via S3, using bin/upload-testnet-info and the testnet package.
   This is a legacy implementation and is not used.

This commit removes files related to Item 2 above.