### PR TITLE
net/raft: format and parse errors using httperror

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -21,6 +21,7 @@ import (
 	"chain/net/http/authz"
 	"chain/net/http/httperror"
 	"chain/net/http/httpjson"
+	"chain/net/raft"
 	"chain/protocol"
 )
 
@@ -89,6 +90,8 @@ var errorFormatter = httperror.Formatter{
 		blocksigner.ErrConsensusChange: {400, "CH150", "Refuse to sign block with consensus change"},
 		errMissingAddr:                 {400, "CH160", "Address is missing"},
 		errInvalidAddr:                 {400, "CH161", "Address is invalid"},
+		raft.ErrAddressNotAllowed:      {400, "CH162", "Address is not allowed"},
+		raft.ErrUninitialized:          {400, "CH163", "No cluster configured"},
 
 		// Signers error namespace (2xx)
 		signers.ErrBadQuorum: {400, "CH200", "Quorum must be greater than 1 and less than or equal to the length of xpubs"},

--- a/core/rpc/rpc.go
+++ b/core/rpc/rpc.go
@@ -148,10 +148,8 @@ func (c *Client) CallRaw(ctx context.Context, path string, request interface{}) 
 		}
 
 		// Attach formatted error message, if available
-		var errData httperror.Response
-		err := json.NewDecoder(resp.Body).Decode(&errData)
-		if err == nil && errData.ChainCode != "" {
-			resErr.ErrorData = &errData
+		if errData, ok := httperror.Parse(resp.Body); ok {
+			resErr.ErrorData = errData
 		}
 
 		return nil, resErr

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3165";
+	public final String Id = "main/rev3166";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3165"
+const ID string = "main/rev3166"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3165"
+export const rev_id = "main/rev3166"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3165".freeze
+	ID = "main/rev3166".freeze
 end

--- a/net/http/httperror/httperror.go
+++ b/net/http/httperror/httperror.go
@@ -4,6 +4,8 @@ package httperror
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 
 	"chain/errors"
@@ -30,6 +32,16 @@ type Response struct {
 	Detail    string                 `json:"detail,omitempty"`
 	Data      map[string]interface{} `json:"data,omitempty"`
 	Temporary bool                   `json:"temporary"`
+}
+
+// Parse reads an error Response from the provided reader.
+func Parse(r io.Reader) (*Response, bool) {
+	var resp Response
+	err := json.NewDecoder(r).Decode(&resp)
+	if err != nil || resp.ChainCode == "" {
+		return nil, false
+	}
+	return &resp, true
 }
 
 // Formatter defines rules for mapping errors to the Chain error


### PR DESCRIPTION
Use the httperror package to format and parse raft endpoints' errors. When we add separate join and init endpoints, this change will help propagate meaningful errors.