### PR TITLE
all: version tick to 1.2.0-rc1

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,7 +62,7 @@ requests from localhost, and the ability to reset the Chain Core.
 from the chain repository and an output directory:
 
 ```sh
-$ ./bin/build-cored-release chain-core-server-1.1.4 .
+$ ./bin/build-cored-release chain-core-server-1.2.0-rc1 .
 ```
 
 This will create two binaries in the current directory:
@@ -106,7 +106,7 @@ The default build process creates a binary with three build tags enabled for a
 friendlier experience. To build from source with build tags, use the following
 command:
 
-> NOTE: when building from source, make sure to check out a specific  
+> NOTE: when building from source, make sure to check out a specific
 tag to build. The `main` branch is __not considered__ stable, and may
 contain in progress features or an inconsistent experience.
 

--- a/bin/build-docker-de
+++ b/bin/build-docker-de
@@ -7,8 +7,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-imageVersion=${IMAGE_VERSION:-1.1.1}
-coredVersion=${CORED_VERSION:-chain-core-server-1.1.3}
+imageVersion=${IMAGE_VERSION:-1.2.0-rc1}
+coredVersion=${CORED_VERSION:-chain-core-server-1.2.0-rc1}
 
 GOOS=linux GOARCH=amd64 bin/build-cored-release "$coredVersion" $CHAIN/docker/de/
 docker build --tag chaincore/developer $CHAIN/docker/de/

--- a/desktop/mac/Chain Core.xcodeproj/project.pbxproj
+++ b/desktop/mac/Chain Core.xcodeproj/project.pbxproj
@@ -437,7 +437,7 @@
 		83FB57281D1B05F000A903A3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_VERSION = 1.1.1;
+				APP_VERSION = 1.2.0.rc1;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -463,7 +463,7 @@
 		83FB57291D1B05F000A903A3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APP_VERSION = 1.1.1;
+				APP_VERSION = 1.2.0.rc1;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/desktop/mac/tools/build_chain.sh
+++ b/desktop/mac/tools/build_chain.sh
@@ -9,7 +9,7 @@ export PATH="${PATH}:/usr/local/go/bin"
 
 tempBuildPath=`mktemp -d`
 trap "rm -rf $tempBuildPath" EXIT
-"${CHAIN}/bin/build-cored-release" chain-core-server-1.1.3 $tempBuildPath
+"${CHAIN}/bin/build-cored-release" chain-core-server-1.2.0-rc1 $tempBuildPath
 
 cp -f $tempBuildPath/cored "${TARGET_DIR}/"
 cp -f $tempBuildPath/corectl "${TARGET_DIR}/"

--- a/desktop/windows/ChainPackage/ChainCoreInstaller.wxs
+++ b/desktop/windows/ChainPackage/ChainCoreInstaller.wxs
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
      xmlns:http="http://schemas.microsoft.com/wix/HttpExtension"
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
-  <Product Id="*" Name="Chain Core Package" Language="1033" Version="1.1.1" Manufacturer="Chain Inc." UpgradeCode="eaa938af-2d6c-4912-b33d-1a09a6b1e81c">
+  <Product Id="*" Name="Chain Core Package" Language="1033" Version="1.2.0" Manufacturer="Chain Inc." UpgradeCode="eaa938af-2d6c-4912-b33d-1a09a6b1e81c">
     <Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
 
     <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />

--- a/docs/core/get-started/sdk.md
+++ b/docs/core/get-started/sdk.md
@@ -19,7 +19,7 @@ The Java SDK is available via [Maven](https://search.maven.org/#search%7Cga%7C1%
   <dependency>
     <groupId>com.chain</groupId>
     <artifactId>chain-sdk-java</artifactId>
-    <version>1.1.3</version>
+    <version>1.2.0-rc1</version>
   </dependency>
 </dependencies>
 ```
@@ -27,10 +27,10 @@ The Java SDK is available via [Maven](https://search.maven.org/#search%7Cga%7C1%
 **Gradle** users should add the following to `build.gradle`:
 
 ```
-compile 'com.chain:chain-sdk-java:1.1.3'
+compile 'com.chain:chain-sdk-java:1.2.0-rc1'
 ```
 
-You can also [download the JAR](https://search.maven.org/remotecontent?filepath=com/chain/chain-sdk-java/1.1.3/chain-sdk-java-1.1.3.jar) as a binary.
+You can also [download the JAR](https://search.maven.org/remotecontent?filepath=com/chain/chain-sdk-java/1.1.3/chain-sdk-java-1.2.0-rc1.jar) as a binary.
 
 ## Node.js
 
@@ -41,7 +41,7 @@ To install, add the `chain-sdk` NPM module to your `package.json`, using a tilde
 ```
 {
   "dependencies": {
-    "chain-sdk": "~1.1.0"
+    "chain-sdk": "~1.2.0-rc1"
   }
 }
 ```
@@ -53,5 +53,5 @@ The Ruby SDK is available [via Rubygems](https://rubygems.org/gems/chain-sdk). R
 To install, add the following to your `Gemfile`:
 
 ```
-gem 'chain-sdk', '~> 1.1.0', require: 'chain'
+gem 'chain-sdk', '~> 1.2.0.rc1', require: 'chain'
 ```

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3100";
+	public final String Id = "main/rev3101";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3100"
+const ID string = "main/rev3101"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3100"
+export const rev_id = "main/rev3101"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3100".freeze
+	ID = "main/rev3101".freeze
 end

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.chain</groupId>
     <artifactId>chain-sdk-java</artifactId>
-    <version>1.1.3</version>
+    <version>1.2.0rc1</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -11,7 +11,7 @@ To install, add the `chain-sdk` NPM module to your `package.json`, using a tilde
 ```
 {
   "dependencies": {
-    "chain-sdk": "~1.1.0"
+    "chain-sdk": "~1.2.0-rc1"
   }
 }
 ```

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chain-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0-rc1",
   "description": "The Official Node.js SDK for Chain Core",
   "homepage": "https://github.com/chain/chain/tree/main/sdk/node",
   "main": "dist/index.js",

--- a/sdk/ruby/README.md
+++ b/sdk/ruby/README.md
@@ -11,7 +11,7 @@ Ruby 2.0 or greater is required. We strongly recommend upgrading to Ruby 2.1 or 
 For most applications, you can simply add the following to your `Gemfile`:
 
 ```
-gem 'chain-sdk', '~> 1.1.1', require: 'chain'
+gem 'chain-sdk', '~> 1.2.0.rc1', require: 'chain'
 ```
 
 ### In your code

--- a/sdk/ruby/lib/chain/version.rb
+++ b/sdk/ruby/lib/chain/version.rb
@@ -1,3 +1,3 @@
 module Chain
-  VERSION = '1.1.1'
+  VERSION = '1.2.0.rc1'
 end


### PR DESCRIPTION
Notes:

- Mac app is not taggable until full build size is known (will follow
  in subsequent commit)
- Windows app is versioned as 1.2.0, since it's not clear what the
  installer will do with prerelease suffixes. The Windows app with the
  final 1.2.0 cored will have a patch version greater than zero.