### PR TITLE
database/raft: add useTLS config option

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -174,7 +174,7 @@ func main() {
 	}
 
 	raftDir := filepath.Join(home, "raft") // TODO(kr): better name for this
-	raftDB, err := raft.Start(*listenAddr, raftDir, *bootURL, httpClient)
+	raftDB, err := raft.Start(*listenAddr, raftDir, *bootURL, httpClient, tlsConfig != nil)
 	if err != nil {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}

--- a/core/authz_test.go
+++ b/core/authz_test.go
@@ -33,7 +33,7 @@ func TestAuthz(t *testing.T) {
 	}
 	defer os.RemoveAll(raftDir)
 
-	raftDB, err := raft.Start("", raftDir, "", new(http.Client))
+	raftDB, err := raft.Start("", raftDir, "", new(http.Client), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/grants_test.go
+++ b/core/grants_test.go
@@ -34,7 +34,7 @@ func TestCreatGrantValidation(t *testing.T) {
 	}
 	defer os.RemoveAll(raftDir)
 
-	raftDB, err := raft.Start("", raftDir, "", new(http.Client))
+	raftDB, err := raft.Start("", raftDir, "", new(http.Client), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -163,7 +163,7 @@ func TestDeleteGrants(t *testing.T) {
 	}
 	defer os.RemoveAll(raftDir)
 
-	raftDB, err := raft.Start("", raftDir, "", new(http.Client))
+	raftDB, err := raft.Start("", raftDir, "", new(http.Client), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/raft/membership_test.go
+++ b/database/raft/membership_test.go
@@ -21,7 +21,7 @@ func TestAllowedMember(t *testing.T) {
 	}
 	defer os.RemoveAll(raftDir)
 
-	raftDB, err := Start("", raftDir, "", new(http.Client))
+	raftDB, err := Start("", raftDir, "", new(http.Client), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -150,6 +150,7 @@ type Getter interface {
 // The returned *Service will use httpClient for outbound
 // connections to peers.
 func Start(laddr, dir, bootURL string, httpClient *http.Client, useTLS bool) (*Service, error) {
+	// TODO(tessr): configure raft service using run options
 	ctx := context.Background()
 
 	// We advertise laddr as the way for peers to reach this process.

--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -65,6 +65,7 @@ type Service struct {
 	wctxReq chan wctxReq
 	donec   chan struct{}
 	client  *http.Client
+	useTLS  bool
 
 	errMu sync.Mutex
 	err   error
@@ -148,7 +149,7 @@ type Getter interface {
 //
 // The returned *Service will use httpClient for outbound
 // connections to peers.
-func Start(laddr, dir, bootURL string, httpClient *http.Client) (*Service, error) {
+func Start(laddr, dir, bootURL string, httpClient *http.Client, useTLS bool) (*Service, error) {
 	ctx := context.Background()
 
 	// We advertise laddr as the way for peers to reach this process.
@@ -167,6 +168,7 @@ func Start(laddr, dir, bootURL string, httpClient *http.Client) (*Service, error
 		rctxReq:     make(chan rctxReq),
 		wctxReq:     make(chan wctxReq),
 		client:      httpClient,
+		useTLS:      useTLS,
 	}
 	sv.stateCond.L = &sv.stateMu
 
@@ -746,14 +748,14 @@ func (sv *Service) send(msgs []raftpb.Message) {
 			log.Printkv(context.Background(), "no-addr-for-peer", msg.To)
 			continue
 		}
-		sendmsg(addr, data, sv.client)
+		sendmsg(addr, data, sv.client, sv.useTLS)
 	}
 }
 
 // best effort. if it fails, oh well -- that's why we're using raft.
-func sendmsg(addr string, data []byte, client *http.Client) {
+func sendmsg(addr string, data []byte, client *http.Client, useTLS bool) {
 	url := "http://" + addr + "/raft/msg"
-	if clientTLS(client) != nil {
+	if useTLS {
 		url = "https://" + addr + "/raft/msg"
 	}
 	resp, err := client.Post(url, contentType, bytes.NewReader(data))

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3053";
+	public final String Id = "main/rev3054";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3053"
+const ID string = "main/rev3054"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3053"
+export const rev_id = "main/rev3054"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3053".freeze
+	ID = "main/rev3054".freeze
 end


### PR DESCRIPTION
The standard library's `net/http` package modifies the http client's transport field when requests are made. Therefore it's not safe to check if we should use TLS by checking the transport. This PR adds a `useTLS` flag to the raft service; in the future, the raft service may be configured by passing in run options, a la cored. 