### PR TITLE
database/sinkdb/sinkdbtest: new package

### DIFF
--- a/core/authz_test.go
+++ b/core/authz_test.go
@@ -18,8 +18,7 @@ func TestAuthz(t *testing.T) {
 	ctx := context.Background()
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
 	accessTokens := &accesstoken.CredentialStore{db}
-	sdb, cleanup := sinkdbtest.NewDB(t)
-	defer cleanup()
+	sdb := sinkdbtest.NewDB(t)
 
 	mux := http.NewServeMux()
 	mux.Handle("/raft/", sdb.RaftService())

--- a/core/authz_test.go
+++ b/core/authz_test.go
@@ -6,37 +6,20 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"chain/core/accesstoken"
 	"chain/database/pg/pgtest"
-	"chain/database/sinkdb"
+	"chain/database/sinkdb/sinkdbtest"
 )
 
 func TestAuthz(t *testing.T) {
 	ctx := context.Background()
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
 	accessTokens := &accesstoken.CredentialStore{db}
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	raftDir := filepath.Join(currentDir, "/.testraft")
-	err = os.Mkdir(raftDir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(raftDir)
-
-	sdb, err := sinkdb.Open("", raftDir, "", new(http.Client), false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sdb, cleanup := sinkdbtest.NewDB(t)
+	defer cleanup()
 
 	mux := http.NewServeMux()
 	mux.Handle("/raft/", sdb.RaftService())

--- a/core/grants_test.go
+++ b/core/grants_test.go
@@ -3,38 +3,21 @@ package core
 import (
 	"context"
 	"net/http"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"chain/core/accesstoken"
 	"chain/database/pg/pgtest"
-	"chain/database/sinkdb"
+	"chain/database/sinkdb/sinkdbtest"
 )
 
 func TestCreatGrantValidation(t *testing.T) {
 	ctx := context.Background()
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	sdb, cleanup := sinkdbtest.NewDB(t)
+	defer cleanup()
 
 	accessTokens := &accesstoken.CredentialStore{db}
 	_, err := accessTokens.Create(ctx, "test-token", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	raftDir := filepath.Join(currentDir, "/.testraft")
-	err = os.Mkdir(raftDir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(raftDir)
-
-	sdb, err := sinkdb.Open("", raftDir, "", new(http.Client), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,26 +127,11 @@ func TestCreatGrantValidation(t *testing.T) {
 func TestDeleteGrants(t *testing.T) {
 	ctx := context.Background()
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	sdb, cleanup := sinkdbtest.NewDB(t)
+	defer cleanup()
 
 	accessTokens := &accesstoken.CredentialStore{db}
 	_, err := accessTokens.Create(ctx, "test-token", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	raftDir := filepath.Join(currentDir, "/.testraft")
-	err = os.Mkdir(raftDir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(raftDir)
-
-	sdb, err := sinkdb.Open("", raftDir, "", new(http.Client), false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,6 +224,8 @@ func TestDeleteGrants(t *testing.T) {
 func TestDeleteGrantsByAccessToken(t *testing.T) {
 	ctx := context.Background()
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	sdb, cleanup := sinkdbtest.NewDB(t)
+	defer cleanup()
 
 	accessTokens := &accesstoken.CredentialStore{db}
 	_, err := accessTokens.Create(ctx, "test-token-0", "")
@@ -264,23 +234,6 @@ func TestDeleteGrantsByAccessToken(t *testing.T) {
 	}
 
 	_, err = accessTokens.Create(ctx, "test-token-1", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	raftDir := filepath.Join(currentDir, "/.testraft")
-	err = os.Mkdir(raftDir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(raftDir)
-
-	sdb, err := sinkdb.Open("", raftDir, "", new(http.Client), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/grants_test.go
+++ b/core/grants_test.go
@@ -13,8 +13,6 @@ import (
 func TestCreatGrantValidation(t *testing.T) {
 	ctx := context.Background()
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
-	sdb, cleanup := sinkdbtest.NewDB(t)
-	defer cleanup()
 
 	accessTokens := &accesstoken.CredentialStore{db}
 	_, err := accessTokens.Create(ctx, "test-token", "")
@@ -24,7 +22,7 @@ func TestCreatGrantValidation(t *testing.T) {
 
 	api := &API{
 		mux:          http.NewServeMux(),
-		sdb:          sdb,
+		sdb:          sinkdbtest.NewDB(t),
 		accessTokens: accessTokens,
 	}
 
@@ -127,8 +125,6 @@ func TestCreatGrantValidation(t *testing.T) {
 func TestDeleteGrants(t *testing.T) {
 	ctx := context.Background()
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
-	sdb, cleanup := sinkdbtest.NewDB(t)
-	defer cleanup()
 
 	accessTokens := &accesstoken.CredentialStore{db}
 	_, err := accessTokens.Create(ctx, "test-token", "")
@@ -138,7 +134,7 @@ func TestDeleteGrants(t *testing.T) {
 
 	api := &API{
 		mux:          http.NewServeMux(),
-		sdb:          sdb,
+		sdb:          sinkdbtest.NewDB(t),
 		accessTokens: accessTokens,
 	}
 
@@ -224,8 +220,6 @@ func TestDeleteGrants(t *testing.T) {
 func TestDeleteGrantsByAccessToken(t *testing.T) {
 	ctx := context.Background()
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
-	sdb, cleanup := sinkdbtest.NewDB(t)
-	defer cleanup()
 
 	accessTokens := &accesstoken.CredentialStore{db}
 	_, err := accessTokens.Create(ctx, "test-token-0", "")
@@ -240,7 +234,7 @@ func TestDeleteGrantsByAccessToken(t *testing.T) {
 
 	api := &API{
 		mux:          http.NewServeMux(),
-		sdb:          sdb,
+		sdb:          sinkdbtest.NewDB(t),
 		accessTokens: accessTokens,
 	}
 

--- a/database/sinkdb/sinkdbtest/sinkdbtest.go
+++ b/database/sinkdb/sinkdbtest/sinkdbtest.go
@@ -1,0 +1,29 @@
+package sinkdbtest
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	"chain/database/sinkdb"
+)
+
+// NewDB creates a new sinkdb instance with a random temporary
+// storage directory.
+func NewDB(t testing.TB) (sdb *sinkdb.DB, cleanup func()) {
+	tempDir, err := ioutil.TempDir("", "chain-syncdbtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sdb, err = sinkdb.Open("", tempDir, "", new(http.Client), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO(jackson): support closing sinkdb.DB and stopping
+	// any goroutines spawned in the raft package.
+	cleanup = func() { os.RemoveAll(tempDir) }
+
+	return sdb, cleanup
+}

--- a/database/sinkdb/state_test.go
+++ b/database/sinkdb/state_test.go
@@ -2,9 +2,9 @@ package sinkdb
 
 import (
 	"context"
+	"io/ioutil"
 	"net/http"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -45,13 +45,7 @@ func TestGetPeerAddr(t *testing.T) {
 }
 
 func TestAllowedMember(t *testing.T) {
-	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	raftDir := filepath.Join(currentDir, "/.testraft")
-	err = os.Mkdir(raftDir, 0700)
+	raftDir, err := ioutil.TempDir("", "sinkdb")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3143";
+	public final String Id = "main/rev3144";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3143"
+const ID string = "main/rev3144"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3143"
+export const rev_id = "main/rev3144"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3143".freeze
+	ID = "main/rev3144".freeze
 end


### PR DESCRIPTION
Add package with test utilities for creating test sinkdb instances.
This will also prevent tests in separate packages from interacting.