### PR TITLE
database/raft: use correct HTTP client

### DIFF
--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -621,7 +621,7 @@ func (sv *Service) serveJoin(w http.ResponseWriter, req *http.Request) {
 func (sv *Service) join(addr, baseURL string) error {
 	reqURL := strings.TrimRight(baseURL, "/") + "/raft/join"
 	b, _ := json.Marshal(struct{ Addr string }{addr})
-	resp, err := http.Post(reqURL, contentType, bytes.NewReader(b))
+	resp, err := sv.client.Post(reqURL, contentType, bytes.NewReader(b))
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3062";
+	public final String Id = "main/rev3063";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3062"
+const ID string = "main/rev3063"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3062"
+export const rev_id = "main/rev3063"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3062".freeze
+	ID = "main/rev3063".freeze
 end


### PR DESCRIPTION
DefaultClient (which uses the system cert pool) will
refuse to validate the peer's certificate.