### PR TITLE
protocol/state: fix duplicate nonce bug

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3090";
+	public final String Id = "main/rev3091";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3090"
+const ID string = "main/rev3091"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3090"
+export const rev_id = "main/rev3091"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3090".freeze
+	ID = "main/rev3091".freeze
 end

--- a/protocol/bc/tx.go
+++ b/protocol/bc/tx.go
@@ -81,3 +81,15 @@ func (tx *Tx) Issuance(id Hash) (*Issuance, error) {
 	}
 	return iss, nil
 }
+
+func (tx *Tx) Nonce(id Hash) (*Nonce, error) {
+	e, ok := tx.Entries[id]
+	if !ok || e == nil {
+		return nil, errors.Wrapf(ErrMissingEntry, "id %x", id.Bytes())
+	}
+	nonce, ok := e.(*Nonce)
+	if !ok {
+		return nil, errors.Wrapf(ErrEntryType, "entry %x has unexpected type %T", id.Bytes(), e)
+	}
+	return nonce, nil
+}


### PR DESCRIPTION
Changes the snapshot to store and check the max time of the nonce,
rather than the tx maxtime. Also enforces the nonce uniqueness with
the block timestamp.

Fixes #1128