### PR TITLE
protocol/vmutil: add mechanism for adding jumps in Builder

### DIFF
--- a/core/asset/asset.go
+++ b/core/asset/asset.go
@@ -419,7 +419,8 @@ func multisigIssuanceProgram(pubkeys []ed25519.PublicKey, nrequired int) (progra
 	}
 	builder := vmutil.NewBuilder()
 	builder.AddRawBytes(issuanceProg)
-	return builder.Program, 1, nil
+	prog, err := builder.Build()
+	return prog, 1, err
 }
 
 func mapToNullString(in map[string]interface{}) (*sql.NullString, error) {

--- a/core/txbuilder/actions.go
+++ b/core/txbuilder/actions.go
@@ -8,10 +8,9 @@ import (
 	"chain/protocol/bc"
 	"chain/protocol/bc/legacy"
 	"chain/protocol/vm"
-	"chain/protocol/vmutil"
 )
 
-var retirementProgram = vmutil.NewBuilder().AddOp(vm.OP_FAIL).Program
+var retirementProgram = []byte{byte(vm.OP_FAIL)}
 
 func DecodeControlReceiverAction(data []byte) (Action, error) {
 	a := new(controlReceiverAction)

--- a/core/txbuilder/constraint.go
+++ b/core/txbuilder/constraint.go
@@ -41,7 +41,8 @@ func (t timeConstraint) code() []byte {
 		}
 		builder.AddOp(vm.OP_MAXTIME).AddInt64(int64(t.maxTimeMS)).AddOp(vm.OP_LESSTHANOREQUAL)
 	}
-	return builder.Program
+	prog, _ := builder.Build()
+	return prog
 }
 
 // outpointConstraint requires the outputID (and therefore, the outpoint) being spent to equal the
@@ -53,7 +54,8 @@ func (o outputIDConstraint) code() []byte {
 	builder.AddData(bc.Hash(o).Bytes())
 	builder.AddOp(vm.OP_OUTPUTID)
 	builder.AddOp(vm.OP_EQUAL)
-	return builder.Program
+	prog, _ := builder.Build()
+	return prog
 }
 
 // refdataConstraint requires the refdatahash of the transaction (if
@@ -75,7 +77,8 @@ func (r refdataConstraint) code() []byte {
 		builder.AddOp(vm.OP_ENTRYDATA)
 	}
 	builder.AddOp(vm.OP_EQUAL)
-	return builder.Program
+	prog, _ := builder.Build()
+	return prog
 }
 
 // PayConstraint requires the transaction to include a given output
@@ -97,5 +100,6 @@ func (p payConstraint) code() []byte {
 	}
 	builder.AddInt64(int64(p.Amount)).AddData(p.AssetId.Bytes()).AddInt64(1).AddData(p.Program)
 	builder.AddOp(vm.OP_CHECKOUTPUT)
-	return builder.Program
+	prog, _ := builder.Build()
+	return prog
 }

--- a/core/txbuilder/constraint.go
+++ b/core/txbuilder/constraint.go
@@ -41,7 +41,7 @@ func (t timeConstraint) code() []byte {
 		}
 		builder.AddOp(vm.OP_MAXTIME).AddInt64(int64(t.maxTimeMS)).AddOp(vm.OP_LESSTHANOREQUAL)
 	}
-	prog, _ := builder.Build()
+	prog, _ := builder.Build() // error is impossible
 	return prog
 }
 
@@ -54,7 +54,7 @@ func (o outputIDConstraint) code() []byte {
 	builder.AddData(bc.Hash(o).Bytes())
 	builder.AddOp(vm.OP_OUTPUTID)
 	builder.AddOp(vm.OP_EQUAL)
-	prog, _ := builder.Build()
+	prog, _ := builder.Build() // error is impossible
 	return prog
 }
 
@@ -77,7 +77,7 @@ func (r refdataConstraint) code() []byte {
 		builder.AddOp(vm.OP_ENTRYDATA)
 	}
 	builder.AddOp(vm.OP_EQUAL)
-	prog, _ := builder.Build()
+	prog, _ := builder.Build() // error is impossible
 	return prog
 }
 
@@ -100,6 +100,6 @@ func (p payConstraint) code() []byte {
 	}
 	builder.AddInt64(int64(p.Amount)).AddData(p.AssetId.Bytes()).AddInt64(1).AddData(p.Program)
 	builder.AddOp(vm.OP_CHECKOUTPUT)
-	prog, _ := builder.Build()
+	prog, _ := builder.Build() // error is impossible
 	return prog
 }

--- a/core/txbuilder/txbuilder_test.go
+++ b/core/txbuilder/txbuilder_test.go
@@ -196,7 +196,7 @@ func TestSignatureWitnessMaterialize(t *testing.T) {
 	builder := vmutil.NewBuilder()
 	builder.AddData(h.Bytes())
 	builder.AddOp(vm.OP_TXSIGHASH).AddOp(vm.OP_EQUAL)
-	prog := builder.Program
+	prog, _ := builder.Build()
 	msg := sha3.Sum256(prog)
 	sig1 := privkey1.Sign(msg[:])
 	sig2 := privkey2.Sign(msg[:])

--- a/core/txbuilder/witness.go
+++ b/core/txbuilder/witness.go
@@ -144,7 +144,8 @@ func buildSigProgram(tpl *Template, index uint32) []byte {
 		builder := vmutil.NewBuilder()
 		builder.AddData(h.Bytes())
 		builder.AddOp(vm.OP_TXSIGHASH).AddOp(vm.OP_EQUAL)
-		return builder.Program
+		prog, _ := builder.Build()
+		return prog
 	}
 	constraints := make([]constraint, 0, 3+len(tpl.Transaction.Outputs))
 	constraints = append(constraints, &timeConstraint{

--- a/core/txbuilder/witness.go
+++ b/core/txbuilder/witness.go
@@ -144,7 +144,7 @@ func buildSigProgram(tpl *Template, index uint32) []byte {
 		builder := vmutil.NewBuilder()
 		builder.AddData(h.Bytes())
 		builder.AddOp(vm.OP_TXSIGHASH).AddOp(vm.OP_EQUAL)
-		prog, _ := builder.Build()
+		prog, _ := builder.Build() // error is impossible
 		return prog
 	}
 	constraints := make([]constraint, 0, 3+len(tpl.Transaction.Outputs))

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3132";
+	public final String Id = "main/rev3133";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3132"
+const ID string = "main/rev3133"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3132"
+export const rev_id = "main/rev3133"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3132".freeze
+	ID = "main/rev3133".freeze
 end

--- a/protocol/bc/bctest/tx.go
+++ b/protocol/bc/bctest/tx.go
@@ -38,7 +38,7 @@ func NewIssuanceTx(tb testing.TB, initial bc.Hash, opts ...func(*legacy.Tx)) *le
 	}
 	builder := vmutil.NewBuilder()
 	builder.AddRawBytes(sigProg)
-	issuanceProgram := builder.Program
+	issuanceProgram, _ := builder.Build()
 
 	// Create a transaction issuing this new asset.
 	var nonce [8]byte
@@ -68,7 +68,7 @@ func NewIssuanceTx(tb testing.TB, initial bc.Hash, opts ...func(*legacy.Tx)) *le
 	h := tx.SigHash(0)
 	builder.AddData(h.Bytes())
 	builder.AddOp(vm.OP_TXSIGHASH).AddOp(vm.OP_EQUAL)
-	sigprog := builder.Program
+	sigprog, _ := builder.Build()
 	sigproghash := sha3.Sum256(sigprog)
 	signature := xprv.Sign(sigproghash[:])
 

--- a/protocol/bc/legacy/map.go
+++ b/protocol/bc/legacy/map.go
@@ -128,8 +128,9 @@ func mapTx(tx *TxData) (headerID bc.Hash, hdr *bc.TxHeader, entryMap map[bc.Hash
 				builder := vmutil.NewBuilder()
 				builder.AddData(oldIss.Nonce).AddOp(vm.OP_DROP)
 				builder.AddOp(vm.OP_ASSET).AddData(assetID.Bytes()).AddOp(vm.OP_EQUAL)
+				prog, _ := builder.Build()
 
-				nonce := bc.NewNonce(&bc.Program{VmVersion: 1, Code: builder.Program}, &trID)
+				nonce := bc.NewNonce(&bc.Program{VmVersion: 1, Code: prog}, &trID)
 				anchorID = addEntry(nonce)
 				setAnchored = nonce.SetAnchored
 			} else if firstSpend != nil {

--- a/protocol/bc/legacy/map.go
+++ b/protocol/bc/legacy/map.go
@@ -128,7 +128,7 @@ func mapTx(tx *TxData) (headerID bc.Hash, hdr *bc.TxHeader, entryMap map[bc.Hash
 				builder := vmutil.NewBuilder()
 				builder.AddData(oldIss.Nonce).AddOp(vm.OP_DROP)
 				builder.AddOp(vm.OP_ASSET).AddData(assetID.Bytes()).AddOp(vm.OP_EQUAL)
-				prog, _ := builder.Build()
+				prog, _ := builder.Build() // error is impossible
 
 				nonce := bc.NewNonce(&bc.Program{VmVersion: 1, Code: prog}, &trID)
 				anchorID = addEntry(nonce)

--- a/protocol/vmutil/builder.go
+++ b/protocol/vmutil/builder.go
@@ -1,31 +1,111 @@
 package vmutil
 
-import "chain/protocol/vm"
+import (
+	"encoding/binary"
+	"fmt"
+
+	"chain/protocol/vm"
+)
 
 type Builder struct {
-	Program []byte
+	program     []byte
+	jumpCounter int
+
+	// Maps a jump target number to its absolute address.
+	jumpAddr map[int]uint32
+
+	// Maps a jump target number to the list of places where its
+	// absolute address must be filled in once known.
+	jumpPlaceholders map[int][]int
 }
 
 func NewBuilder() *Builder {
-	return &Builder{}
+	return &Builder{
+		jumpAddr:         make(map[int]uint32),
+		jumpPlaceholders: make(map[int][]int),
+	}
 }
 
+// AddInt64 adds a pushdata instruction for an integer value.
 func (b *Builder) AddInt64(n int64) *Builder {
-	b.Program = append(b.Program, vm.PushdataInt64(n)...)
+	b.program = append(b.program, vm.PushdataInt64(n)...)
 	return b
 }
 
+// AddData adds a pushdata instruction for a given byte string.
 func (b *Builder) AddData(data []byte) *Builder {
-	b.Program = append(b.Program, vm.PushdataBytes(data)...)
+	b.program = append(b.program, vm.PushdataBytes(data)...)
 	return b
 }
 
+// AddRawBytes simply appends the given bytes to the program. (It does
+// not introduce a pushdata opcode.)
 func (b *Builder) AddRawBytes(data []byte) *Builder {
-	b.Program = append(b.Program, data...)
+	b.program = append(b.program, data...)
 	return b
 }
 
+// AddOp adds the given opcode to the program.
 func (b *Builder) AddOp(op vm.Op) *Builder {
-	b.Program = append(b.Program, byte(op))
+	b.program = append(b.program, byte(op))
 	return b
+}
+
+// NewJumpTarget allocates a number that can be used as a jump target
+// in AddJump and AddJumpIf. Call SetJumpTarget to associate the
+// number with a program location.
+func (b *Builder) NewJumpTarget() int {
+	b.jumpCounter++
+	return b.jumpCounter
+}
+
+// AddJump adds a JUMP opcode whose target is the given target
+// number. The actual program location of the target does not need to
+// be known yet, as long as SetJumpTarget is called before Build.
+func (b *Builder) AddJump(target int) *Builder {
+	return b.addJump(vm.OP_JUMP, target)
+}
+
+// AddJump adds a JUMPIF opcode whose target is the given target
+// number. The actual program location of the target does not need to
+// be known yet, as long as SetJumpTarget is called before Build.
+func (b *Builder) AddJumpIf(target int) *Builder {
+	return b.addJump(vm.OP_JUMPIF, target)
+}
+
+func (b *Builder) addJump(op vm.Op, target int) *Builder {
+	b.AddOp(op)
+	var addrBytes [4]byte
+	if addr, ok := b.jumpAddr[target]; ok {
+		binary.LittleEndian.PutUint32(addrBytes[:], addr)
+	} else {
+		b.jumpPlaceholders[target] = append(b.jumpPlaceholders[target], len(b.program))
+	}
+	b.AddRawBytes(addrBytes[:])
+	return b
+}
+
+// SetJumpTarget associates the given jump-target number with the
+// current position in the program - namely, the program's length,
+// such that the first instruction executed by a jump using this
+// target will be whatever instruction is added next. It is legal for
+// SetJumpTarget to be called at the end of the program, causing jumps
+// using that target to fall off the end. There must be a call to
+// SetJumpTarget for every jump target used before any call to Build.
+func (b *Builder) SetJumpTarget(target int) *Builder {
+	b.jumpAddr[target] = uint32(len(b.program))
+	return b
+}
+
+func (b *Builder) Build() ([]byte, error) {
+	for target, placeholders := range b.jumpPlaceholders {
+		addr, ok := b.jumpAddr[target]
+		if !ok {
+			return nil, fmt.Errorf("unresolved jump target %d", target)
+		}
+		for _, placeholder := range placeholders {
+			binary.LittleEndian.PutUint32(b.program[placeholder:placeholder+4], addr)
+		}
+	}
+	return b.program, nil
 }

--- a/protocol/vmutil/builder_test.go
+++ b/protocol/vmutil/builder_test.go
@@ -1,0 +1,161 @@
+package vmutil
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"chain/protocol/vm"
+)
+
+func TestAddInt64(t *testing.T) {
+	cases := []struct {
+		num     int64
+		wantHex string
+	}{
+		{0, "00"},
+		{1, "51"},
+		{15, "5f"},
+		{16, "60"},
+		{17, "0111"},
+		{255, "01ff"},
+		{256, "020001"},
+		{258, "020201"},
+		{65535, "02ffff"},
+		{65536, "03000001"},
+		{-1, "08ffffffffffffffff"},
+		{-2, "08feffffffffffffff"},
+		{-65536, "080000ffffffffffff"},
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("adding %d", c.num), func(t *testing.T) {
+			b := NewBuilder()
+			b.AddInt64(c.num)
+			prog, err := b.Build()
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := hex.DecodeString(c.wantHex)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(prog, want) {
+				t.Errorf("got %x, want %x", prog, want)
+			}
+		})
+	}
+}
+
+func TestAddJump(t *testing.T) {
+	cases := []struct {
+		name    string
+		wantHex string
+		fn      func(t *testing.T, b *Builder)
+	}{
+		{
+			"single jump single target not yet defined",
+			"630600000061",
+			func(t *testing.T, b *Builder) {
+				target := b.NewJumpTarget()
+				b.AddJump(target)
+				b.AddOp(vm.OP_NOP)
+				b.SetJumpTarget(target)
+			},
+		},
+		{
+			"single jump single target already defined",
+			"616300000000",
+			func(t *testing.T, b *Builder) {
+				target := b.NewJumpTarget()
+				b.SetJumpTarget(target)
+				b.AddOp(vm.OP_NOP)
+				b.AddJump(target)
+			},
+		},
+		{
+			"two jumps single target not yet defined",
+			"630c00000061630c00000061",
+			func(t *testing.T, b *Builder) {
+				target := b.NewJumpTarget()
+				b.AddJump(target)
+				b.AddOp(vm.OP_NOP)
+				b.AddJump(target)
+				b.AddOp(vm.OP_NOP)
+				b.SetJumpTarget(target)
+			},
+		},
+		{
+			"two jumps single target already defined",
+			"616300000000616300000000",
+			func(t *testing.T, b *Builder) {
+				target := b.NewJumpTarget()
+				b.SetJumpTarget(target)
+				b.AddOp(vm.OP_NOP)
+				b.AddJump(target)
+				b.AddOp(vm.OP_NOP)
+				b.AddJump(target)
+			},
+		},
+		{
+			"two jumps single target, one not yet defined, one already defined",
+			"630600000061616306000000",
+			func(t *testing.T, b *Builder) {
+				target := b.NewJumpTarget()
+				b.AddJump(target)
+				b.AddOp(vm.OP_NOP)
+				b.SetJumpTarget(target)
+				b.AddOp(vm.OP_NOP)
+				b.AddJump(target)
+			},
+		},
+		{
+			"two jumps, two targets, not yet defined",
+			"630c00000061630d0000006161",
+			func(t *testing.T, b *Builder) {
+				target1 := b.NewJumpTarget()
+				b.AddJump(target1)
+				b.AddOp(vm.OP_NOP)
+				target2 := b.NewJumpTarget()
+				b.AddJump(target2)
+				b.AddOp(vm.OP_NOP)
+				b.SetJumpTarget(target1)
+				b.AddOp(vm.OP_NOP)
+				b.SetJumpTarget(target2)
+			},
+		},
+		{
+			"two jumps, two targets, already defined",
+			"6161616301000000616302000000",
+			func(t *testing.T, b *Builder) {
+				b.AddOp(vm.OP_NOP)
+				target1 := b.NewJumpTarget()
+				b.SetJumpTarget(target1)
+				b.AddOp(vm.OP_NOP)
+				target2 := b.NewJumpTarget()
+				b.SetJumpTarget(target2)
+				b.AddOp(vm.OP_NOP)
+				b.AddJump(target1)
+				b.AddOp(vm.OP_NOP)
+				b.AddJump(target2)
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b := NewBuilder()
+			c.fn(t, b)
+			prog, err := b.Build()
+			if err != nil {
+				t.Fatal(err)
+			}
+			want, err := hex.DecodeString(c.wantHex)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(prog, want) {
+				t.Errorf("got %x, want %x", prog, want)
+			}
+		})
+	}
+}

--- a/protocol/vmutil/builder_test.go
+++ b/protocol/vmutil/builder_test.go
@@ -3,49 +3,10 @@ package vmutil
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
 	"testing"
 
 	"chain/protocol/vm"
 )
-
-func TestAddInt64(t *testing.T) {
-	cases := []struct {
-		num     int64
-		wantHex string
-	}{
-		{0, "00"},
-		{1, "51"},
-		{15, "5f"},
-		{16, "60"},
-		{17, "0111"},
-		{255, "01ff"},
-		{256, "020001"},
-		{258, "020201"},
-		{65535, "02ffff"},
-		{65536, "03000001"},
-		{-1, "08ffffffffffffffff"},
-		{-2, "08feffffffffffffff"},
-		{-65536, "080000ffffffffffff"},
-	}
-	for _, c := range cases {
-		t.Run(fmt.Sprintf("adding %d", c.num), func(t *testing.T) {
-			b := NewBuilder()
-			b.AddInt64(c.num)
-			prog, err := b.Build()
-			if err != nil {
-				t.Fatal(err)
-			}
-			want, err := hex.DecodeString(c.wantHex)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !bytes.Equal(prog, want) {
-				t.Errorf("got %x, want %x", prog, want)
-			}
-		})
-	}
-}
 
 func TestAddJump(t *testing.T) {
 	cases := []struct {

--- a/protocol/vmutil/script.go
+++ b/protocol/vmutil/script.go
@@ -31,7 +31,7 @@ func BlockMultiSigProgram(pubkeys []ed25519.PublicKey, nrequired int) ([]byte, e
 		builder.AddData(key)
 	}
 	builder.AddInt64(int64(nrequired)).AddInt64(int64(len(pubkeys))).AddOp(vm.OP_CHECKMULTISIG)
-	return builder.Program, nil
+	return builder.Build()
 }
 
 func ParseBlockMultiSigProgram(script []byte) ([]ed25519.PublicKey, int, error) {
@@ -91,7 +91,7 @@ func P2SPMultiSigProgram(pubkeys []ed25519.PublicKey, nrequired int) ([]byte, er
 	builder.AddOp(vm.OP_CHECKMULTISIG).AddOp(vm.OP_VERIFY) // stack is now [... NARGS]
 	builder.AddOp(vm.OP_FROMALTSTACK)                      // stack is now [... NARGS PREDICATE]
 	builder.AddInt64(0).AddOp(vm.OP_CHECKPREDICATE)
-	return builder.Program, nil
+	return builder.Build()
 }
 
 func ParseP2SPMultiSigProgram(program []byte) ([]ed25519.PublicKey, int, error) {


### PR DESCRIPTION
The `Builder` object keeps track of jump-target addresses and fills them in when `Build` is called.