### PR TITLE
cmd/cored: use TLS for remote generator RPCs

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -348,6 +348,7 @@ func launchConfiguredCore(ctx context.Context, raftDB *raft.Service, db *sql.DB,
 			CoreID:       conf.Id,
 			BuildTag:     buildTag,
 			BlockchainID: conf.BlockchainId.String(),
+			Client:       httpClient,
 		}))
 	}
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3095";
+	public final String Id = "main/rev3096";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3095"
+const ID string = "main/rev3096"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3095"
+export const rev_id = "main/rev3096"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3095".freeze
+	ID = "main/rev3096".freeze
 end


### PR DESCRIPTION
We need the configured root cert pool to verify the
generator's TLS cert.