### PR TITLE
core/config: fix mockhsm log statement

### DIFF
--- a/core/config/mockhsm.go
+++ b/core/config/mockhsm.go
@@ -18,9 +18,9 @@ func getOrCreateDevKey(ctx context.Context, db pg.DB, c *Config) (blockPub ed255
 		return nil, err
 	}
 	if created {
-		log.Printf(ctx, "Generated new block-signing key %s\n", corePub.Pub)
+		log.Printf(ctx, "Generated new block-signing key %x", corePub.Pub)
 	} else {
-		log.Printf(ctx, "Using block-signing key %s\n", corePub.Pub)
+		log.Printf(ctx, "Using block-signing key %x", corePub.Pub)
 	}
 	c.BlockPub = corePub.Pub
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3153";
+	public final String Id = "main/rev3154";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3153"
+const ID string = "main/rev3154"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3153"
+export const rev_id = "main/rev3154"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3153".freeze
+	ID = "main/rev3154".freeze
 end


### PR DESCRIPTION
Log the block pub key in hex.

When configuring with the blockhsm, previously cored would log the
raw bytes of the block-signing key and add an unnecessary "\n"
to the end:

```
app=cored buildtag=? processID=chain-mba.local-26010 reqid=5ab5bcc6660c33989b9f at=mockhsm.go:21 t=2017-05-18T17:15:14.019931843Z message="Generated new block-signing key J\xd4\x00\x0f\xbcR*\xf84(\x1c\xa0q\xb1\xe3\x16\xd1;\u0382R\xb2\xdbuS\x15\x0f4\xc3\x00\x852\n"
```