### PR TITLE
core/rpc: use version over buildTag

### DIFF
--- a/cmd/testnet-reset/main.go
+++ b/cmd/testnet-reset/main.go
@@ -36,7 +36,7 @@ func coreEnv(prefix string) (*rpc.Client, core) {
 		BaseURL:     url,
 		AccessToken: clientTok,
 		Username:    "testnet-resetter", // for user-agent, not auth
-		BuildTag:    "none",
+		Version:     "none",
 	}
 
 	return client, core

--- a/core/rpc/rpc.go
+++ b/core/rpc/rpc.go
@@ -35,7 +35,7 @@ type Client struct {
 	BaseURL      string
 	AccessToken  string
 	Username     string
-	BuildTag     string
+	Version      string
 	BlockchainID string
 	CoreID       string
 
@@ -45,8 +45,8 @@ type Client struct {
 }
 
 func (c Client) userAgent() string {
-	return fmt.Sprintf("Chain; process=%s; buildtag=%s; blockchainID=%s",
-		c.Username, c.BuildTag, c.BlockchainID)
+	return fmt.Sprintf("Chain; process=%s; version=%s; blockchainID=%s",
+		c.Username, c.Version, c.BlockchainID)
 }
 
 // ErrStatusCode is an error returned when an rpc fails with a non-200

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3166";
+	public final String Id = "main/rev3167";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3166"
+const ID string = "main/rev3167"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3166"
+export const rev_id = "main/rev3167"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3166".freeze
+	ID = "main/rev3167".freeze
 end


### PR DESCRIPTION
Use the Chain Core version in the rpc client user agent instead of the
raw build tag. The version string is strictly more useful than the
buildTag that it's derived from.