### PR TITLE
cmd/cored: set feature flags consistently

### DIFF
--- a/cmd/cored/mockhsm.go
+++ b/cmd/cored/mockhsm.go
@@ -5,9 +5,14 @@ package main
 import (
 	"chain/core"
 	"chain/core/blocksigner"
+	"chain/core/config"
 	"chain/core/mockhsm"
 	"chain/database/pg"
 )
+
+func init() {
+	config.BuildConfig.MockHSM = true
+}
 
 func enableMockHSM(db pg.DB) []core.RunOption {
 	return []core.RunOption{core.MockHSM(mockhsm.New(db))}

--- a/cmd/cored/no_mockhsm.go
+++ b/cmd/cored/no_mockhsm.go
@@ -5,14 +5,9 @@ package main
 import (
 	"chain/core"
 	"chain/core/blocksigner"
-	"chain/core/config"
 	"chain/database/pg"
 	"errors"
 )
-
-func init() {
-	config.BuildConfig.MockHSM = false
-}
 
 func enableMockHSM(pg.DB) []core.RunOption {
 	return nil

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -46,18 +46,13 @@ var (
 
 	Version, BuildCommit, BuildDate string
 
-	// This is the default, Chain development configuration.
-	// These options can be updated with build tags.
-	BuildConfig = struct {
+	// These feature flags are marked as enabled by build tags.
+	// See files in $CHAIN/cmd/cored.
+	BuildConfig struct {
 		LocalhostAuth bool `json:"is_localhost_auth"`
 		MockHSM       bool `json:"is_mockhsm"`
 		Reset         bool `json:"is_reset"`
 		HTTPOk        bool `json:"is_http_ok"`
-	}{
-		LocalhostAuth: false,
-		MockHSM:       true,
-		Reset:         true,
-		HTTPOk:        false,
 	}
 )
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3135";
+	public final String Id = "main/rev3136";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3135"
+const ID string = "main/rev3136"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3135"
+export const rev_id = "main/rev3136"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3135".freeze
+	ID = "main/rev3136".freeze
 end


### PR DESCRIPTION
This affects two features: mockhsm and reset (with
corresponding build tags no_mockhsm and no_reset).
The rule is: feature flags in chain/core/config always
default to false; build tags in chain/cmd/cored must set
them to true when the feature is enabled. This can be
either because the build tag is present, e.g. http_ok,
or absent, e.g. no_reset.

This also fixes a bug. Previously, building with
no_reset would incorrectly report reset=true in the
cored version output. A file in cored was explicitly
setting it to true when the feature was enabled, and the
default value hard coded in package config was also
true, but nothing ever set it to false when the feature
was disabled.