### PR TITLE
database/sinkdb: fix key existence check

### DIFF
--- a/database/sinkdb/sinkdb.go
+++ b/database/sinkdb/sinkdb.go
@@ -54,20 +54,14 @@ func (db *DB) Get(ctx context.Context, key string, v proto.Message) (found bool,
 		return false, err
 	}
 	buf, found := db.state.get(key)
-	if !found {
-		return false, err
-	}
-	return true, proto.Unmarshal(buf, v)
+	return found, proto.Unmarshal(buf, v)
 }
 
 // GetStale performs a non-linearizable read of the provided key.
 // The value may be stale. The read value is unmarshalled into v.
 func (db *DB) GetStale(key string, v proto.Message) (found bool, err error) {
 	buf, found := db.state.get(key) // read directly from state
-	if !found {
-		return false, err
-	}
-	return true, proto.Unmarshal(buf, v)
+	return found, proto.Unmarshal(buf, v)
 }
 
 // AddAllowedMember configures sinkdb to allow the provided address

--- a/database/sinkdb/sinkdb.go
+++ b/database/sinkdb/sinkdb.go
@@ -53,9 +53,8 @@ func (db *DB) Get(ctx context.Context, key string, v proto.Message) (found bool,
 	if err != nil {
 		return false, err
 	}
-	buf := db.state.get(key)
-	// TODO(jackson): propagate real key existence bool
-	if len(buf) == 0 {
+	buf, found := db.state.get(key)
+	if !found {
 		return false, err
 	}
 	return true, proto.Unmarshal(buf, v)
@@ -64,9 +63,8 @@ func (db *DB) Get(ctx context.Context, key string, v proto.Message) (found bool,
 // GetStale performs a non-linearizable read of the provided key.
 // The value may be stale. The read value is unmarshalled into v.
 func (db *DB) GetStale(key string, v proto.Message) (found bool, err error) {
-	buf := db.state.get(key) // read directly from state
-	// TODO(jackson): propagate real key existence bool
-	if len(buf) == 0 {
+	buf, found := db.state.get(key) // read directly from state
+	if !found {
 		return false, err
 	}
 	return true, proto.Unmarshal(buf, v)

--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -134,8 +134,9 @@ func (s *state) Apply(data []byte, index uint64) (satisfied bool, err error) {
 }
 
 // get performs a provisional read operation.
-func (s *state) get(key string) (value []byte) {
-	return s.state[key]
+func (s *state) get(key string) (value []byte, ok bool) {
+	value, ok = s.state[key]
+	return
 }
 
 // AppliedIndex returns the raft log index (applied index) of current state
@@ -153,8 +154,8 @@ func (s *state) NextNodeID() (id, version uint64) {
 }
 
 func (s *state) IsAllowedMember(addr string) bool {
-	data := s.get(allowedMemberPrefix + "/" + addr)
-	return len(data) > 0
+	_, ok := s.get(allowedMemberPrefix + "/" + addr)
+	return ok
 }
 
 func (s *state) IncrementNextNodeID(oldID uint64, index uint64) (instruction []byte) {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3144";
+	public final String Id = "main/rev3145";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3144"
+const ID string = "main/rev3145"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3144"
+export const rev_id = "main/rev3145"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3144".freeze
+	ID = "main/rev3145".freeze
 end


### PR DESCRIPTION
Propagate a flag indicating the existence of the key instead of
interpreting an empty byte slice as a nonexistent key.