### PR TITLE
core/config: use TLS config for cross-core RPC

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -142,7 +142,7 @@ func (a *API) configure(ctx context.Context, x *config.Config) error {
 		x.MaxIssuanceWindowMs = bc.DurationMillis(24 * time.Hour)
 	}
 
-	err := config.Configure(ctx, a.db, a.raftDB, x)
+	err := config.Configure(ctx, a.db, a.raftDB, a.httpClient, x)
 	if err != nil {
 		return err
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3094";
+	public final String Id = "main/rev3095";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3094"
+const ID string = "main/rev3095"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3094"
+export const rev_id = "main/rev3095"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3094".freeze
+	ID = "main/rev3095".freeze
 end


### PR DESCRIPTION
We need the configured root cert pool to verify the
generator's TLS cert.