### PR TITLE
database/raft: match behavior of crypto/tls

### DIFF
--- a/database/raft/tls.go
+++ b/database/raft/tls.go
@@ -3,12 +3,14 @@ package raft
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"net"
 	"net/http"
 
 	"chain/errors"
 )
 
-func verifyTLSName(name string, client *http.Client) error {
+func verifyTLSName(addr string, client *http.Client) error {
+	hostname, _, _ := net.SplitHostPort(addr)
 	c := clientTLS(client)
 	if c == nil {
 		return nil
@@ -17,7 +19,7 @@ func verifyTLSName(name string, client *http.Client) error {
 	if err != nil {
 		return errors.Wrap(err)
 	}
-	return errors.Wrap(x509Cert.VerifyHostname(name))
+	return errors.Wrap(x509Cert.VerifyHostname(hostname))
 }
 
 func clientTLS(c *http.Client) *tls.Config {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3061";
+	public final String Id = "main/rev3062";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3061"
+const ID string = "main/rev3062"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3061"
+export const rev_id = "main/rev3062"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3061".freeze
+	ID = "main/rev3062".freeze
 end


### PR DESCRIPTION
We need to verify just the hostname, not including the
colon and port number suffix.