### PR TITLE
cmd/corectl: new command to add allowed addresses

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -60,6 +60,7 @@ var commands = map[string]*command{
 	"reset":                {reset},
 	"grant":                {grant},
 	"revoke":               {revoke},
+	"allow-address":        {allowRaftMember},
 }
 
 func main() {
@@ -371,6 +372,23 @@ The type of guard (before the = sign) is case-insensitive.
 	err := client.Call(context.Background(), path, req, nil)
 	if err != nil {
 		fatalln("error:", action, fmt.Sprintf("%+v:", req), err)
+	}
+}
+
+// allowRaftMember takes an address and adds it to the list of addresses that are
+// allowed for raft cluster members.
+func allowRaftMember(client *rpc.Client, args []string) {
+	if len(args) != 0 {
+		fatalln("error: reset takes no args")
+	}
+
+	req := map[string]string{
+		"addr": addr,
+	}
+
+	err := client.Call(context.Background(), "/raft/add-allowed-member", req, nil)
+	if err != nil {
+		fatalln("rpc error:", err)
 	}
 }
 

--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -378,15 +378,16 @@ The type of guard (before the = sign) is case-insensitive.
 // allowRaftMember takes an address and adds it to the list of addresses that are
 // allowed for raft cluster members.
 func allowRaftMember(client *rpc.Client, args []string) {
-	if len(args) != 0 {
-		fatalln("error: reset takes no args")
+	usage := "usage: corectl allow-address [member address]"
+	if len(args) != 1 {
+		fatalln(usage)
 	}
 
 	req := map[string]string{
-		"addr": addr,
+		"addr": args[0],
 	}
 
-	err := client.Call(context.Background(), "/raft/add-allowed-member", req, nil)
+	err := client.Call(context.Background(), "/add-allowed-member", req, nil)
 	if err != nil {
 		fatalln("rpc error:", err)
 	}

--- a/core/membership.go
+++ b/core/membership.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net"
 	"time"
 
@@ -27,7 +28,6 @@ func (a *API) addAllowedMember(ctx context.Context, x struct {
 	if err != nil {
 		return errors.Wrap(err)
 	}
-
 	data := map[string]interface{}{
 		"subject": map[string]string{
 			"CN": hostname,
@@ -46,6 +46,8 @@ func (a *API) addAllowedMember(ctx context.Context, x struct {
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
 		Protected: true,
 	}
+
+	log.Printf("grant: %+v", grant)
 
 	_, err = authz.StoreGrant(ctx, a.raftDB, grant, grantPrefix)
 	return errors.Wrap(err)

--- a/core/membership.go
+++ b/core/membership.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"encoding/json"
-	"log"
 	"net"
 	"time"
 
@@ -28,6 +27,7 @@ func (a *API) addAllowedMember(ctx context.Context, x struct {
 	if err != nil {
 		return errors.Wrap(err)
 	}
+
 	data := map[string]interface{}{
 		"subject": map[string]string{
 			"CN": hostname,
@@ -46,8 +46,6 @@ func (a *API) addAllowedMember(ctx context.Context, x struct {
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
 		Protected: true,
 	}
-
-	log.Printf("grant: %+v", grant)
 
 	_, err = authz.StoreGrant(ctx, a.raftDB, grant, grantPrefix)
 	return errors.Wrap(err)

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3071";
+	public final String Id = "main/rev3072";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3071"
+const ID string = "main/rev3072"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3071"
+export const rev_id = "main/rev3072"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3071".freeze
+	ID = "main/rev3072".freeze
 end


### PR DESCRIPTION
... for raft. 

Also includes a fix to the raft package: previously, raft did not anticipate a failure partway through a node attempting to join the cluster, and so it created the WAL directory and the node ID in an order that did not accommodate retrying after a partial failure. 