### PR TITLE
all: fix use of %s format string with bc.Hash

### DIFF
--- a/cmd/blockcache/main.go
+++ b/cmd/blockcache/main.go
@@ -283,7 +283,8 @@ func getBlockchainID(peer *rpc.Client) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return block.Hash().HexString(), nil
+	h := block.Hash()
+	return h.String(), nil
 }
 
 func backoffDur(n uint) time.Duration {

--- a/cmd/decode/main.go
+++ b/cmd/decode/main.go
@@ -73,7 +73,7 @@ func main() {
 
 		// The struct doesn't have the hash, so calculate it and print it
 		// before pretty printing the header.
-		fmt.Printf("Block Hash: %s\n", bh.Hash())
+		fmt.Printf("Block Hash: %x\n", bh.Hash().Bytes())
 		prettyPrint(bh)
 	case "block":
 		b := make([]byte, len(data)/2)
@@ -90,7 +90,7 @@ func main() {
 
 		// The struct doesn't have the hash, so calculate it and print it
 		// before pretty printing the block
-		fmt.Printf("Block Hash: %s\n", block.Hash())
+		fmt.Printf("Block Hash: %x\n", block.Hash().Bytes())
 		prettyPrint(block)
 	case "script":
 		b := make([]byte, len(data)/2)

--- a/core/transact_test.go
+++ b/core/transact_test.go
@@ -161,7 +161,7 @@ func TestWaitForTxInBlockResubmits(t *testing.T) {
 	wg.Add(timesToResubmit)
 	a.submitter = submitterFunc(func(_ context.Context, tx *legacy.Tx) error {
 		if orig.ID != tx.ID {
-			t.Errorf("got tx %s, want tx %s", tx.ID, orig.ID)
+			t.Errorf("got tx %s, want tx %s", tx.ID.String(), orig.ID.String())
 		}
 		wg.Done()
 		return nil

--- a/core/txdb/snapshot_test.go
+++ b/core/txdb/snapshot_test.go
@@ -105,7 +105,7 @@ func TestReadWriteStateSnapshot(t *testing.T) {
 
 		for _, lookup := range changeset.lookups {
 			if !snapshot.Tree.Contains(lookup.Bytes()) {
-				t.Errorf("Lookup(%s, %s) = false, want true", lookup, lookup)
+				t.Errorf("Lookup(%s, %s) = false, want true", lookup.String(), lookup.String())
 			}
 		}
 
@@ -113,7 +113,7 @@ func TestReadWriteStateSnapshot(t *testing.T) {
 			t.Fatalf("%d: state snapshot height got=%d want=%d", i, height, uint64(i))
 		}
 		if loadedSnapshot.Tree.RootHash() != snapshot.Tree.RootHash() {
-			t.Fatalf("%d: Wrote %s to db, read %s from db\n", i, snapshot.Tree.RootHash(), loadedSnapshot.Tree.RootHash())
+			t.Fatalf("%d: Wrote %x to db, read %x from db\n", i, snapshot.Tree.RootHash().Bytes(), loadedSnapshot.Tree.RootHash().Bytes())
 		}
 		if !testutil.DeepEqual(loadedSnapshot.Nonces, snapshot.Nonces) {
 			t.Fatalf("%d: Wrote %#v nonces to db, read %#v from db\n", i, snapshot.Nonces, loadedSnapshot.Nonces)

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3131";
+	public final String Id = "main/rev3132";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3131"
+const ID string = "main/rev3132"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3131"
+export const rev_id = "main/rev3132"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3131".freeze
+	ID = "main/rev3132".freeze
 end

--- a/protocol/bc/hash.go
+++ b/protocol/bc/hash.go
@@ -32,13 +32,6 @@ func (h Hash) Byte32() (b32 [32]byte) {
 	return b32
 }
 
-// HexString is a reader-friendlier alternative to the
-// protoc-generated String method.
-func (h Hash) HexString() string {
-	b, _ := h.MarshalText()
-	return string(b)
-}
-
 // MarshalText satisfies the TextMarshaler interface.
 // It returns the bytes of h encoded in hex,
 // for formats that can't hold arbitrary binary data.

--- a/protocol/patricia/patricia_test.go
+++ b/protocol/patricia/patricia_test.go
@@ -73,7 +73,7 @@ func TestRootHashBug(t *testing.T) {
 		t.Fatal(err)
 	}
 	if tr.RootHash() == before {
-		t.Errorf("before and after root hash is %s", before)
+		t.Errorf("before and after root hash is %s", before.String())
 	}
 }
 
@@ -114,7 +114,7 @@ func TestLeafVsInternalNodes(t *testing.T) {
 	}
 
 	if tr1.RootHash() == tr0.RootHash() {
-		t.Errorf("tr0 and tr1 have matching root hashes: %s", tr1.RootHash())
+		t.Errorf("tr0 and tr1 have matching root hashes: %x", tr1.RootHash().Bytes())
 	}
 }
 
@@ -220,7 +220,7 @@ func TestInsert(t *testing.T) {
 		root: &node{key: bools("11111111"), hash: hashPtr(hashForLeaf(bits("11111111"))), isLeaf: true},
 	}
 	if !testutil.DeepEqual(tr.root, want.root) {
-		log.Printf("want hash? %s", hashForLeaf(bits("11111111")))
+		log.Printf("want hash? %x", hashForLeaf(bits("11111111")).Bytes())
 		t.Log("insert into empty tree")
 		t.Fatalf("got:\n%swant:\n%s", pretty(tr), pretty(want))
 	}

--- a/protocol/recover.go
+++ b/protocol/recover.go
@@ -51,8 +51,8 @@ func (c *Chain) Recover(ctx context.Context) (*legacy.Block, *state.Snapshot, er
 			return nil, nil, errors.Wrap(err, "applying block")
 		}
 		if b.AssetsMerkleRoot != snapshot.Tree.RootHash() {
-			return nil, nil, fmt.Errorf("block %d has state root %s; snapshot has root %s",
-				b.Height, b.AssetsMerkleRoot, snapshot.Tree.RootHash())
+			return nil, nil, fmt.Errorf("block %d has state root %x; snapshot has root %x",
+				b.Height, b.AssetsMerkleRoot.Bytes(), snapshot.Tree.RootHash().Bytes())
 		}
 	}
 	if b != nil {


### PR DESCRIPTION
These are picked up by go vet. The pointer has a String
method, the value does not. Unfortunately, this makes
non-addressable bc.Hashes a little difficult to format.

I opted for calling the value-receiver method `Bytes` and
using the `%x` format specifier here. Another option is to
keep the `HexString` method and prefer `HexString` to
`String` so that we can use it when we have a non-pointer
value. Thoughts?