### PR TITLE
core: don't create self-grant for raft member list if not using TLS

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -79,6 +79,7 @@ type API struct {
 	remoteGenerator *rpc.Client
 	indexTxs        bool
 	forwardUsingTLS bool
+	useTLS          bool
 	internalSubj    pkix.Name
 	httpClient      *http.Client
 
@@ -255,7 +256,6 @@ func AuthHandler(handler http.Handler, rDB *raft.Service, accessTokens *accessto
 
 	rootCAs := x509.NewCertPool()
 	if tlsConfig != nil {
-		log.Printf(context.Background(), "%+v", tlsConfig)
 		x509Cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
 		if err != nil {
 			log.Fatalkv(context.Background(), log.KeyError, err)
@@ -263,8 +263,6 @@ func AuthHandler(handler http.Handler, rDB *raft.Service, accessTokens *accessto
 
 		authorizer.GrantInternal(x509Cert.Subject)
 		rootCAs = tlsConfig.ClientCAs
-	} else {
-		log.Printf(context.Background(), "nope")
 	}
 
 	authenticator := authn.NewAPI(accessTokens, crosscoreRPCPrefix, rootCAs)

--- a/core/api.go
+++ b/core/api.go
@@ -255,6 +255,7 @@ func AuthHandler(handler http.Handler, rDB *raft.Service, accessTokens *accessto
 
 	rootCAs := x509.NewCertPool()
 	if tlsConfig != nil {
+		log.Printf(context.Background(), "%+v", tlsConfig)
 		x509Cert, err := x509.ParseCertificate(tlsConfig.Certificates[0].Certificate[0])
 		if err != nil {
 			log.Fatalkv(context.Background(), log.KeyError, err)
@@ -262,6 +263,8 @@ func AuthHandler(handler http.Handler, rDB *raft.Service, accessTokens *accessto
 
 		authorizer.GrantInternal(x509Cert.Subject)
 		rootCAs = tlsConfig.ClientCAs
+	} else {
+		log.Printf(context.Background(), "nope")
 	}
 
 	authenticator := authn.NewAPI(accessTokens, crosscoreRPCPrefix, rootCAs)

--- a/core/api.go
+++ b/core/api.go
@@ -78,7 +78,6 @@ type API struct {
 	generator       *generator.Generator
 	remoteGenerator *rpc.Client
 	indexTxs        bool
-	forwardUsingTLS bool
 	useTLS          bool
 	internalSubj    pkix.Name
 	httpClient      *http.Client
@@ -367,7 +366,7 @@ func (a *API) forwardToLeader(ctx context.Context, path string, body interface{}
 		BaseURL: "http://" + addr,
 		Client:  a.httpClient,
 	}
-	if a.forwardUsingTLS {
+	if a.useTLS {
 		l.BaseURL = "https://" + addr
 	}
 

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -52,9 +52,9 @@ func TestForwardToLeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	api := &API{
-		config:          &config.Config{},
-		leader:          alwaysFollower{leaderAddress: u.Host},
-		forwardUsingTLS: true,
+		config: &config.Config{},
+		leader: alwaysFollower{leaderAddress: u.Host},
+		useTLS: true,
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{

--- a/core/membership.go
+++ b/core/membership.go
@@ -26,25 +26,28 @@ func (a *API) addAllowedMember(ctx context.Context, x struct{ Addr string }) err
 		return errors.Wrap(err)
 	}
 
-	data := map[string]interface{}{
-		"subject": map[string]string{
-			"CN": hostname,
-		},
-	}
+	if a.useTLS {
+		data := map[string]interface{}{
+			"subject": map[string]string{
+				"CN": hostname,
+			},
+		}
 
-	guardData, err := json.Marshal(data)
-	if err != nil {
+		guardData, err := json.Marshal(data)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+
+		grant := authz.Grant{
+			Policy:    "internal",
+			GuardType: "x509",
+			GuardData: guardData,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+			Protected: true,
+		}
+
+		_, err = authz.StoreGrant(ctx, a.raftDB, grant, grantPrefix)
 		return errors.Wrap(err)
 	}
-
-	grant := authz.Grant{
-		Policy:    "internal",
-		GuardType: "x509",
-		GuardData: guardData,
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-		Protected: true,
-	}
-
-	_, err = authz.StoreGrant(ctx, a.raftDB, grant, grantPrefix)
-	return errors.Wrap(err)
+	return nil
 }

--- a/core/run.go
+++ b/core/run.go
@@ -43,6 +43,7 @@ type RunOption func(*API)
 func UseTLS(c *tls.Config) RunOption {
 	return func(a *API) {
 		a.forwardUsingTLS = c != nil
+		a.useTLS = c != nil
 		a.httpClient = new(http.Client)
 		a.httpClient.Transport = &http.Transport{
 			DialContext: (&net.Dialer{

--- a/core/run.go
+++ b/core/run.go
@@ -42,7 +42,6 @@ type RunOption func(*API)
 // If c is nil, TLS is disabled.
 func UseTLS(c *tls.Config) RunOption {
 	return func(a *API) {
-		a.forwardUsingTLS = c != nil
 		a.useTLS = c != nil
 		a.httpClient = new(http.Client)
 		a.httpClient.Transport = &http.Transport{

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3119";
+	public final String Id = "main/rev3120";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3119"
+const ID string = "main/rev3120"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3119"
+export const rev_id = "main/rev3120"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3119".freeze
+	ID = "main/rev3120".freeze
 end


### PR DESCRIPTION
This fixes a bug where a single internal grant was being created with an empty certificate for cores that were being run without a TLS config. 