### PR TITLE
database/pg/pgtest: make useful outside of package testing

### DIFF
--- a/database/pg/pgtest/pgtest.go
+++ b/database/pg/pgtest/pgtest.go
@@ -61,14 +61,14 @@ const (
 //
 // Prefer NewTx whenever the caller can do its
 // work in exactly one transaction.
-func NewDB(t testing.TB, schemaPath string) (url string, db *sql.DB) {
+func NewDB(f Fataler, schemaPath string) (url string, db *sql.DB) {
 	ctx := context.Background()
 	if os.Getenv("CHAIN") == "" {
-		t.Log("warning: $CHAIN not set; probably can't find schema")
+		logTo(f, "warning: $CHAIN not set; probably can't find schema")
 	}
 	url, db, err := open(ctx, DBURL, schemaPath)
 	if err != nil {
-		t.Fatal(err)
+		f.Fatal(err)
 	}
 	runtime.SetFinalizer(db, (*sql.DB).Close)
 	return url, db
@@ -84,20 +84,20 @@ func NewDB(t testing.TB, schemaPath string) (url string, db *sql.DB) {
 // The caller should not commit the returned Tx; doing so
 // will prevent the underlying database from being reused
 // and so cause future calls to NewTx to be slower.
-func NewTx(t testing.TB) *sql.Tx {
+func NewTx(f Fataler) *sql.Tx {
 	runtime.GC() // give the finalizers a better chance to run
 	ctx := context.Background()
 	if os.Getenv("CHAIN") == "" {
-		t.Log("warning: $CHAIN not set; probably can't find schema")
+		logTo(f, "warning: $CHAIN not set; probably can't find schema")
 	}
 	db, err := getdb(ctx, DBURL, SchemaPath)
 	if err != nil {
-		t.Fatal(err)
+		f.Fatal(err)
 	}
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		db.Close()
-		t.Fatal(err)
+		f.Fatal(err)
 	}
 	// NOTE(kr): we do not set a finalizer on the DB.
 	// It is closed explicitly, if necessary, by finalizeTx.
@@ -252,5 +252,34 @@ func Exec(ctx context.Context, db pg.DB, t testing.TB, q string, args ...interfa
 	_, err := db.ExecContext(ctx, q, args...)
 	if err != nil {
 		testutil.FatalErr(t, err)
+	}
+}
+
+// Fataler lets NewTx and NewDB signal immediate failure.
+type Fataler interface {
+	Fatal(...interface{})
+}
+
+// Logger is an optional interface that can be satisfied
+// by the first argument to NewTx or NewDB.
+// If available, it will be used to print non-fatal diagnostics.
+type Logger interface {
+	Log(...interface{})
+}
+
+// Printlner is an optional interface that can be satisfied
+// by the first argument to NewTx or NewDB.
+// If available, it will be used to print non-fatal diagnostics.
+type Printlner interface {
+	Println(...interface{})
+}
+
+func logTo(x interface{}, args ...interface{}) {
+	if l, ok := x.(Logger); ok {
+		l.Log(args...)
+	} else if p, ok := x.(Printlner); ok {
+		p.Println(args...)
+	} else {
+		log.Println(args...)
 	}
 }

--- a/database/pg/pgtest/pgtest.go
+++ b/database/pg/pgtest/pgtest.go
@@ -256,6 +256,7 @@ func Exec(ctx context.Context, db pg.DB, t testing.TB, q string, args ...interfa
 }
 
 // Fataler lets NewTx and NewDB signal immediate failure.
+// It is satisfied by *testing.T, *testing.B, and *log.Logger.
 type Fataler interface {
 	Fatal(...interface{})
 }

--- a/database/pg/pgtest/pgtest.go
+++ b/database/pg/pgtest/pgtest.go
@@ -64,7 +64,7 @@ const (
 func NewDB(f Fataler, schemaPath string) (url string, db *sql.DB) {
 	ctx := context.Background()
 	if os.Getenv("CHAIN") == "" {
-		logTo(f, "warning: $CHAIN not set; probably can't find schema")
+		log.Println("warning: $CHAIN not set; probably can't find schema")
 	}
 	url, db, err := open(ctx, DBURL, schemaPath)
 	if err != nil {
@@ -88,7 +88,7 @@ func NewTx(f Fataler) *sql.Tx {
 	runtime.GC() // give the finalizers a better chance to run
 	ctx := context.Background()
 	if os.Getenv("CHAIN") == "" {
-		logTo(f, "warning: $CHAIN not set; probably can't find schema")
+		log.Println("warning: $CHAIN not set; probably can't find schema")
 	}
 	db, err := getdb(ctx, DBURL, SchemaPath)
 	if err != nil {
@@ -258,28 +258,4 @@ func Exec(ctx context.Context, db pg.DB, t testing.TB, q string, args ...interfa
 // Fataler lets NewTx and NewDB signal immediate failure.
 type Fataler interface {
 	Fatal(...interface{})
-}
-
-// Logger is an optional interface that can be satisfied
-// by the first argument to NewTx or NewDB.
-// If available, it will be used to print non-fatal diagnostics.
-type Logger interface {
-	Log(...interface{})
-}
-
-// Printlner is an optional interface that can be satisfied
-// by the first argument to NewTx or NewDB.
-// If available, it will be used to print non-fatal diagnostics.
-type Printlner interface {
-	Println(...interface{})
-}
-
-func logTo(x interface{}, args ...interface{}) {
-	if l, ok := x.(Logger); ok {
-		l.Log(args...)
-	} else if p, ok := x.(Printlner); ok {
-		p.Println(args...)
-	} else {
-		log.Println(args...)
-	}
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3145";
+	public final String Id = "main/rev3146";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3145"
+const ID string = "main/rev3146"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3145"
+export const rev_id = "main/rev3146"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3145".freeze
+	ID = "main/rev3146".freeze
 end


### PR DESCRIPTION
This package doesn't use nearly all of the methods of
type testing.TB. By defining a new interface containing
just what we need here, we let the caller supply their own
object. In particular, *log.Logger satisfies Fataler.