### PR TITLE
sdk/java: relax visibility of Transaction.Builder properties

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3123";
+	public final String Id = "main/rev3124";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3123"
+const ID string = "main/rev3124"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3123"
+export const rev_id = "main/rev3124"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3123".freeze
+	ID = "main/rev3124".freeze
 end

--- a/sdk/java/src/main/java/com/chain/api/Transaction.java
+++ b/sdk/java/src/main/java/com/chain/api/Transaction.java
@@ -990,12 +990,12 @@ public class Transaction {
      * Hex-encoded serialization of a transaction to add to the current template.
      */
     @SerializedName("base_transaction")
-    private String baseTransaction;
+    protected String baseTransaction;
 
     /**
      * List of actions in a transaction.
      */
-    private List<Action> actions;
+    protected List<Action> actions;
 
     /**
      * A time duration in milliseconds. If the transaction is not fully
@@ -1003,7 +1003,7 @@ public class Transaction {
      * blockchain. Additionally, any outputs reserved when building this
      * transaction will remain reserved for this duration.
      */
-    private long ttl;
+    protected long ttl;
 
     /**
      * Builds a single transaction template.


### PR DESCRIPTION
Moving visibility from private to protected allows derived classes to
access the builder internals for custom client-side behavior.