### PR TITLE
cmd/corectl: expose cored error messages

### DIFF
--- a/core/rpc/rpc.go
+++ b/core/rpc/rpc.go
@@ -140,6 +140,8 @@ func (c *Client) CallRaw(ctx context.Context, path string, request interface{}) 
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer resp.Body.Close()
+
 		resErr := ErrStatusCode{
 			URL:        cleanedURLString(u),
 			StatusCode: resp.StatusCode,
@@ -151,10 +153,10 @@ func (c *Client) CallRaw(ctx context.Context, path string, request interface{}) 
 		if err == nil && errData.ChainCode != "" {
 			resErr.ErrorData = &errData
 		}
-		resp.Body.Close()
 
 		return nil, resErr
 	}
+
 	return resp.Body, nil
 }
 

--- a/core/rpc/rpc.go
+++ b/core/rpc/rpc.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"chain/errors"
+	"chain/net/http/httperror"
 	"chain/net/http/reqid"
 )
 
@@ -53,6 +54,7 @@ func (c Client) userAgent() string {
 type ErrStatusCode struct {
 	URL        string
 	StatusCode int
+	ErrorData  *httperror.Response
 }
 
 func (e ErrStatusCode) Error() string {
@@ -138,11 +140,20 @@ func (c *Client) CallRaw(ctx context.Context, path string, request interface{}) 
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		resp.Body.Close()
-		return nil, ErrStatusCode{
+		resErr := ErrStatusCode{
 			URL:        cleanedURLString(u),
 			StatusCode: resp.StatusCode,
 		}
+
+		// Attach formatted error message, if available
+		var errData httperror.Response
+		err := json.NewDecoder(resp.Body).Decode(&errData)
+		if err == nil && errData.ChainCode != "" {
+			resErr.ErrorData = &errData
+		}
+		resp.Body.Close()
+
+		return nil, resErr
 	}
 	return resp.Body, nil
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3080";
+	public final String Id = "main/rev3081";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3080"
+const ID string = "main/rev3081"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3080"
+export const rev_id = "main/rev3081"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3080".freeze
+	ID = "main/rev3081".freeze
 end


### PR DESCRIPTION
This commit allows corectl to report formatted error data (chain code,
message, and detail) to the command-line user.

Fixes #1078