### PR TITLE
protocol/validation: cache per-entry validation results during ValidateTx

### DIFF
--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -69,28 +69,21 @@ func BenchmarkBuildTx(b *testing.B) {
 	}
 
 	for _, c := range cases {
+		actions := prepareActions(c.numAssets, c.numIssuances)
 		name := fmt.Sprintf("%d-asset--%d-issuance", c.numAssets, c.numIssuances)
 		b.Run(name+"--build", func(b *testing.B) {
-			actions := prepareActions(c.numAssets, c.numIssuances)
 			for i := 0; i < b.N; i++ {
-				b.StartTimer()
 				doBuild(actions)
-				b.StopTimer()
 			}
 		})
 		b.Run(name+"--build-sign", func(b *testing.B) {
-			actions := prepareActions(c.numAssets, c.numIssuances)
 			for i := 0; i < b.N; i++ {
-				b.StartTimer()
 				tpl := doBuild(actions)
 				coretest.SignTxTemplate(b, ctx, tpl, &testutil.TestXPrv)
-				b.StopTimer()
 			}
 		})
 		b.Run(name+"--build-sign-finalize", func(b *testing.B) {
-			actions := prepareActions(c.numAssets, c.numIssuances)
 			for i := 0; i < b.N; i++ {
-				b.StartTimer()
 				tpl := doBuild(actions)
 				coretest.SignTxTemplate(b, ctx, tpl, &testutil.TestXPrv)
 				func() {
@@ -102,7 +95,6 @@ func BenchmarkBuildTx(b *testing.B) {
 						b.Fatal(err)
 					}
 				}()
-				b.StopTimer()
 			}
 		})
 	}

--- a/core/bench_test.go
+++ b/core/bench_test.go
@@ -1,0 +1,109 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"chain/core/account"
+	"chain/core/asset"
+	"chain/core/coretest"
+	"chain/core/generator"
+	"chain/core/pin"
+	"chain/core/txbuilder"
+	"chain/database/pg/pgtest"
+	"chain/protocol/bc"
+	"chain/protocol/prottest"
+	"chain/testutil"
+)
+
+func BenchmarkBuildTx(b *testing.B) {
+	b.StopTimer()
+
+	cases := []struct {
+		numAssets, numIssuances int
+	}{
+		{1, 1}, {1, 10}, {1, 100},
+		{10, 1}, {10, 10}, {10, 100},
+		{100, 1}, {100, 10},
+	}
+
+	_, db := pgtest.NewDB(b, pgtest.SchemaPath)
+	ctx := context.Background()
+	pinStore := pin.NewStore(db)
+	chain := prottest.NewChain(b)
+	accounts := account.NewManager(db, chain, pinStore)
+	assets := asset.NewRegistry(db, chain, pinStore)
+	accountID := coretest.CreateAccount(ctx, b, accounts, "account", nil)
+	generator := generator.New(chain, nil, db)
+
+	var assetIDs []bc.AssetID
+	for _, c := range cases {
+		if c.numAssets > len(assetIDs) {
+			for i := len(assetIDs); i < c.numAssets; i++ {
+				assetID := coretest.CreateAsset(ctx, b, assets, nil, fmt.Sprintf("asset%d", i), nil)
+				assetIDs = append(assetIDs, assetID)
+			}
+		}
+	}
+
+	prepareActions := func(numAssets, numIssuances int) []txbuilder.Action {
+		var actions []txbuilder.Action
+		for i := 0; i < numAssets; i++ {
+			assetID := assetIDs[i]
+			for j := 0; j < numIssuances; j++ {
+				actions = append(actions, assets.NewIssueAction(bc.AssetAmount{AssetId: &assetID, Amount: 1}, nil))
+			}
+			actions = append(actions, accounts.NewControlAction(bc.AssetAmount{AssetId: &assetID, Amount: uint64(numIssuances)}, accountID, nil))
+		}
+		return actions
+	}
+
+	doBuild := func(actions []txbuilder.Action) *txbuilder.Template {
+		tpl, err := txbuilder.Build(ctx, nil, actions, time.Now().Add(time.Minute))
+		if err != nil {
+			b.Fatal(err)
+		}
+		return tpl
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf("%d-asset--%d-issuance", c.numAssets, c.numIssuances)
+		b.Run(name+"--build", func(b *testing.B) {
+			actions := prepareActions(c.numAssets, c.numIssuances)
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				doBuild(actions)
+				b.StopTimer()
+			}
+		})
+		b.Run(name+"--build-sign", func(b *testing.B) {
+			actions := prepareActions(c.numAssets, c.numIssuances)
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				tpl := doBuild(actions)
+				coretest.SignTxTemplate(b, ctx, tpl, &testutil.TestXPrv)
+				b.StopTimer()
+			}
+		})
+		b.Run(name+"--build-sign-finalize", func(b *testing.B) {
+			actions := prepareActions(c.numAssets, c.numIssuances)
+			for i := 0; i < b.N; i++ {
+				b.StartTimer()
+				tpl := doBuild(actions)
+				coretest.SignTxTemplate(b, ctx, tpl, &testutil.TestXPrv)
+				func() {
+					dbtx := pgtest.NewTx(b)
+					defer dbtx.Rollback()
+
+					err := txbuilder.FinalizeTx(ctx, chain, generator, tpl.Transaction)
+					if err != nil {
+						b.Fatal(err)
+					}
+				}()
+				b.StopTimer()
+			}
+		})
+	}
+}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3155";
+	public final String Id = "main/rev3156";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3155"
+const ID string = "main/rev3156"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3155"
+export const rev_id = "main/rev3156"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3155".freeze
+	ID = "main/rev3156".freeze
 end

--- a/protocol/validation/validation_test.go
+++ b/protocol/validation/validation_test.go
@@ -345,6 +345,7 @@ func TestTxValidation(t *testing.T) {
 				blockchainID: fixture.initialBlockID,
 				tx:           tx,
 				entryID:      tx.ID,
+				cache:        make(map[bc.Hash]error),
 			}
 			out := tx.Entries[*tx.ResultIds[0]].(*bc.Output)
 			muxID := out.Source.Ref


### PR DESCRIPTION
A new benchmark (included in this PR) led us to discover that during `ValidateTx` of certain kinds of very large transactions, some entries were being validated multiple times - in some cases, thousands of times each. This short-circuits that by caching the result of entry validation for the duration of `ValidateTx`.

```
$ benchstat before.txt after.txt 
name                                                   old time/op  new time/op  delta
BuildTx/1-asset--1-issuance--build-8                    591µs ± 1%   606µs ± 3%     ~     (p=0.056 n=5+5)
BuildTx/1-asset--1-issuance--build-sign-8               852µs ± 1%   838µs ± 0%   -1.56%  (p=0.008 n=5+5)
BuildTx/1-asset--1-issuance--build-sign-finalize-8      339ms ± 7%   333ms ±12%     ~     (p=0.841 n=5+5)
BuildTx/1-asset--10-issuance--build-8                   790µs ± 2%   776µs ± 0%   -1.68%  (p=0.008 n=5+5)
BuildTx/1-asset--10-issuance--build-sign-8             2.88ms ± 1%  3.23ms ± 8%  +12.28%  (p=0.008 n=5+5)
BuildTx/1-asset--10-issuance--build-sign-finalize-8     325ms ± 0%   333ms ± 2%     ~     (p=0.190 n=4+5)
BuildTx/1-asset--100-issuance--build-8                 2.78ms ± 1%  2.94ms ±10%     ~     (p=0.548 n=5+5)
BuildTx/1-asset--100-issuance--build-sign-8            21.2ms ± 1%  24.4ms ± 2%  +15.11%  (p=0.008 n=5+5)
BuildTx/1-asset--100-issuance--build-sign-finalize-8    361ms ± 1%   363ms ± 1%     ~     (p=0.222 n=5+5)
BuildTx/10-asset--1-issuance--build-8                  2.48ms ± 2%  2.49ms ± 1%     ~     (p=0.421 n=5+5)
BuildTx/10-asset--1-issuance--build-sign-8             4.46ms ± 1%  4.50ms ± 1%     ~     (p=0.056 n=5+5)
BuildTx/10-asset--1-issuance--build-sign-finalize-8     345ms ± 0%   333ms ± 2%   -3.60%  (p=0.016 n=4+5)
BuildTx/10-asset--10-issuance--build-8                 4.41ms ± 1%  4.44ms ± 1%     ~     (p=0.310 n=5+5)
BuildTx/10-asset--10-issuance--build-sign-8            23.2ms ± 2%  23.6ms ± 1%   +1.68%  (p=0.008 n=5+5)
BuildTx/10-asset--10-issuance--build-sign-finalize-8    531ms ± 5%   373ms ± 2%  -29.83%  (p=0.008 n=5+5)
BuildTx/10-asset--100-issuance--build-8                23.2ms ± 1%  23.6ms ± 2%     ~     (p=0.222 n=5+5)
BuildTx/10-asset--100-issuance--build-sign-8            211ms ± 2%   211ms ± 1%     ~     (p=0.690 n=5+5)
BuildTx/10-asset--100-issuance--build-sign-finalize-8   2.32s ± 2%   0.75s ± 2%  -67.46%  (p=0.008 n=5+5)
BuildTx/100-asset--1-issuance--build-8                 19.6ms ± 1%  19.7ms ± 1%     ~     (p=0.548 n=5+5)
BuildTx/100-asset--1-issuance--build-sign-8            38.1ms ± 1%  37.9ms ± 2%     ~     (p=0.310 n=5+5)
BuildTx/100-asset--1-issuance--build-sign-finalize-8    2.12s ± 3%   0.42s ± 1%  -80.35%  (p=0.008 n=5+5)
BuildTx/100-asset--10-issuance--build-8                38.8ms ± 1%  39.3ms ± 3%     ~     (p=0.841 n=5+5)
BuildTx/100-asset--10-issuance--build-sign-8            224ms ± 2%   227ms ± 1%     ~     (p=0.421 n=5+5)
BuildTx/100-asset--10-issuance--build-sign-finalize-8   18.5s ± 2%    0.9s ± 2%  -95.27%  (p=0.008 n=5+5)
```