### PR TITLE
net/http/authn: return 401 when loopback_auth is off

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3079";
+	public final String Id = "main/rev3080";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3079"
+const ID string = "main/rev3080"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3079"
+export const rev_id = "main/rev3080"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3079".freeze
+	ID = "main/rev3080".freeze
 end

--- a/net/http/authn/authn.go
+++ b/net/http/authn/authn.go
@@ -58,8 +58,12 @@ func (a *API) Authenticate(req *http.Request) (*http.Request, error) {
 		ctx = newContextWithLocalhost(ctx)
 	}
 
-	// Temporary workaround. See loopbackOn comment above.
-	if want := loopbackOn || strings.HasPrefix(req.URL.Path, "/dashboard/"); want && local {
+	// Temporary workaround. Dashboard is always ok.
+	// See loopbackOn comment above.
+	if strings.HasPrefix(req.URL.Path, "/dashboard/") || req.URL.Path == "/dashboard" {
+		return req.WithContext(ctx), nil
+	}
+	if loopbackOn && local {
 		return req.WithContext(ctx), nil
 	}
 

--- a/net/http/authn/authn.go
+++ b/net/http/authn/authn.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +14,12 @@ import (
 )
 
 const tokenExpiry = time.Minute * 5
+
+// TODO(kr): This a hack. Please revisit this soon.
+// When compiled without loopback_auth, we want to avoid
+// running the loopback authenticator at all, except for
+// requests to /dashboard/, where we *do* want to run it.
+var loopbackOn = false
 
 type API struct {
 	tokens             *accesstoken.CredentialStore
@@ -51,9 +58,14 @@ func (a *API) Authenticate(req *http.Request) (*http.Request, error) {
 		ctx = newContextWithLocalhost(ctx)
 	}
 
+	// Temporary workaround. See loopbackOn comment above.
+	if want := loopbackOn || strings.HasPrefix(req.URL.Path, "/dashboard/"); want && local {
+		return req.WithContext(ctx), nil
+	}
+
 	// if there is no authentication at all, we return an "unauthenticated" error,
 	// which may be helpful when debugging
-	if len(X509Certs(ctx)) < 1 && err != nil && !local {
+	if len(X509Certs(ctx)) < 1 && err != nil {
 		return req, errors.New("unauthenticated")
 	}
 

--- a/net/http/authn/loopback_auth.go
+++ b/net/http/authn/loopback_auth.go
@@ -1,0 +1,7 @@
+//+build loopback_auth
+
+package authn
+
+func init() {
+	loopbackOn = true
+}


### PR DESCRIPTION
This is a temporary workaround until we can more
carefully plan how to treat authn vs authz in various
clients such as Dashboard. Currently, we want to return
a 401 to indicate that the user needs to supply some
credentials, but we want to avoid returning that error
for requests to known-public resources (/dashboard/).

In the future, we should avoid ever returning 401,
internally treating authn as a set of orthogonal
credentials, which may legitimately be empty. (An empty
set of credentials is still useful when accessing public
resources.) Clients should then detect the "needs to
prompt for credentials" situation by requesting access
to a known lowest-common-denominator resource (most
likely /info) and looking for a 403 response to that
request.