### PR TITLE
docker/ci: Pin rust crate versions

### DIFF
--- a/docker/ci/install/install-rust
+++ b/docker/ci/install/install-rust
@@ -5,8 +5,17 @@ set -e
 # Pin to a specific nightly until we can get off nightly entirely
 RUST_VERSION="nightly-2017-04-16"
 
+# Pin to this version of rustfmt
+RUSTFMT_VERSION="0.8.3"
+
+# Pin to this version of clippy
+CLIPPY_VERSION="0.0.124"
+
+# Pin to this version of cargo-audiot
+CARGO_AUDIT_VERSION="0.2.0"
+
 curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION}
 
-~/.cargo/bin/cargo install rustfmt
-~/.cargo/bin/cargo install clippy
-~/.cargo/bin/cargo install cargo-audit
+~/.cargo/bin/cargo install rustfmt --vers ${RUSTFMT_VERSION}
+~/.cargo/bin/cargo install clippy --vers ${CLIPPY_VERSION}
+~/.cargo/bin/cargo install cargo-audit --vers ${CARGO_AUDIT_VERSION}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3081";
+	public final String Id = "main/rev3082";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3081"
+const ID string = "main/rev3082"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3081"
+export const rev_id = "main/rev3082"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3081".freeze
+	ID = "main/rev3082".freeze
 end

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20170417
+box: chaindev/ci:20170502
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 


### PR DESCRIPTION
Pin the versions of all crates to the ones originally installed when rust was
added to the docker image.

This makes the build reproducible so future versions of crates won't break the
docker image build (like they're doing now)