### PR TITLE
cmd/corectl: add wait subcommand

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -470,10 +470,8 @@ func wait(client *rpc.Client, args []string) {
 			break
 		}
 
-		if statusErr, ok := errors.Root(err).(rpc.ErrStatusCode); ok {
-			if statusErr.StatusCode/100 != 5 {
-				break
-			}
+		if statusErr, ok := errors.Root(err).(rpc.ErrStatusCode); ok && statusErr.StatusCode/100 != 5 {
+			break
 		}
 
 		time.Sleep(500 * time.Millisecond)

--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -22,6 +22,7 @@ import (
 	"chain/core/rpc"
 	"chain/crypto/ed25519"
 	"chain/env"
+	"chain/errors"
 	"chain/generated/rev"
 	"chain/log"
 	"chain/protocol/bc"
@@ -61,6 +62,7 @@ var commands = map[string]*command{
 	"grant":                {grant},
 	"revoke":               {revoke},
 	"allow-address":        {allowRaftMember},
+	"wait":                 {wait},
 }
 
 func main() {
@@ -455,4 +457,25 @@ func splitAfter2(s, sep string) (a, b string) {
 	i := strings.Index(s, sep)
 	k := i + len(sep)
 	return s[:k], s[k:]
+}
+
+func wait(client *rpc.Client, args []string) {
+	if len(args) != 0 {
+		fatalln("error: wait takes no args")
+	}
+
+	for {
+		err := client.Call(context.Background(), "/info", nil, nil)
+		if err == nil {
+			break
+		}
+
+		if statusErr, ok := errors.Root(err).(rpc.ErrStatusCode); ok {
+			if statusErr.StatusCode/100 != 5 {
+				break
+			}
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
 }

--- a/core/rpc/rpc.go
+++ b/core/rpc/rpc.go
@@ -47,14 +47,14 @@ func (c Client) userAgent() string {
 		c.Username, c.BuildTag, c.BlockchainID)
 }
 
-// errStatusCode is an error returned when an rpc fails with a non-200
+// ErrStatusCode is an error returned when an rpc fails with a non-200
 // response code.
-type errStatusCode struct {
+type ErrStatusCode struct {
 	URL        string
 	StatusCode int
 }
 
-func (e errStatusCode) Error() string {
+func (e ErrStatusCode) Error() string {
 	return fmt.Sprintf("Request to `%s` responded with %d %s",
 		e.URL, e.StatusCode, http.StatusText(e.StatusCode))
 }
@@ -138,7 +138,7 @@ func (c *Client) CallRaw(ctx context.Context, path string, request interface{}) 
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		resp.Body.Close()
-		return nil, errStatusCode{
+		return nil, ErrStatusCode{
 			URL:        cleanedURLString(u),
 			StatusCode: resp.StatusCode,
 		}

--- a/core/rpc/rpc_test.go
+++ b/core/rpc/rpc_test.go
@@ -83,7 +83,7 @@ func TestRPCCallError(t *testing.T) {
 	defer server.Close()
 
 	client := &Client{BaseURL: server.URL}
-	wantErr := errStatusCode{URL: server.URL + "/error", StatusCode: 500}
+	wantErr := ErrStatusCode{URL: server.URL + "/error", StatusCode: 500}
 	err := client.Call(context.Background(), "/error", nil, nil)
 	if !testutil.DeepEqual(wantErr, err) {
 		t.Errorf("got=%#v; want=%#v", err, wantErr)

--- a/docs/core/reference/corectl.md
+++ b/docs/core/reference/corectl.md
@@ -51,6 +51,7 @@ $ go install chain/cmd/corectl
 * [reset](#reset)
 * [grant](#grant)
 * [revoke](#revoke)
+* [wait][#wait]
 
 ### `config-generator`
 
@@ -181,3 +182,11 @@ It must take one of three forms:
    * `OU=[name]` to affect an X.509 Organizational Unit
 
    The type of guard (before the = sign) is case-insensitive.
+
+### `wait`
+
+Blocks until the Chain Core server is available.
+
+```
+corectl wait
+```

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3074";
+	public final String Id = "main/rev3075";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3074"
+const ID string = "main/rev3075"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3074"
+export const rev_id = "main/rev3075"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3074".freeze
+	ID = "main/rev3075".freeze
 end


### PR DESCRIPTION
This is a generic utility for blocking until cored is available.
A typical usecase would be as follows:

```
cored &
corectl wait
corectl config-generator
corectl create-token foobar client-readwrite
```