### PR TITLE
database/sinkdb: protect state with a mutex

### DIFF
--- a/database/sinkdb/state_test.go
+++ b/database/sinkdb/state_test.go
@@ -11,25 +11,21 @@ import (
 
 func TestRemovePeerAddr(t *testing.T) {
 	s := state{peers: map[uint64]string{1: "1.2.3.4:567"}}
-	want := state{peers: map[uint64]string{}}
+	wantPeers := map[uint64]string{}
 
 	s.RemovePeerAddr(1)
-	if !reflect.DeepEqual(s, want) {
-		t.Errorf("RemovePeerAddr(%d) => %v want %v", 1, s, want)
+	if !reflect.DeepEqual(s.peers, wantPeers) {
+		t.Errorf("RemovePeerAddr(%d) => %v want %v", 1, s.peers, wantPeers)
 	}
 }
 
 func TestSetPeerAddr(t *testing.T) {
 	s := newState()
-	want := &state{
-		state:   s.state,
-		peers:   map[uint64]string{1: "1.2.3.4:567"},
-		version: s.version,
-	}
+	wantPeers := map[uint64]string{1: "1.2.3.4:567"}
 
 	s.SetPeerAddr(1, "1.2.3.4:567")
-	if !reflect.DeepEqual(s, want) {
-		t.Errorf("s.SetPeerAddr(1, \"1.2.3.4:567\") => %v, want %v", s, want)
+	if !reflect.DeepEqual(s.peers, wantPeers) {
+		t.Errorf("s.SetPeerAddr(1, \"1.2.3.4:567\") => %v, want %v", s.peers, wantPeers)
 	}
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3151";
+	public final String Id = "main/rev3152";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3151"
+const ID string = "main/rev3152"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3151"
+export const rev_id = "main/rev3152"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3151".freeze
+	ID = "main/rev3152".freeze
 end


### PR DESCRIPTION
Before the sinkdb refactor, all accesses to the state were protected
by raft.Service's stateMu. After the refactor, sinkdb directly accesses
the state without acquiring raft.Service's mutex, allowing data races.

This adds a mutex to protect the state. The raft package's stateMu is
still necessary for protecting raft-specific fields and for the
condition variable. There are a few places where we can likely avoid
acquiring stateMu's mutex and instead rely on State's internal locking.