### PR TITLE
database/sinkdb: expose ErrConflict

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -16,6 +16,7 @@ import (
 	"chain/core/txbuilder"
 	"chain/core/txfeed"
 	"chain/database/pg"
+	"chain/database/sinkdb"
 	"chain/errors"
 	"chain/net/http/authz"
 	"chain/net/http/httperror"
@@ -28,6 +29,8 @@ func isTemporary(info httperror.Info, err error) bool {
 	case "CH000": // internal server error
 		return true
 	case "CH001": // request timed out
+		return true
+	case "CH012": // conflict
 		return true
 	case "CH761": // outputs currently reserved
 		return true
@@ -63,6 +66,7 @@ var errorFormatter = httperror.Formatter{
 		errNotAuthenticated:        {401, "CH009", "Request could not be authenticated"},
 		txbuilder.ErrMissingFields: {400, "CH010", "One or more fields are missing"},
 		authz.ErrNotAuthorized:     {403, "CH011", "Request is unauthorized"},
+		sinkdb.ErrConflict:         {409, "CH012", "Database transaction conflict; retry"},
 		asset.ErrDuplicateAlias:    {400, "CH050", "Alias already exists"},
 		account.ErrDuplicateAlias:  {400, "CH050", "Alias already exists"},
 		txfeed.ErrDuplicateAlias:   {400, "CH050", "Alias already exists"},

--- a/core/errors.go
+++ b/core/errors.go
@@ -30,8 +30,6 @@ func isTemporary(info httperror.Info, err error) bool {
 		return true
 	case "CH001": // request timed out
 		return true
-	case "CH012": // conflict
-		return true
 	case "CH761": // outputs currently reserved
 		return true
 	case "CH706": // 1 or more action errors
@@ -66,7 +64,7 @@ var errorFormatter = httperror.Formatter{
 		errNotAuthenticated:        {401, "CH009", "Request could not be authenticated"},
 		txbuilder.ErrMissingFields: {400, "CH010", "One or more fields are missing"},
 		authz.ErrNotAuthorized:     {403, "CH011", "Request is unauthorized"},
-		sinkdb.ErrConflict:         {409, "CH012", "Database transaction conflict; retry"},
+		sinkdb.ErrConflict:         {409, "CH012", "Conflict processing request"},
 		asset.ErrDuplicateAlias:    {400, "CH050", "Alias already exists"},
 		account.ErrDuplicateAlias:  {400, "CH050", "Alias already exists"},
 		txfeed.ErrDuplicateAlias:   {400, "CH050", "Alias already exists"},

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3152";
+	public final String Id = "main/rev3153";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3152"
+const ID string = "main/rev3153"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3152"
+export const rev_id = "main/rev3153"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3152".freeze
+	ID = "main/rev3153".freeze
 end


### PR DESCRIPTION
Remove raft.ErrUnsatisifed, replacing it with sinkdb.ErrConflict. By
default map sinkdb.ErrConflict to a 409 status code. When we introduce
code paths where sinkdb.ErrConflict is result of a temporary conflict in a
read-modify-write cycle, we can add another error mapped to a temporary
error.

Also, remove the error return value from raft.State.Apply. The raft
package would panic if it was non-nil. Now, the sinkdb state will panic
in those error conditions.