### PR TITLE
cmd/integtest: run integration tests (new command)

### DIFF
--- a/cmd/integtest/doc.go
+++ b/cmd/integtest/doc.go
@@ -12,12 +12,12 @@ Subsequent arguments are passed on to the test process.
 
 Flags
 
-Flag '-timeout' aborts the test after the given duration.
+Flag '-t [duration]' aborts the test after the given duration.
 The default is 15 minutes.
 
 Files and Environment
 
-It puts all temporary files in various subdirectories
+This command puts all temporary files in various subdirectories
 of $HOME/integration.
 This scratch space is cleaned up before each test,
 but left intact after the test
@@ -26,9 +26,14 @@ to assist in debugging a failed test.
 can write files anywhere.)
 
 It requires Postgres and Go installed.
-(The default value for GOPATH is $HOME/go.)
-If CHAIN is unset, command integtest sets it to $HOME/go/src/chain
-before running the test process.
+
+Test Environment
+
+This tool always sets some values for the test process:
+
+  CHAIN          from environment, or $HOME/go/src/chain
+  DB_URL_TEST    the URL of a new, empty postgres cluster
+  (working dir)  an empty scratch directory
 
 */
 package main

--- a/cmd/integtest/doc.go
+++ b/cmd/integtest/doc.go
@@ -1,0 +1,34 @@
+/*
+
+Command integtest compiles and runs a command
+to perform integration tests on Chain Core
+and related systems.
+It sets up common resources used by most or all integration tests,
+so the tests themselves don't have to.
+
+Its first argument is the import path of a command package
+to compile and execute.
+Subsequent arguments are passed on to the test process.
+
+Flags
+
+Flag '-timeout' aborts the test after the given duration.
+The default is 15 minutes.
+
+Files and Environment
+
+It puts all temporary files in various subdirectories
+of $HOME/integration.
+This scratch space is cleaned up before each test,
+but left intact after the test
+to assist in debugging a failed test.
+(Note, however, that the test process itself
+can write files anywhere.)
+
+It requires Postgres and Go installed.
+(The default value for GOPATH is $HOME/go.)
+If CHAIN is unset, command integtest sets it to $HOME/go/src/chain
+before running the test process.
+
+*/
+package main

--- a/cmd/integtest/main.go
+++ b/cmd/integtest/main.go
@@ -90,7 +90,7 @@ func main() {
 	err = cmd.Wait()
 	if err != nil {
 		log.Printf("%s: %v", base, err)
-		panic("cmd failed")
+		os.Exit(1)
 	}
 }
 

--- a/cmd/integtest/main.go
+++ b/cmd/integtest/main.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+)
+
+/*
+
+Required environment:
+
+  HOME
+  GOPATH (default $HOME/go)
+  CHAIN  (default $HOME/go/src/chain)
+
+*/
+
+const (
+	pgport = "12345"
+)
+
+// This command assumes it has free rein over $HOME/integration.
+var (
+	home     = os.Getenv("HOME")
+	dir      = home + "/integration"
+	lockFile = dir + "/lock"
+	wkdir    = dir + "/work"
+	gobin    = dir + "/bin"
+	pgdir    = dir + "/pg"
+	pgrun    = dir + "/pgrun" // for socket file
+)
+
+var (
+	flagTimeout = flag.Duration("timeout", 15*time.Minute, "abort the test after the given duration")
+)
+
+func main() {
+	ctx := context.Background()
+	log.SetPrefix("integration: ")
+	log.SetFlags(log.Lshortfile | log.LstdFlags)
+	flag.Usage = usage
+	flag.Parse()
+	lock() // ensure only one at a time
+
+	ctx, cancel := context.WithTimeout(ctx, *flagTimeout)
+	defer cancel()
+
+	if s := pgbin(); s != "" {
+		must(os.Setenv("PATH", os.Getenv("PATH")+":"+s))
+	}
+
+	must(os.RemoveAll(wkdir))
+	must(os.RemoveAll(gobin))
+	must(os.RemoveAll(pgdir))
+
+	if flag.NArg() < 1 {
+		usage()
+	}
+	pkg := flag.Arg(0)
+	args := flag.Args()[1:]
+
+	// accumulate environment for the test process
+	var env []string
+
+	if os.Getenv("CHAIN") == "" {
+		env = append(env, "CHAIN="+home+"/go/src/chain")
+	}
+
+	setupDB(ctx)
+	pgURL := "postgresql:///postgres?host=" + pgrun + "&port=" + pgport
+	env = append(env, "DB_URL_TEST="+pgURL) // for chain/database/pg/pgtest
+
+	buildTest(ctx, pkg)
+
+	must(os.MkdirAll(wkdir, 0700))
+
+	_, base := path.Split(pkg)
+	fmt.Println(base, strings.Join(args, " "))
+	cmd := command(ctx, gobin+"/"+base, args...)
+	cmd.Dir = wkdir
+	cmd.Env = mergeEnvLists(env, os.Environ())
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Start()
+	if err != nil {
+		log.Printf("%s: %v", base, err)
+		panic("cmd failed")
+	}
+	defer syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	err = cmd.Wait()
+	if err != nil {
+		log.Printf("%s: %v", base, err)
+		panic("cmd failed")
+	}
+}
+
+func setupDB(ctx context.Context) {
+	fmt.Println("initdb", "-D", pgdir)
+	err := command(ctx, "initdb", "-D", pgdir).Run()
+	if err, ok := err.(*exec.ExitError); ok {
+		os.Stderr.Write(err.Stderr)
+	}
+	if err != nil {
+		log.Printf("initdb: %v", err)
+		panic("cmd failed")
+	}
+
+	var buf bytes.Buffer
+	must(configTemplate.Execute(&buf, map[string]string{
+		"port":    pgport,
+		"sockdir": pgrun,
+	}))
+	must(ioutil.WriteFile(pgdir+"/postgresql.conf", buf.Bytes(), 0600))
+
+	buf.Reset()
+	must(hbaTemplate.Execute(&buf, nil))
+	must(ioutil.WriteFile(pgdir+"/pg_hba.conf", buf.Bytes(), 0600))
+
+	fmt.Println("postgres", "-D", pgdir)
+	cmd := command(ctx, "postgres", "-D", pgdir)
+	cmd.Env = mergeEnvLists([]string{"GOBIN=" + gobin}, os.Environ())
+	err = cmd.Start()
+	if err, ok := err.(*exec.ExitError); ok {
+		os.Stderr.Write(err.Stderr)
+	}
+	if err != nil {
+		log.Printf("go: %v", err)
+		panic("cmd failed")
+	}
+
+	must(os.MkdirAll(pgrun, 0700))
+}
+
+func buildTest(ctx context.Context, pkg string) {
+	fmt.Println("go", "install", pkg)
+	cmd := command(ctx, "go", "install", pkg)
+	cmd.Env = mergeEnvLists([]string{"GOBIN=" + gobin}, os.Environ())
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err, ok := err.(*exec.ExitError); ok {
+		os.Stderr.Write(err.Stderr)
+	}
+	if err != nil {
+		log.Printf("go: %v", err)
+		panic("cmd failed")
+	}
+}
+
+func lock() {
+	must(os.MkdirAll(dir, 0700))
+	f, err := os.Create(lockFile)
+	must(err)
+	err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		log.Fatalln("lock:", err)
+	}
+	// note: do not close f here, retain the lock
+	// for the process lifetime
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr, "usage: integtest [flags] [package] [args...]")
+	fmt.Fprintln(os.Stderr, "flags:")
+	flag.PrintDefaults()
+	os.Exit(2)
+}
+
+// mergeEnvLists merges the two environment lists such that
+// variables with the same name in "in" replace those in "out".
+// This always returns a newly allocated slice.
+func mergeEnvLists(in, out []string) []string {
+	out = append([]string(nil), out...)
+NextVar:
+	for _, inkv := range in {
+		k := strings.SplitAfterN(inkv, "=", 2)[0]
+		for i, outkv := range out {
+			if strings.HasPrefix(outkv, k) {
+				out[i] = inkv
+				continue NextVar
+			}
+		}
+		out = append(out, inkv)
+	}
+	return out
+}
+
+func command(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	c := exec.CommandContext(ctx, name, arg...)
+	c.SysProcAttr = newSysProcAttr()
+	return c
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cmd/integtest/main.go
+++ b/cmd/integtest/main.go
@@ -15,16 +15,6 @@ import (
 	"time"
 )
 
-/*
-
-Required environment:
-
-  HOME
-  GOPATH (default $HOME/go)
-  CHAIN  (default $HOME/go/src/chain)
-
-*/
-
 const (
 	pgport = "12345"
 )
@@ -41,7 +31,7 @@ var (
 )
 
 var (
-	flagTimeout = flag.Duration("timeout", 15*time.Minute, "abort the test after the given duration")
+	flagT = flag.Duration("t", 15*time.Minute, "abort the test after the given duration")
 )
 
 func main() {
@@ -52,7 +42,7 @@ func main() {
 	flag.Parse()
 	lock() // ensure only one at a time
 
-	ctx, cancel := context.WithTimeout(ctx, *flagTimeout)
+	ctx, cancel := context.WithTimeout(ctx, *flagT)
 	defer cancel()
 
 	if s := pgbin(); s != "" {
@@ -169,7 +159,7 @@ func lock() {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: integtest [flags] [package] [args...]")
+	fmt.Fprintln(os.Stderr, "usage: integtest [-t duration] [package] [args...]")
 	fmt.Fprintln(os.Stderr, "flags:")
 	flag.PrintDefaults()
 	os.Exit(2)

--- a/cmd/integtest/pg.go
+++ b/cmd/integtest/pg.go
@@ -43,6 +43,12 @@ lc_time = 'en_US.UTF-8'       # locale for time formatting
 
 # default configuration for text search
 default_text_search_config = 'pg_catalog.english'
+
+log_destination = 'csvlog'
+log_directory = '{{.logdir}}'
+log_filename = 'integtest-queries.log'
+log_file_mode = 0644
+log_min_duration_statement = {{.logdur}}
 `))
 
 var hbaTemplate = template.Must(template.New("pg_hba.conf").Parse(`

--- a/cmd/integtest/pg.go
+++ b/cmd/integtest/pg.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"text/template"
+)
+
+// Postgres might be installed in a weird place.
+// Look for it and return its location if we find it.
+// Otherwise it'll have to be in $PATH.
+func pgbin() string {
+	for _, s := range []string{
+		"/usr/lib/postgresql/9.6/bin",
+		"/usr/lib/postgresql/9.5/bin",
+		"/Applications/Postgres.app/Contents/Versions/9.6/bin",
+		"/Applications/Postgres.app/Contents/Versions/9.5/bin",
+	} {
+		if fi, err := os.Lstat(s); err == nil && fi.IsDir() {
+			return s
+		}
+	}
+	return ""
+}
+
+// based on a mix of RDS's default.postgres9.4 parameter group, the Flynn
+// defaults, and my own notes from running local postgreses
+var configTemplate = template.Must(template.New("postgresql.conf").Parse(`
+port = {{.port}}
+listen_addresses = 'localhost'
+max_connections = 100
+shared_buffers = 128MB
+dynamic_shared_memory_type = posix
+unix_socket_directories = '{{.sockdir}}'
+
+# replication
+# logging
+datestyle = 'iso, mdy'
+timezone = 'UTC'
+lc_messages = 'en_US.UTF-8'     # locale for system error message
+lc_monetary = 'en_US.UTF-8'     # locale for monetary formatting
+lc_numeric = 'en_US.UTF-8'      # locale for number formatting
+lc_time = 'en_US.UTF-8'       # locale for time formatting
+
+# default configuration for text search
+default_text_search_config = 'pg_catalog.english'
+`))
+
+var hbaTemplate = template.Must(template.New("pg_hba.conf").Parse(`
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     trust
+# IPv4 local connections:
+host    all             all             127.0.0.0/8             trust
+# IPv6 local connections:
+host    all             all             ::1/128                 trust
+`))

--- a/cmd/integtest/sysprocattr_darwin.go
+++ b/cmd/integtest/sysprocattr_darwin.go
@@ -1,0 +1,9 @@
+package main
+
+import "syscall"
+
+func newSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/cmd/integtest/sysprocattr_linux.go
+++ b/cmd/integtest/sysprocattr_linux.go
@@ -1,0 +1,10 @@
+package main
+
+import "syscall"
+
+func newSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Setpgid:   true,
+		Pdeathsig: syscall.SIGKILL,
+	}
+}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3146";
+	public final String Id = "main/rev3147";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3146"
+const ID string = "main/rev3147"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3146"
+export const rev_id = "main/rev3147"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3146".freeze
+	ID = "main/rev3147".freeze
 end


### PR DESCRIPTION
This new command provides support for integration test
packages. It sets up common resources neede by most or
all tests, such as running a postgres cluster and
providing a working directory.