### PR TITLE
core: respond with Bad Request on bad address

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -88,6 +88,7 @@ var errorFormatter = httperror.Formatter{
 		errNoClientTokens:              {400, "CH120", "Cannot enable client authentication with no client tokens"},
 		blocksigner.ErrConsensusChange: {400, "CH150", "Refuse to sign block with consensus change"},
 		errMissingAddr:                 {400, "CH160", "Address is missing"},
+		errInvalidAddr:                 {400, "CH161", "Address is invalid"},
 
 		// Signers error namespace (2xx)
 		signers.ErrBadQuorum: {400, "CH200", "Quorum must be greater than 1 and less than or equal to the length of xpubs"},

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3156";
+	public final String Id = "main/rev3157";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3156"
+const ID string = "main/rev3157"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3156"
+export const rev_id = "main/rev3157"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3156".freeze
+	ID = "main/rev3157".freeze
 end


### PR DESCRIPTION
In calls to the /add-allowed-member RPC endpoint, return a 400 Bad
Request error response when the provided address is invalid.

```
jackson@mba ~ $ corectl allow-address http://:1999
RPC error: CH161 Address is invalid
Detail: too many colons in address
```