### PR TITLE
core/migrate: drop unnecessary secondary indexes

### DIFF
--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -67,4 +67,9 @@ var migrations = []migration{
 		ALTER TABLE generator_pending_block
 			ADD COLUMN height bigint;
 	`},
+	{Name: `2017-05-08.0.core.drop-redundant-indexes.sql`, SQL: `
+		ALTER TABLE account_utxos DROP CONSTRAINT account_utxos_output_id_key;
+		DROP INDEX signers_type_id_idx;
+		DROP INDEX assets_sort_id;
+	`},
 }

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -470,11 +470,6 @@ ALTER TABLE ONLY accounts
 
 
 ALTER TABLE ONLY account_utxos
-    ADD CONSTRAINT account_utxos_output_id_key UNIQUE (output_id);
-
-
-
-ALTER TABLE ONLY account_utxos
     ADD CONSTRAINT account_utxos_pkey PRIMARY KEY (output_id);
 
 
@@ -640,19 +635,11 @@ CREATE INDEX annotated_txs_data_idx ON annotated_txs USING gin (data jsonb_path_
 
 
 
-CREATE INDEX assets_sort_id ON assets USING btree (sort_id);
-
-
-
 CREATE INDEX query_blocks_timestamp_idx ON query_blocks USING btree ("timestamp");
 
 
 
 CREATE UNIQUE INDEX signed_blocks_block_height_idx ON signed_blocks USING btree (block_height);
-
-
-
-CREATE INDEX signers_type_id_idx ON signers USING btree (type, id);
 
 
 
@@ -666,3 +653,4 @@ insert into migrations (filename, hash) values ('2017-03-09.0.core.account-utxos
 insert into migrations (filename, hash) values ('2017-04-13.0.query.block-transactions-count.sql', '7cb17e05596dbfdf75e347e43ccab110e393f41ea86f70697e59cf0c32c3a564');
 insert into migrations (filename, hash) values ('2017-04-17.0.core.null-token-type.sql', '185942cec464c12a2573f19ae386153389328f8e282af071024706e105e37eeb');
 insert into migrations (filename, hash) values ('2017-04-27.0.generator.pending-block-height.sql', 'bfe4fe5eec143e4367a91fd952cb5e3879f1c311f649ec13bfe95b202e94d4ec');
+insert into migrations (filename, hash) values ('2017-05-08.0.core.drop-redundant-indexes.sql', '5140e53b287b058c57ddf361d61cff3d3d1cbc3259a9de413b11574a71d09bec');

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3130";
+	public final String Id = "main/rev3131";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3130"
+const ID string = "main/rev3131"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3130"
+export const rev_id = "main/rev3131"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3130".freeze
+	ID = "main/rev3131".freeze
 end


### PR DESCRIPTION
Remove a few secondary indexes that are redundant or unused:

* The account_utxos_output_id_key constraint is redundant with the
  primary key of the account_utxos table which is already on the
  output_id.
* The signers_type_id index is intended to be used on JOINs between
  the assets/accounts tables and the signers table. The primary key
  of the signers table is already on the ID. The signers table also
  already scopes its IDs by the type of signer (ex, acc123). There's
  also not a high enough cardinality on the type column to be useful.
* The assets_sort_id index is never used.