### PR TITLE
cmd/report: report test results to S3

### DIFF
--- a/cmd/report/doc.go
+++ b/cmd/report/doc.go
@@ -1,0 +1,20 @@
+/*
+
+Command report executes its argument as a child process
+and reports the results to S3.
+
+It uploads the full combined output (stdout and stderr)
+plus the exit code (if nonzero)
+to the S3 object "run/[started at]-[name]",
+then updates a summary table of past runs
+at 'summary.json' and 'index.html'.
+
+It also writes the time of the last run
+in RFC 3339 format in S3 object 'lastrun'.
+
+All output of this command goes to S3.
+The only exception is error messages for failures accessing S3,
+which are written to stderr.
+
+*/
+package main

--- a/cmd/report/doc.go
+++ b/cmd/report/doc.go
@@ -7,7 +7,7 @@ It uploads the full combined output (stdout and stderr)
 plus the exit code (if nonzero)
 to the S3 object "run/[started at]-[name]",
 then updates a summary table of past runs
-at 'summary.json' and 'index.html'.
+at 'results.json' and 'index.html'.
 
 It also writes the time of the last run
 in RFC 3339 format in S3 object 'lastrun'.

--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+var (
+	bucket = aws.String(os.Getenv("BUCKET"))
+	region = "us-east-1" // TODO(kr): figure out how to not hard code this
+	sess   = session.Must(session.NewSession(aws.NewConfig().WithRegion(region)))
+	s3svc  = s3.New(sess)
+)
+
+func main() {
+	t := time.Now().UTC()
+	s := Run{
+		StartedAt: t.Format(time.RFC3339),
+		Command:   os.Args[1:],
+	}
+	s.Path = "log/" + s.StartedAt + "-" + slug(strings.Join(s.Command, "-"))
+	var b bytes.Buffer
+	fmt.Fprintln(&b, s.StartedAt)
+	fmt.Fprintf(&b, "%q\n", s.Command)
+	s.Ok = run(&b, s.Command)
+	s.Elapsed = time.Now().Sub(t)
+	fmt.Fprintln(&b, "elapsed", s.Elapsed)
+	// Do all the S3 stuff at the end.
+	// If anything fails after this point,
+	// we will panic.
+	ctx := context.Background()
+	report(ctx, b.Bytes(), s)
+}
+
+func run(w io.Writer, args []string) bool {
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	err := cmd.Run()
+	w.Write([]byte{'\n'}) // output might not have trailing LF
+	if err != nil {
+		fmt.Fprintln(w, err)
+	}
+	return err == nil
+}
+
+func report(ctx context.Context, body []byte, s Run) {
+	put(ctx, s.Path, body, "text/plain; charset=utf-8")
+	summarize(ctx, s)
+	put(ctx, "lastrun", []byte(s.StartedAt), "text/plain; charset=utf-8")
+}
+
+func summarize(ctx context.Context, s Run) {
+	sum := getSummary(ctx)
+	sum.Runs = append(sum.Runs, s)
+	putSummary(ctx, sum)
+}
+
+func put(ctx context.Context, key string, body []byte, contentType string) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	_, err := s3svc.PutObjectWithContext(ctx, &s3.PutObjectInput{
+		ACL:         aws.String("public-read"),
+		Bucket:      bucket,
+		Key:         &key,
+		Body:        bytes.NewReader(body),
+		ContentType: &contentType,
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func slug(s string) string {
+	return strings.Map(slugChar, s)
+}
+
+func slugChar(c rune) rune {
+	if !okInURL(c) {
+		return -1
+	}
+	return c
+}
+
+func okInURL(c rune) bool {
+	// See RFC 3986 (URI Syntax) section 2.3 (Unreserved Characters)
+	// https://www.ietf.org/rfc/rfc3986.txt
+	return strings.ContainsRune("-._~", c) ||
+		'a' <= c && c <= 'z' ||
+		'A' <= c && c <= 'Z' ||
+		'0' <= c && c <= '9'
+}

--- a/cmd/report/summary.go
+++ b/cmd/report/summary.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"html/template"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+type results struct {
+	Runs []Run
+}
+
+type Run struct {
+	StartedAt string
+	Elapsed   time.Duration
+	Path      string
+	Command   []string
+	Ok        bool
+}
+
+func getSummary(ctx context.Context) *results {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	res, err := s3svc.GetObjectWithContext(ctx, &s3.GetObjectInput{
+		Bucket: bucket,
+		Key:    aws.String("results.json"),
+	})
+	if a, ok := err.(awserr.Error); ok && a.Code() == "NoSuchKey" {
+		return new(results)
+	} else if err != nil {
+		panic(err)
+	}
+	var s *results
+	err = json.NewDecoder(res.Body).Decode(&s)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func putSummary(ctx context.Context, s *results) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	b, err := json.MarshalIndent(s, "", "\t")
+	if err != nil {
+		panic(err)
+	}
+	put(ctx, "results.json", b, "text/plain; charset=utf-8")
+
+	reverse(s.Runs)
+
+	var buf bytes.Buffer
+	err = summaryTemplate.Execute(&buf, s)
+	if err != nil {
+		panic(err)
+	}
+	put(ctx, "index.html", buf.Bytes(), "text/html; charset=utf-8")
+
+	_, err = s3svc.PutBucketWebsite(&s3.PutBucketWebsiteInput{
+		Bucket: bucket,
+		WebsiteConfiguration: &s3.WebsiteConfiguration{
+			IndexDocument: &s3.IndexDocument{Suffix: aws.String("index.html")},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func reverse(a []Run) {
+	for i := 0; i < len(a)/2; i++ {
+		a[i], a[len(a)-i-1] = a[len(a)-i-1], a[i]
+	}
+}
+
+var summaryTemplate = template.Must(template.New("results").Parse(`
+<!doctype html>
+<html>
+<head>
+<style>
+:root {
+	font-family: monospace;
+}
+td {
+	padding: .25em .5em;
+}
+</style>
+</head>
+<body>
+
+<p>Raw results: <a href=results.json>results.json</a></p>
+
+<table>
+{{range .Runs}}
+<tr>
+<td>{{.StartedAt}}</td>
+<td>{{if .Ok}}ok{{else}}<a href={{.Path}}><b>fail</b></a>{{end}}</td>
+<td>{{.Elapsed}}</td>
+<td>{{.Command}}</td>
+</tr>
+{{ end }}
+</table>
+</body>
+</html>
+`))

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3138";
+	public final String Id = "main/rev3139";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3138"
+const ID string = "main/rev3139"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3138"
+export const rev_id = "main/rev3139"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3138".freeze
+	ID = "main/rev3139".freeze
 end


### PR DESCRIPTION
The new command "report" executes its arguments, then uploads the result to S3 and adds a summary of the result to a history table for a convenient web-accessible overview.

Future work: announce in Slack when a test fails.