### PR TITLE
core: set policies for /debug/ endpoints

### DIFF
--- a/core/authz.go
+++ b/core/authz.go
@@ -58,7 +58,8 @@ var policyByRoute = map[string][]string{
 	"/info":                       {"client-readwrite", "client-readonly", "crosscore", "crosscore-signblock", "monitoring", "internal"},
 
 	"/debug/vars":          {"client-readwrite", "client-readonly", "monitoring"}, // should monitoring endpoints also be available to any other policy-holders?
-	"/debug/pprof":         {"client-readwrite", "client-readonly", "monitoring"},
+	"/debug/pprof/block":   {"client-readwrite", "client-readonly", "monitoring"},
+	"/debug/pprof/heap":    {"client-readwrite", "client-readonly", "monitoring"},
 	"/debug/pprof/profile": {"client-readwrite", "client-readonly", "monitoring"},
 	"/debug/pprof/symbol":  {"client-readwrite", "client-readonly", "monitoring"},
 	"/debug/pprof/trace":   {"client-readwrite", "client-readonly", "monitoring"},

--- a/core/authz.go
+++ b/core/authz.go
@@ -57,12 +57,7 @@ var policyByRoute = map[string][]string{
 	"/configure":                  {"client-readwrite", "internal"},
 	"/info":                       {"client-readwrite", "client-readonly", "crosscore", "crosscore-signblock", "monitoring", "internal"},
 
-	"/debug/vars":          {"client-readwrite", "client-readonly", "monitoring"}, // should monitoring endpoints also be available to any other policy-holders?
-	"/debug/pprof/block":   {"client-readwrite", "client-readonly", "monitoring"},
-	"/debug/pprof/heap":    {"client-readwrite", "client-readonly", "monitoring"},
-	"/debug/pprof/profile": {"client-readwrite", "client-readonly", "monitoring"},
-	"/debug/pprof/symbol":  {"client-readwrite", "client-readonly", "monitoring"},
-	"/debug/pprof/trace":   {"client-readwrite", "client-readonly", "monitoring"},
+	"/debug/": {"client-readwrite", "client-readonly", "monitoring"},
 
 	"/raft/": {"internal"},
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3159";
+	public final String Id = "main/rev3160";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3159"
+const ID string = "main/rev3160"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3159"
+export const rev_id = "main/rev3160"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3159".freeze
+	ID = "main/rev3160".freeze
 end


### PR DESCRIPTION
The handler installed at the path /debug/pprof/ serves the heap and
blocking profiles at /debug/pprof/heap and /debug/pprof/block. The
handler was installed at /debug/pprof/ but the policies were defined on
the path /debug/pprof, so these profiles were inaccessible.

Fix #1213