### PR TITLE
database/raft: enforce allowed members list

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -175,6 +175,7 @@ func (a *API) buildHandler() {
 	m.Handle("/create-access-token", jsonHandler(a.createAccessToken))
 	m.Handle("/list-access-tokens", jsonHandler(a.listAccessTokens))
 	m.Handle("/delete-access-token", jsonHandler(a.deleteAccessToken))
+	m.Handle("/add-allowed-member", jsonHandler(a.addAllowedMember))
 	m.Handle("/configure", jsonHandler(a.configure))
 	m.Handle("/info", jsonHandler(a.info))
 

--- a/core/authz.go
+++ b/core/authz.go
@@ -53,6 +53,7 @@ var policyByRoute = map[string][]string{
 	"/create-access-token":        {"client-readwrite", "internal"},
 	"/list-access-tokens":         {"client-readwrite", "client-readonly"},
 	"/delete-access-token":        {"client-readwrite"},
+	"/add-allowed-member":         {"internal"},
 	"/configure":                  {"client-readwrite", "internal"},
 	"/info":                       {"client-readwrite", "client-readonly", "crosscore", "crosscore-signblock", "monitoring"},
 

--- a/core/authz.go
+++ b/core/authz.go
@@ -62,8 +62,7 @@ var policyByRoute = map[string][]string{
 	"/debug/pprof/symbol":  {"client-readwrite", "client-readonly", "monitoring"},
 	"/debug/pprof/trace":   {"client-readwrite", "client-readonly", "monitoring"},
 
-	"/raft/join": {"internal"},
-	"/raft/msg":  {"internal"},
+	"/raft/": {"internal"},
 
 	"/dashboard":  {"public"},
 	"/dashboard/": {"public"},

--- a/core/errors.go
+++ b/core/errors.go
@@ -85,6 +85,7 @@ var errorFormatter = httperror.Formatter{
 		config.ErrNoBlockHSMURL:        {400, "CH111", "Block HSM URL cannot be empty when configuring a non mockhsm signer"},
 		errNoClientTokens:              {400, "CH120", "Cannot enable client authentication with no client tokens"},
 		blocksigner.ErrConsensusChange: {400, "CH150", "Refuse to sign block with consensus change"},
+		errMissingAddr:                 {400, "CH160", "Address is missing"},
 
 		// Signers error namespace (2xx)
 		signers.ErrBadQuorum: {400, "CH200", "Quorum must be greater than 1 and less than or equal to the length of xpubs"},

--- a/core/membership.go
+++ b/core/membership.go
@@ -1,0 +1,19 @@
+package core
+
+import (
+	"context"
+
+	"chain/errors"
+)
+
+var errMissingAddr = errors.New("missing address")
+
+func (a *API) addAllowedMember(ctx context.Context, x struct {
+	Addr string `json:"addr"`
+}) error {
+	if x.Addr == "" {
+		return errMissingAddr
+	}
+	return a.raftDB.AddAllowedMember(ctx, x.Addr)
+	// TODO(tessr): create grant for this new member
+}

--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -593,7 +593,7 @@ func (sv *Service) serveJoin(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if !sv.isAllowedMember(req.Context(), x.Addr) {
-		http.Error(w, "this address is not allowed. please add this address to the allowed member list", 400) // it's like a country club in here
+		http.Error(w, "this address is not allowed. please add this address to the allowed member list", 400)
 		return
 	}
 

--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -175,7 +175,6 @@ func Start(laddr, dir, bootURL string, httpClient *http.Client, useTLS bool) (*S
 
 	// TODO(kr): grpc
 	sv.mux.HandleFunc("/raft/join", sv.serveJoin)
-	sv.mux.HandleFunc("/raft/add-allowed-member", sv.serveAddAllowedMember)
 	sv.mux.HandleFunc("/raft/msg", sv.serveMsg)
 
 	walobj, err := sv.recover()
@@ -615,29 +614,6 @@ func (sv *Service) serveJoin(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	json.NewEncoder(w).Encode(nodeJoin{newID, snapData})
-}
-
-func (sv *Service) serveAddAllowedMember(w http.ResponseWriter, req *http.Request) {
-	var x struct {
-		Addr string `json:"addr"`
-	}
-	err := json.NewDecoder(req.Body).Decode(&x)
-	if err != nil {
-		http.Error(w, err.Error(), 400)
-		return
-	}
-
-	if x.Addr == "" {
-		http.Error(w, "missing address", 400)
-	}
-
-	err = sv.AddAllowedMember(req.Context(), x.Addr)
-	if err != nil {
-		http.Error(w, err.Error(), 500)
-		return
-	}
-
-	json.NewEncoder(w).Encode("success") // ??
 }
 
 // join attempts to join the cluster.

--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -636,7 +636,7 @@ func (sv *Service) join(addr, baseURL string) error {
 			return errors.Wrap(err, "could not parse response from boot server")
 		}
 		defer resp.Body.Close()
-		return errors.New(fmt.Sprintf("boot server responded with status %d: %s", resp.StatusCode, errmsg))
+		return fmt.Errorf("boot server responded with status %d: %s", resp.StatusCode, errmsg)
 	}
 
 	var x nodeJoin

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3065";
+	public final String Id = "main/rev3066";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3065"
+const ID string = "main/rev3066"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3065"
+export const rev_id = "main/rev3066"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3065".freeze
+	ID = "main/rev3066".freeze
 end


### PR DESCRIPTION
Enforces the allowed members list and adds an endpoint to actually add to this list. 

Next: Connecting corectl to that endpoint. 