### PR TITLE
cmd/cored: use correct HTTP client

### DIFF
--- a/core/rpc/rpc.go
+++ b/core/rpc/rpc.go
@@ -39,6 +39,7 @@ type Client struct {
 	CoreID       string
 
 	// If set, Client is used for outgoing requests.
+	// TODO(kr): make this required (crash on nil)
 	Client *http.Client
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3076";
+	public final String Id = "main/rev3077";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3076"
+const ID string = "main/rev3077"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3076"
+export const rev_id = "main/rev3077"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3076".freeze
+	ID = "main/rev3077".freeze
 end


### PR DESCRIPTION
When connecting to signerd we need to use the trusted
root cert pool that was configured, so we can't use the
DefaultTransport in package net/http.