### PR TITLE
dashboard: support protected grant flag

### DIFF
--- a/dashboard/src/features/accessControl/actions.js
+++ b/dashboard/src/features/accessControl/actions.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { chainClient } from 'utility/environment'
 import { actions as appActions } from 'features/app'
 import { push } from 'react-router-redux'
-import { subjectFieldOptions } from 'features/accessControl/constants'
+import { subjectFieldOptions, hasProtectedGrant } from 'features/accessControl/constants'
 import TokenCreateModal from './components/TokenCreateModal'
 
 // Given a list of policies, create a grant for
@@ -12,8 +12,11 @@ const setPolicies = (body, policies) => {
   const promises = []
 
   for (let key in policies) {
+    if (body.grants && hasProtectedGrant(body.grants, key)) continue
+
     const grant = {
-      ...body,
+      guardData: body.guardData,
+      guardType: body.guardType,
       policy: key
     }
 
@@ -119,10 +122,7 @@ export default {
   }),
 
   editPolicies: data => {
-    const body = {
-      guardType: data.grant.guardType,
-      guardData: data.grant.guardData,
-    }
+    const body = data.grant
     const policies = data.policies
 
     return dispatch =>

--- a/dashboard/src/features/accessControl/actions.js
+++ b/dashboard/src/features/accessControl/actions.js
@@ -2,7 +2,8 @@ import React from 'react'
 import { chainClient } from 'utility/environment'
 import { actions as appActions } from 'features/app'
 import { push } from 'react-router-redux'
-import { subjectFieldOptions, hasProtectedGrant } from 'features/accessControl/constants'
+import { subjectFieldOptions } from './constants'
+import { hasProtectedGrant } from './selectors'
 import TokenCreateModal from './components/TokenCreateModal'
 
 // Given a list of policies, create a grant for

--- a/dashboard/src/features/accessControl/actions.js
+++ b/dashboard/src/features/accessControl/actions.js
@@ -12,7 +12,7 @@ const setPolicies = (body, policies) => {
   const promises = []
 
   for (let key in policies) {
-    if (body.grants && hasProtectedGrant(body.grants, key)) continue
+    if (hasProtectedGrant(body.grants || [], key)) continue
 
     const grant = {
       guardData: body.guardData,

--- a/dashboard/src/features/accessControl/components/EditPolicies.jsx
+++ b/dashboard/src/features/accessControl/components/EditPolicies.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { BaseNew, CheckboxField } from 'features/shared/components'
-import { policyOptions } from 'features/accessControl/constants'
+import { policyOptions, hasProtectedGrant } from 'features/accessControl/constants'
 import { reduxForm } from 'redux-form'
 import actions from 'features/accessControl/actions'
 import styles from './EditPolicies.scss'
@@ -15,13 +15,13 @@ class EditPolicies extends React.Component {
     return(
       <div className={styles.main}>
         {policyOptions.map(option => {
-          const grant = this.props.item.grants.find(g => g.policy == option.value)
+          const isProtected = hasProtectedGrant(this.props.item.grants, option.value)
           return <CheckboxField key={option.label}
             title={option.label}
             hint={option.hint}
             fieldProps={{
               ...policies[option.value],
-              disabled: grant && grant.protected
+              disabled: isProtected,
             }} />
         })}
 

--- a/dashboard/src/features/accessControl/components/EditPolicies.jsx
+++ b/dashboard/src/features/accessControl/components/EditPolicies.jsx
@@ -15,10 +15,14 @@ class EditPolicies extends React.Component {
     return(
       <div className={styles.main}>
         {policyOptions.map(option => {
+          const grant = this.props.item.grants.find(g => g.policy == option.value)
           return <CheckboxField key={option.label}
             title={option.label}
             hint={option.hint}
-            fieldProps={policies[option.value]} />
+            fieldProps={{
+              ...policies[option.value],
+              disabled: grant && grant.protected
+            }} />
         })}
 
         <button className='btn btn-primary' onClick={handleSubmit(this.props.submitForm)}>Save</button>
@@ -39,7 +43,8 @@ const initialValues = (state, ownProps) => {
     initialValues: {
       grant: item,
       policies: policyOptions.reduce((memo, p) => {
-        memo[p.value] = item.policies.indexOf(p.value) >= 0
+        const policyIndex = item.grants.findIndex(grant => grant.policy == p.value)
+        memo[p.value] = policyIndex >= 0
         return memo
       }, {}),
     }

--- a/dashboard/src/features/accessControl/components/EditPolicies.jsx
+++ b/dashboard/src/features/accessControl/components/EditPolicies.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { BaseNew, CheckboxField } from 'features/shared/components'
-import { policyOptions, hasProtectedGrant } from 'features/accessControl/constants'
+import { policyOptions } from 'features/accessControl/constants'
+import { hasProtectedGrant } from 'features/accessControl/selectors'
 import { reduxForm } from 'redux-form'
 import actions from 'features/accessControl/actions'
 import styles from './EditPolicies.scss'

--- a/dashboard/src/features/accessControl/components/GrantListItem.jsx
+++ b/dashboard/src/features/accessControl/components/GrantListItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { isAccessToken, getPolicyNamesString } from 'features/accessControl/selectors'
+import { isAccessToken, getPolicyNames } from 'features/accessControl/selectors'
 import EditPolicies from './EditPolicies'
 import { isArray } from 'lodash'
 
@@ -29,7 +29,9 @@ class GrantListItem extends React.Component {
       <tr>
         <td>{desc}</td>
         {!item.isEditing && <td>
-          {getPolicyNamesString(item)}
+          {getPolicyNames(item).map(name =>
+            <span key={name}>{name}<br /></span>
+          )}
         </td>}
         {!item.isEditing && <td>
           <button className='btn btn-link' onClick={this.props.beginEditing.bind(this, item.id)}>

--- a/dashboard/src/features/accessControl/constants.js
+++ b/dashboard/src/features/accessControl/constants.js
@@ -26,6 +26,8 @@ export const policyOptions = [
   },
 ]
 
+export const protectedSuffix = '-protected'
+
 export const subjectFieldOptions = [
   {label: 'CommonName', value: 'cn'},
   {label: 'Country', value: 'c', array: true},

--- a/dashboard/src/features/accessControl/constants.js
+++ b/dashboard/src/features/accessControl/constants.js
@@ -37,3 +37,6 @@ export const subjectFieldOptions = [
   {label: 'PostalCode', value: 'postalcode', array: true},
   {label: 'SerialNumber', value: 'serialnumber'},
 ]
+
+export const hasProtectedGrant = (grants, policy) =>
+  grants.find(grant => grant.protected && grant.policy == policy) != undefined

--- a/dashboard/src/features/accessControl/constants.js
+++ b/dashboard/src/features/accessControl/constants.js
@@ -26,8 +26,6 @@ export const policyOptions = [
   },
 ]
 
-export const protectedSuffix = '-protected'
-
 export const subjectFieldOptions = [
   {label: 'CommonName', value: 'cn'},
   {label: 'Country', value: 'c', array: true},

--- a/dashboard/src/features/accessControl/constants.js
+++ b/dashboard/src/features/accessControl/constants.js
@@ -37,6 +37,3 @@ export const subjectFieldOptions = [
   {label: 'PostalCode', value: 'postalcode', array: true},
   {label: 'SerialNumber', value: 'serialnumber'},
 ]
-
-export const hasProtectedGrant = (grants, policy) =>
-  grants.find(grant => grant.protected && grant.policy == policy) != undefined

--- a/dashboard/src/features/accessControl/reducers.js
+++ b/dashboard/src/features/accessControl/reducers.js
@@ -1,4 +1,11 @@
 import createHash from 'sha.js'
+import { protectedSuffix } from './constants'
+
+const grantPolicy = (grant) => {
+  let policy = grant.policy
+  if (grant.protected) policy = `${policy}${protectedSuffix}`
+  return policy
+}
 
 export default (state = {ids: [], items: {}}, action) => {
   // Grant list is always complete, so we rebuild state from scratch
@@ -24,7 +31,7 @@ export default (state = {ids: [], items: {}}, action) => {
       const id = createHash('sha256').update(JSON.stringify(grant.guardData), 'utf8').digest('hex')
 
       if (newObjects[id]) {
-        newObjects[id].policies.push(grant.policy)
+        newObjects[id].policies.push(grantPolicy(grant))
         if (newObjects[id].createdAt.localeCompare(grant.createdAt) > 0) {
           newObjects[id].createdAt = grant.createdAt
         }
@@ -33,7 +40,7 @@ export default (state = {ids: [], items: {}}, action) => {
           id: id,
           guardType: grant.guardType,
           guardData: grant.guardData,
-          policies: [grant.policy],
+          policies: [grantPolicy(grant)],
           createdAt: grant.createdAt
         }
       }

--- a/dashboard/src/features/accessControl/reducers.js
+++ b/dashboard/src/features/accessControl/reducers.js
@@ -1,5 +1,5 @@
 import createHash from 'sha.js'
-import { hasProtectedGrant } from './constants'
+import { hasProtectedGrant } from './selectors'
 
 export default (state = {ids: [], items: {}}, action) => {
   // Grant list is always complete, so we rebuild state from scratch

--- a/dashboard/src/features/accessControl/reducers.js
+++ b/dashboard/src/features/accessControl/reducers.js
@@ -1,4 +1,5 @@
 import createHash from 'sha.js'
+import { hasProtectedGrant } from './constants'
 
 export default (state = {ids: [], items: {}}, action) => {
   // Grant list is always complete, so we rebuild state from scratch
@@ -24,6 +25,8 @@ export default (state = {ids: [], items: {}}, action) => {
       const id = createHash('sha256').update(JSON.stringify(grant.guardData), 'utf8').digest('hex')
 
       if (newObjects[id]) {
+        if (hasProtectedGrant(newObjects[id].grants, grant.policy)) return
+
         newObjects[id].grants.push(grant)
         if (newObjects[id].createdAt.localeCompare(grant.createdAt) > 0) {
           newObjects[id].createdAt = grant.createdAt

--- a/dashboard/src/features/accessControl/reducers.js
+++ b/dashboard/src/features/accessControl/reducers.js
@@ -1,5 +1,4 @@
 import createHash from 'sha.js'
-import { hasProtectedGrant } from './selectors'
 
 export default (state = {ids: [], items: {}}, action) => {
   // Grant list is always complete, so we rebuild state from scratch
@@ -25,7 +24,12 @@ export default (state = {ids: [], items: {}}, action) => {
       const id = createHash('sha256').update(JSON.stringify(grant.guardData), 'utf8').digest('hex')
 
       if (newObjects[id]) {
-        if (hasProtectedGrant(newObjects[id].grants, grant.policy)) return
+        const existingIndex = newObjects[id].grants.findIndex(g => g.policy == grant.policy)
+        if (existingIndex >= 0) {
+          const existing = newObjects[id].grants[existingIndex]
+          if (existing.protected) { return }
+          if (grant.protected) { newObjects[id].grants.splice(existingIndex, 1) }
+        }
 
         newObjects[id].grants.push(grant)
         if (newObjects[id].createdAt.localeCompare(grant.createdAt) > 0) {

--- a/dashboard/src/features/accessControl/selectors.js
+++ b/dashboard/src/features/accessControl/selectors.js
@@ -1,12 +1,23 @@
 import { createSelector } from 'reselect'
-import { policyOptions } from './constants'
+import { policyOptions, protectedSuffix } from './constants'
 
 export const getPolicyNames = createSelector(
   item => item.policies,
   policies => policies.map(
-    policy => policyOptions.find(
-      elem => elem.value == policy
-    ).label
+    policy => {
+      let isProtected = false
+      if (policy.indexOf(protectedSuffix) >= 0) {
+        policy = policy.replace(protectedSuffix, '')
+        isProtected = true
+      }
+
+      const found = policyOptions.find(elem => elem.value == policy)
+      let label = found ? found.label : policy
+      if (isProtected) {
+        label = label + ' (Protected)'
+      }
+      return label
+    }
   )
 )
 

--- a/dashboard/src/features/accessControl/selectors.js
+++ b/dashboard/src/features/accessControl/selectors.js
@@ -24,3 +24,6 @@ export const isAccessToken = createSelector(
   guardType,
   type => type == 'access_token'
 )
+
+export const hasProtectedGrant = (grants, policy) =>
+  grants.find(grant => grant.protected && grant.policy == policy) != undefined

--- a/dashboard/src/features/accessControl/selectors.js
+++ b/dashboard/src/features/accessControl/selectors.js
@@ -5,8 +5,8 @@ export const getPolicyNames = createSelector(
   item => item.grants,
   grants => grants.map(
     grant => {
-      let isProtected = grant.protected
-      let policy = grant.policy
+      const isProtected = grant.protected
+      const policy = grant.policy
 
       const found = policyOptions.find(elem => elem.value == policy)
       let label = found ? found.label : policy

--- a/dashboard/src/features/accessControl/selectors.js
+++ b/dashboard/src/features/accessControl/selectors.js
@@ -1,15 +1,12 @@
 import { createSelector } from 'reselect'
-import { policyOptions, protectedSuffix } from './constants'
+import { policyOptions } from './constants'
 
 export const getPolicyNames = createSelector(
-  item => item.policies,
-  policies => policies.map(
-    policy => {
-      let isProtected = false
-      if (policy.indexOf(protectedSuffix) >= 0) {
-        policy = policy.replace(protectedSuffix, '')
-        isProtected = true
-      }
+  item => item.grants,
+  grants => grants.map(
+    grant => {
+      let isProtected = grant.protected
+      let policy = grant.policy
 
       const found = policyOptions.find(elem => elem.value == policy)
       let label = found ? found.label : policy
@@ -19,11 +16,6 @@ export const getPolicyNames = createSelector(
       return label
     }
   )
-)
-
-export const getPolicyNamesString = createSelector(
-  getPolicyNames,
-  names => names.join(', ')
 )
 
 export const guardType = (item) => item.guardType

--- a/dashboard/src/features/shared/components/CheckboxField/CheckboxField.jsx
+++ b/dashboard/src/features/shared/components/CheckboxField/CheckboxField.jsx
@@ -8,7 +8,8 @@ const CHECKBOX_FIELD_PROPS = [
   'onChange',
   'onFocus',
   'name',
-  'checked'
+  'checked',
+  'disabled'
 ]
 
 class CheckboxField extends React.Component {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3072";
+	public final String Id = "main/rev3073";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3072"
+const ID string = "main/rev3073"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3072"
+export const rev_id = "main/rev3073"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3072".freeze
+	ID = "main/rev3073".freeze
 end


### PR DESCRIPTION
Persist individual grants in the redux store instead of just policy names
to allow access to the `protected` flag.

Protected grants are marked as `checked` and `disabled` when editing,
indicating to users that they cannot be removed.