### PR TITLE
sdk/java: tick version to 1.2.0rc3

### DIFF
--- a/sdk/java/CHANGELOG.md
+++ b/sdk/java/CHANGELOG.md
@@ -5,11 +5,15 @@ This changelog is for the 1.2 branch of the Java SDK. Older versions:
 - [1.1](https://github.com/chain/chain/blob/1.1-stable/sdk/java/CHANGELOG.md)
 - [1.0](https://github.com/chain/chain/blob/1.0-stable/sdk/java/CHANGELOG.md)
 
-## 1.2.0rc2 (May 4, 2017)
+## 1.2.0rc3 (May 11, 2017)
 
 This is a pre-release version. A complete list of changes is forthcoming.
 
+## 1.2.0rc2 (May 4, 2017)
+
+Pre-release version.
+
 ## 1.2.0rc1
 
-* Unpublished pre-release version
+Unpublished pre-release version.
 

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.chain</groupId>
     <artifactId>chain-sdk-java</artifactId>
-    <version>1.2.0rc2</version>
+    <version>1.2.0rc3</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
This is a publishable version of the SDK that includes changes from
#1182.