### PR TITLE
database/raft: fix WAL snapshot after joining a cluster

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3067";
+	public final String Id = "main/rev3068";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3067"
+const ID string = "main/rev3068"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3067"
+export const rev_id = "main/rev3068"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3067".freeze
+	ID = "main/rev3068".freeze
 end


### PR DESCRIPTION
We need to save the initial snapshot to the WAL
immediately when joining a cluster. Failing to do this
means subsequent entries are not saved until the next
snapshot, causing a crash on restart.

In the vendored raft package, on startup, the read
snapshot serves as the base index for the slice of
entries. The slice of entries is initially empty, and
entries are appended as they're read. Entries with an
index greater than the currently read entry are sliced
off.

The crash happens there. If we fail to save the initial
snapshot, then the base index will be 0 and the first
entry record has a nonzero index, causing an
out-of-bounds slice operation.