### PR TITLE
net/http/authn: make client certs more optional

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -143,15 +143,6 @@ func main() {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 
-	var internalDN *pkix.Name
-	if tlsConfig != nil {
-		x509Cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
-		if err != nil {
-			chainlog.Fatalkv(ctx, chainlog.KeyError, err)
-		}
-		internalDN = &x509Cert.Subject
-	}
-
 	// TODO(kr): make core.UseTLS take just an http client
 	// and use this object in it.
 	httpClient := new(http.Client)
@@ -213,7 +204,7 @@ func main() {
 	mux.Handle("/", &coreHandler)
 
 	var handler http.Handler = mux
-	handler = core.AuthHandler(handler, raftDB, accessTokens, internalDN)
+	handler = core.AuthHandler(handler, raftDB, accessTokens, tlsConfig)
 	handler = core.RedirectHandler(handler)
 	handler = reqid.Handler(handler)
 

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -4,8 +4,6 @@ package main
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"expvar"
 	"flag"
 	"fmt"

--- a/core/tls.go
+++ b/core/tls.go
@@ -37,7 +37,7 @@ func TLSConfig(certFile, keyFile, rootCAs string) (*tls.Config, error) {
 		// TODO(kr): disabled for now; consider adding h2 support here.
 		// See also the comment on TLSNextProto in $CHAIN/cmd/cored/main.go.
 		//NextProtos: []string{"http/1.1", "h2"},
-		ClientAuth: tls.VerifyClientCertIfGiven,
+		ClientAuth: tls.RequestClientCert,
 	}
 
 	cert, certErr := ioutil.ReadFile(certFile)

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3092";
+	public final String Id = "main/rev3093";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3092"
+const ID string = "main/rev3093"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3092"
+export const rev_id = "main/rev3093"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3092".freeze
+	ID = "main/rev3093".freeze
 end

--- a/net/http/authn/authn.go
+++ b/net/http/authn/authn.go
@@ -81,6 +81,9 @@ func (a *API) Authenticate(req *http.Request) (*http.Request, error) {
 
 // checks the request for a valid client cert list.
 // If found, it is added to the request's context.
+// Note that an *invalid* client cert is treated the
+// same as no client cert -- it is omitted from the
+// returned context, but the connection may proceed.
 func certAuthn(req *http.Request, rootCAs *x509.CertPool) context.Context {
 	if req.TLS != nil && len(req.TLS.PeerCertificates) > 0 {
 		certs := req.TLS.PeerCertificates

--- a/net/http/authn/authn.go
+++ b/net/http/authn/authn.go
@@ -98,7 +98,10 @@ func certAuthn(req *http.Request, rootCAs *x509.CertPool) context.Context {
 		}
 		_, err := certs[0].Verify(opts)
 		if err != nil {
+			// crypto/tls treats this as an error:
 			// errors.New("tls: failed to verify client's certificate: " + err.Error())
+			// For us, it is ok; we want to treat it the same as if there
+			// were no client cert presented.
 			return req.Context()
 		}
 


### PR DESCRIPTION
The std library package crypto/tls provides several
options for ClientAuthType; see
https://godoc.org/crypto/tls#ClientAuthType. None of
these do what we want, which is to request a client
cert, and validate it if given, but to treat an invalid
cert the same as a missing client cert: the connection
should be permitted but the cert should not be used in
authz.

We can fix this by using RequestClientCert and calling
Verify ourselves in the authn package. This also
requires plumbing to give authn access to the cert pool.