### PR TITLE
sdk/node: tick verson to 1.2.1

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3128";
+	public final String Id = "main/rev3129";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3128"
+const ID string = "main/rev3129"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3128"
+export const rev_id = "main/rev3129"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3128".freeze
+	ID = "main/rev3129".freeze
 end

--- a/sdk/node/CHANGELOG.md
+++ b/sdk/node/CHANGELOG.md
@@ -5,7 +5,7 @@ This changelog is for the 1.2 branch of the Node.js SDK. Older versions:
 - [1.1](https://github.com/chain/chain/blob//1.1-stable/sdk/node/CHANGELOG.md)
 - [1.0](https://github.com/chain/chain/blob/1.0-stable/sdk/node/CHANGELOG.md)
 
-## 1.2.0 (May 12, 2017)
+## 1.2.1 (May 12, 2017)
 
 This is a *minor version* release that includes breaking changes and new features. Before upgrading your SDK, please review a [a full summary of what's new in Chain Core 1.2](https://chain.com/docs/1.2/core/reference/changelog#1.2.0).
 
@@ -46,6 +46,10 @@ The `client.authorizationGrants` interface allows you to programmatically regist
 The SDK now features flexible TLS configuration, allowing you to accept server certificates outside of the public X.509 PKI, and to authenticate requests to Chain Core using client X.509 certificates.
 
 See the [documentation](https://chain.com/docs/1.2/core/learn-more/mutual-tls-auth) for specific instructions.
+
+## 1.2.0
+
+Unpublished version.
 
 ## 1.2.0-rc.2 (May 4, 2017)
 

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chain-sdk",
-  "version": "1.2.0-rc.2",
+  "version": "1.2.1",
   "description": "The Official Node.js SDK for Chain Core",
   "homepage": "https://github.com/chain/chain/tree/main/sdk/node",
   "main": "dist/index.js",


### PR DESCRIPTION
Forgot to do this, needs to be 1.2.1 because 1.2.0 was already tagged.