### PR TITLE
all: use "localhost auth" instead of "loopback auth"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ Build and install from source:
 
 There are four build tags that change the behavior of the resulting binary:
   - `reset`: allows the core database to be reset through the api
-  - `loopback_auth`: allows unauthenticated requests on the loopback device
+  - `loopback_auth`: allows unauthenticated requests on the loopback device (localhost)
   - `no_mockhsm`: disables the MockHSM provided for development
   - `plain_http`: allows plain HTTP requests
 

--- a/cmd/cored/loopback_auth.go
+++ b/cmd/cored/loopback_auth.go
@@ -1,5 +1,5 @@
 //+build loopback_auth
-// TODO: for consistent language, rename this build flag to localhost_auth
+// TODO: for consistent language, rename this tag to localhost_auth
 
 package main
 

--- a/cmd/cored/loopback_auth.go
+++ b/cmd/cored/loopback_auth.go
@@ -7,5 +7,5 @@ import "chain/core/config"
 
 // See $CHAIN/net/http/authz/loopback_authz.go for the implementation.
 func init() {
-	config.BuildConfig.LocalhostAuth = true
+	config.BuildConfig.LoopbackAuth = true
 }

--- a/cmd/cored/loopback_auth.go
+++ b/cmd/cored/loopback_auth.go
@@ -1,4 +1,5 @@
 //+build loopback_auth
+// TODO: for consistent language, rename this build flag to localhost_auth
 
 package main
 
@@ -6,5 +7,5 @@ import "chain/core/config"
 
 // See $CHAIN/net/http/authz/loopback_authz.go for the implementation.
 func init() {
-	config.BuildConfig.LoopbackAuth = true
+	config.BuildConfig.LocalhostAuth = true
 }

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -118,7 +118,7 @@ func main() {
 	fmt.Printf("build-commit: %v\n", config.BuildCommit)
 	fmt.Printf("build-date: %v\n", config.BuildDate)
 	fmt.Printf("mockhsm: %t\n", config.BuildConfig.MockHSM)
-	fmt.Printf("localhost_auth: %t\n", config.BuildConfig.LocalhostAuth)
+	fmt.Printf("localhost_auth: %t\n", config.BuildConfig.LoopbackAuth)
 	fmt.Printf("reset: %t\n", config.BuildConfig.Reset)
 	fmt.Printf("plain_http: %t\n", config.BuildConfig.PlainHTTP)
 

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -118,7 +118,7 @@ func main() {
 	fmt.Printf("build-commit: %v\n", config.BuildCommit)
 	fmt.Printf("build-date: %v\n", config.BuildDate)
 	fmt.Printf("mockhsm: %t\n", config.BuildConfig.MockHSM)
-	fmt.Printf("loopback_auth: %t\n", config.BuildConfig.LoopbackAuth)
+	fmt.Printf("localhost_auth: %t\n", config.BuildConfig.LocalhostAuth)
 	fmt.Printf("reset: %t\n", config.BuildConfig.Reset)
 	fmt.Printf("plain_http: %t\n", config.BuildConfig.PlainHTTP)
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -49,15 +49,15 @@ var (
 	// This is the default, Chain development configuration.
 	// These options can be updated with build tags.
 	BuildConfig = struct {
-		LoopbackAuth bool `json:"is_loopback_auth"`
-		MockHSM      bool `json:"is_mockhsm"`
-		Reset        bool `json:"is_reset"`
-		PlainHTTP    bool `json:"is_plain_http"`
+		LocalhostAuth bool `json:"is_localhost_auth"`
+		MockHSM       bool `json:"is_mockhsm"`
+		Reset         bool `json:"is_reset"`
+		PlainHTTP     bool `json:"is_plain_http"`
 	}{
-		LoopbackAuth: false,
-		MockHSM:      true,
-		Reset:        false,
-		PlainHTTP:    false,
+		LocalhostAuth: false,
+		MockHSM:       true,
+		Reset:         false,
+		PlainHTTP:     false,
 	}
 )
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -49,15 +49,15 @@ var (
 	// This is the default, Chain development configuration.
 	// These options can be updated with build tags.
 	BuildConfig = struct {
-		LocalhostAuth bool `json:"is_localhost_auth"`
-		MockHSM       bool `json:"is_mockhsm"`
-		Reset         bool `json:"is_reset"`
-		PlainHTTP     bool `json:"is_plain_http"`
+		LoopbackAuth bool `json:"is_localhost_auth"`
+		MockHSM      bool `json:"is_mockhsm"`
+		Reset        bool `json:"is_reset"`
+		PlainHTTP    bool `json:"is_plain_http"`
 	}{
-		LocalhostAuth: false,
-		MockHSM:       true,
-		Reset:         false,
-		PlainHTTP:     false,
+		LoopbackAuth: false,
+		MockHSM:      true,
+		Reset:        false,
+		PlainHTTP:    false,
 	}
 )
 

--- a/dashboard/src/features/core/components/CoreIndex/CoreIndex.jsx
+++ b/dashboard/src/features/core/components/CoreIndex/CoreIndex.jsx
@@ -79,8 +79,8 @@ class CoreIndex extends React.Component {
                 <td><code>{this.props.core.mockhsm.toString()}</code></td>
               </tr>
               <tr>
-                <td className={styles.row_label}>Loopback auth:</td>
-                <td><code>{this.props.core.loopback.toString()}</code></td>
+                <td className={styles.row_label}>Localhost auth:</td>
+                <td><code>{this.props.core.localhostAuth.toString()}</code></td>
               </tr>
               <tr>
                 <td className={styles.row_label}>Reset enabled:</td>

--- a/dashboard/src/features/core/reducers.js
+++ b/dashboard/src/features/core/reducers.js
@@ -40,8 +40,8 @@ export const configuredAt = (state, action) => {
 
 export const mockhsm = (state, action) =>
   buildConfigReducer('isMockhsm', state, false, action)
-export const loopback = (state, action) =>
-  buildConfigReducer('isLoopbackAuth', state, false, action)
+export const localhostAuth = (state, action) =>
+  buildConfigReducer('isLocalhostAuth', state, false, action)
 export const reset = (state, action) =>
   buildConfigReducer('isReset', state, false, action)
 export const plainHttp = (state, action) =>
@@ -219,7 +219,7 @@ export default combineReducers({
   generatorAccessToken,
   generatorBlockHeight,
   generatorUrl,
-  loopback,
+  localhostAuth,
   mockhsm,
   crosscoreRpcVersion,
   onTestnet,

--- a/docs/internal/api-spec.swagger.yml
+++ b/docs/internal/api-spec.swagger.yml
@@ -1069,7 +1069,7 @@ definitions:
         type: boolean
         description: Whether the core was compiled with the ability to reset
           the database.
-      is_loopback_auth:
+      is_localhost_auth:
         type: boolean
         description: Whether the core was compiled with the ability to make
           unauthenticated requests on the loopback interface.

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3063";
+	public final String Id = "main/rev3064";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3063"
+const ID string = "main/rev3064"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3063"
+export const rev_id = "main/rev3064"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3063".freeze
+	ID = "main/rev3064".freeze
 end

--- a/net/http/authz/loopback_authz.go
+++ b/net/http/authz/loopback_authz.go
@@ -1,5 +1,5 @@
 //+build loopback_auth
-// TODO: for consistent language, rename this build flag to localhost_auth
+// TODO: for consistent language, rename this tag to localhost_auth
 
 package authz
 

--- a/net/http/authz/loopback_authz.go
+++ b/net/http/authz/loopback_authz.go
@@ -1,4 +1,5 @@
 //+build loopback_auth
+// TODO: for consistent language, rename this build flag to localhost_auth
 
 package authz
 

--- a/sdk/java/src/main/java/com/chain/api/CoreConfig.java
+++ b/sdk/java/src/main/java/com/chain/api/CoreConfig.java
@@ -63,8 +63,8 @@ public class CoreConfig {
     public Snapshot snapshot;
 
     public static class BuildConfig {
-      @SerializedName("is_loopback_auth")
-      public boolean isLoopbackAuth;
+      @SerializedName("is_localhost_auth")
+      public boolean isLocalhostAuth;
 
       @SerializedName("is_mockhsm")
       public boolean isMockHsm;

--- a/sdk/node/src/api/config.js
+++ b/sdk/node/src/api/config.js
@@ -68,7 +68,7 @@ const shared = require('../shared')
  * @property {Object} buildConfig
  * Features enabled or disabled in this build of Chain Core.
  *
- * @property {Boolean} buildConfig.isLoopbackAuth
+ * @property {Boolean} buildConfig.isLocalhostAuth
  * Whether any request from the loopback device (localhost) should be
  * automatically authenticated and authorized, without additional
  * credentials.

--- a/sdk/ruby/lib/chain/config.rb
+++ b/sdk/ruby/lib/chain/config.rb
@@ -6,12 +6,12 @@ module Chain
 
     class Info < ResponseObject
       class BuildConfig < ResponseObject
-        # @!attribute [r] is_loopback_auth
+        # @!attribute [r] is_localhost_auth
         # @return [Boolean]
         # Whether any request from the loopback device (localhost) should be
         # automatically authenticated and authorized, without additional
         # credentials.
-        attrib :is_loopback_auth
+        attrib :is_localhost_auth
 
         # @!attribute [r] is_mockhsm
         # @return [Boolean]


### PR DESCRIPTION
"Localhost" is more legible than "loopback". This builds on the
direction already started by the "localhost" authorization guard.

The loopback_auth build tag will be updated in the future, when there is
less QA churn.