### PR TITLE
cmd/testnet-info: use "crosscore RPC" language

### DIFF
--- a/cmd/testnet-info/main.go
+++ b/cmd/testnet-info/main.go
@@ -11,14 +11,16 @@ import (
 var (
 	addr = env.String("LISTEN", ":8080")
 	info = struct {
-		GeneratorURL      *string `json:"generator_url"`
-		BlockchainID      *string `json:"blockchain_id"`
-		NetworkRPCVersion *int    `json:"network_rpc_version"`
-		NextReset         *string `json:"next_reset"`
+		GeneratorURL        *string `json:"generator_url"`
+		BlockchainID        *string `json:"blockchain_id"`
+		NetworkRPCVersion   *int    `json:"network_rpc_version"`
+		CrosscoreRPCVersion *int    `json:"crosscore_rpc_version"`
+		NextReset           *string `json:"next_reset"`
 	}{
 		env.String("GENERATOR_URL", ""),
 		env.String("BLOCKCHAIN_ID", ""),
-		env.Int("NETWORK_RPC_VERSION", 1),
+		env.Int("CROSSCORE_RPC_VERSION", 1), // network_rpc_version is a legacy term for crosscore_rpc_version
+		env.Int("CROSSCORE_RPC_VERSION", 1),
 		env.String("NEXT_RESET", ""),
 	}
 )

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3085";
+	public final String Id = "main/rev3086";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3085"
+const ID string = "main/rev3086"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3085"
+export const rev_id = "main/rev3086"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3085".freeze
+	ID = "main/rev3086".freeze
 end


### PR DESCRIPTION
"network RPC" has been superseded by "crosscore RPC".
testnet-info.chain.com should provide the crosscore RPC version with
both the old and new names.