### PR TITLE
docs: clarify backward compatibility rules for SDKs

### DIFF
--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -60,7 +60,17 @@ Software packages are mutually compatible if they share the same major and minor
 
 #### Deprecations and breaking changes
 
-Deprecations and breaking changes can occur when the minor version changes. If a feature is deprecated, it will remain functional for at least one minor version before being removed.
+Deprecations and breaking changes can occur when the minor version changes. To the greatest extent possible, breaking changes in server packages will be preceded by a deprecation announcement and at least one minor version cycle of continued support.
+
+Breaking changes may be introduced at any time in client packages (such as SDKs). However, since server packages are backward-compatible with the previous minor version of client packages, you can safely upgrade your server packages without breaking your application code.
+
+#### Upgrading example
+
+Chain Core is a quickly growing product, but the versioning scheme is designed to allow for a smooth upgrade process. To demonstrate this, here's an example of how to perform a minor-vesrion upgrade of Chain Core and the client SDK. Assume we're using Chain Core 1.1 and SDK 1.1, and wish to upgrade to 1.2.
+
+1. Upgrade Chain Core to 1.2, the next minor version of server software. The versioning rules specify that it the new version is backward-compatible with 1.1 SDKs, so your application code should continue to work.
+2. In a development environment, upgrade your SDKs to 1.2. Adjust your application code to account for any interface changes in the new SDK version.
+3. Deploy your upgraded application code from the previous step.
 
 ## Network versioning
 

--- a/docs/core/reference/versioning.md
+++ b/docs/core/reference/versioning.md
@@ -60,7 +60,7 @@ Software packages are mutually compatible if they share the same major and minor
 
 #### Deprecations and breaking changes
 
-Deprecations and breaking changes can occur when the minor version changes. To the greatest extent possible, breaking changes in server packages will be preceded by a deprecation announcement and at least one minor version cycle of continued support.
+Deprecations and breaking changes can occur when the minor version changes. Breaking changes in server packages will be preceded by a deprecation announcement and at least one minor version cycle of continued support.
 
 Breaking changes may be introduced at any time in client packages (such as SDKs). However, since server packages are backward-compatible with the previous minor version of client packages, you can safely upgrade your server packages without breaking your application code.
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3164";
+	public final String Id = "main/rev3165";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3164"
+const ID string = "main/rev3165"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3164"
+export const rev_id = "main/rev3165"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3164".freeze
+	ID = "main/rev3165".freeze
 end


### PR DESCRIPTION
This commit refines our versioning language such that
backward compatibility guarantees only hold between server packages and
client packages of the previous minor version. In particular, this
is intended to eliminate any interpretation that holds that new SDKs
should be backward-compatible with application code written for a
previous SDK version.

The goal of this change is to allow us to pursue a more aggressive
release roadmap, and to eliminate versioning kludges in the SDK. It
allows us to introduce new usage patterns (potentially breaking changes)
in consecutive minor versions of the SDK without eliminating a smooth
upgrade path for application code.