### PR TITLE
docker/de: fix startup.sh token generation

### DIFF
--- a/docker/de/startup.sh
+++ b/docker/de/startup.sh
@@ -10,20 +10,30 @@ chown -R postgres /var/lib/postgresql/data
 su postgres -c 'initdb -D /var/lib/postgresql/data' >$initlog 2>&1
 su postgres -c 'pg_ctl start -w -D /var/lib/postgresql/data -l /var/lib/postgresql/data/postgres.log' >>$initlog 2>&1
 su postgres -c 'createdb core' >>$initlog 2>&1
-shouldInitToken=$?
+newDatabase=$?
 
 (
 	/usr/bin/chain/cored
 	echo 'cored' >$psmgr
 ) &
-echo "Listening on: http://localhost:1999"
 
-corectl wait
-
-if [[ $shouldInitToken -eq 0 ]]; then
-  /usr/bin/chain/corectl create-token client client-readwrite | tee -a $initlog | tail -n1 >/var/log/chain/client-token
-fi
+/usr/bin/chain/corectl wait
 
 echo "Chain Core is online!"
+echo "Listening on: http://localhost:1999"
+
+if [[ $newDatabase -eq 0 ]]; then
+  echo "Autogenerating acccess token with client-readwrite privileges..."
+  /usr/bin/chain/corectl create-token client client-readwrite \
+    | tee -a $initlog \
+    | tail -n1 > /var/log/chain/client-token
+
+  tail /var/log/chain/client-token | grep -q ":"
+  if [[ $? -eq 0 ]]; then
+    echo "Copy the whole line below:"
+    tail /var/log/chain/client-token
+  fi
+fi
+
 read exit_process <$psmgr
 exit 1

--- a/docker/de/startup.sh
+++ b/docker/de/startup.sh
@@ -10,16 +10,20 @@ chown -R postgres /var/lib/postgresql/data
 su postgres -c 'initdb -D /var/lib/postgresql/data' >$initlog 2>&1
 su postgres -c 'pg_ctl start -w -D /var/lib/postgresql/data -l /var/lib/postgresql/data/postgres.log' >>$initlog 2>&1
 su postgres -c 'createdb core' >>$initlog 2>&1
-if [[ $? -eq 0 ]]; then
-	/usr/bin/chain/corectl migrate
-	/usr/bin/chain/corectl create-token client | tee -a $initlog | tail -n1 >/var/log/chain/client-token
-fi
+shouldInitToken=$?
+
 (
 	/usr/bin/chain/cored
 	echo 'cored' >$psmgr
 ) &
 echo "Listening on: http://localhost:1999"
-echo "Client access token: `tail /var/log/chain/client-token`"
+
+corectl wait
+
+if [[ $shouldInitToken -eq 0 ]]; then
+  /usr/bin/chain/corectl create-token client client-readwrite | tee -a $initlog | tail -n1 >/var/log/chain/client-token
+fi
+
 echo "Chain Core is online!"
 read exit_process <$psmgr
 exit 1

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3083";
+	public final String Id = "main/rev3084";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3083"
+const ID string = "main/rev3084"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3083"
+export const rev_id = "main/rev3084"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3083".freeze
+	ID = "main/rev3084".freeze
 end


### PR DESCRIPTION
Now that corectl does not talk to the data store directly, we need the Docker startup script to wait for cored to become available before generating an access token.

Example output:

    Chain Core is online!
    Listening on: http://localhost:1999
    Autogenerating acccess token with client-readwrite privileges...
    Copy the whole line below:
    client:965aca3b62a068bf57af2302c621359237116ee6683f17fd5ca09d86645886ed