### PR TITLE
cmd/cored: do not automatically setup raft cluster

### DIFF
--- a/bin/build-cored-release
+++ b/bin/build-cored-release
@@ -51,7 +51,7 @@ DATE=${DATE:-`date +%s`} # date can be set via envvar
 ldflags="-X main.buildTag=$releaseRef -X main.buildCommit=$commit -X main.buildDate=$DATE"
 
 go build\
-  -tags 'http_ok localhost_auth'\
+  -tags 'http_ok localhost_auth init_cluster'\
   -ldflags "$ldflags"\
   -o $outputDir/cored\
   chain/cmd/cored

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -40,7 +40,7 @@ SDKTARGET=chain-test
 	export DATABASE_URL="postgres:///it-core?sslmode=disable"
 	createdb it-core
 	go install -tags "http_ok localhost_auth no_reset" chain/cmd/cored chain/cmd/corectl
-	corectl migrate
+	corectl init
 	corectl config-generator
 	cored | tee $initlog &
 	cd $CHAIN/sdk/java

--- a/cmd/benchcore/main.go
+++ b/cmd/benchcore/main.go
@@ -817,6 +817,7 @@ const corectlsh = `#!/bin/bash
 export COREURL=:1999
 
 ./corectl wait
+./corectl init
 ./corectl config-generator
 ./corectl create-token benchcore client-readwrite > $HOME/token.txt
 ./corectl create-token benchcrosscore crosscore > $HOME/crosscore-token.txt

--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -61,6 +61,8 @@ var commands = map[string]*command{
 	"reset":                {reset},
 	"grant":                {grant},
 	"revoke":               {revoke},
+	"join":                 {joinCluster},
+	"init":                 {initCluster},
 	"allow-address":        {allowRaftMember},
 	"wait":                 {wait},
 }
@@ -379,6 +381,28 @@ func allowRaftMember(client *rpc.Client, args []string) {
 	}
 
 	err := client.Call(context.Background(), "/add-allowed-member", req, nil)
+	dieOnRPCError(err)
+}
+
+// initCluster initializes a new Chain Core cluster.
+func initCluster(client *rpc.Client, args []string) {
+	if len(args) != 0 {
+		fatalln("error: init takes no args")
+	}
+	err := client.Call(context.Background(), "/init-cluster", nil, nil)
+	dieOnRPCError(err)
+}
+
+// joinCluster connects to an existing Chain Core cluster at the
+// provided boot address.
+func joinCluster(client *rpc.Client, args []string) {
+	const usage = "usage: corectl join [boot address]"
+	if len(args) != 1 {
+		fatalln(usage)
+	}
+
+	req := map[string]string{"boot_address": args[0]}
+	err := client.Call(context.Background(), "/join-cluster", req, nil)
 	dieOnRPCError(err)
 }
 

--- a/cmd/cored/init_cluster.go
+++ b/cmd/cored/init_cluster.go
@@ -1,0 +1,18 @@
+//+build init_cluster
+
+package main
+
+import "chain/core/config"
+
+/*
+This file exposes a build tag to automatically initialize a new
+Chain Core cluster on boot. By default a new cored process has no
+Chain Core cluster and must be explicitly initialized. Initializing
+the cluster automatically will be useful for chain core developer
+edition. Users will be able to launch cored and immediately have
+a useable Chain Core cluster.
+*/
+
+func init() {
+	config.BuildConfig.InitCluster = true
+}

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -252,7 +252,7 @@ func main() {
 	resetIfAllowedAndRequested(db, sdb)
 
 	conf, err := config.Load(ctx, db, sdb)
-	if err != nil {
+	if err != nil && errors.Root(err) != raft.ErrUninitialized {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -125,7 +125,7 @@ func main() {
 	fmt.Printf("localhost_auth: %t\n", config.BuildConfig.LocalhostAuth)
 	fmt.Printf("reset: %t\n", config.BuildConfig.Reset)
 	fmt.Printf("http_ok: %t\n", config.BuildConfig.HTTPOk)
-	fmt.Printf("cluster_init: %t\n", config.BuildConfig.ClusterInit)
+	fmt.Printf("init_cluster: %t\n", config.BuildConfig.InitCluster)
 
 	if *v {
 		return
@@ -177,7 +177,7 @@ func main() {
 
 	// In Developer Edition, automatically create a new cluster if
 	// there's no existing raft cluster.
-	if config.BuildConfig.ClusterInit {
+	if config.BuildConfig.InitCluster {
 		err = sdb.RaftService().Init()
 		if err != nil && errors.Root(err) != raft.ErrExistingCluster {
 			chainlog.Fatalkv(ctx, chainlog.KeyError, err)

--- a/core/api.go
+++ b/core/api.go
@@ -180,6 +180,8 @@ func (a *API) buildHandler() {
 	m.Handle("/list-access-tokens", jsonHandler(a.listAccessTokens))
 	m.Handle("/delete-access-token", jsonHandler(a.deleteAccessToken))
 	m.Handle("/add-allowed-member", jsonHandler(a.addAllowedMember))
+	m.Handle("/init-cluster", jsonHandler(a.initCluster))
+	m.Handle("/join-cluster", jsonHandler(a.joinCluster))
 	m.Handle("/configure", jsonHandler(a.configure))
 	m.Handle("/info", jsonHandler(a.info))
 

--- a/core/authz.go
+++ b/core/authz.go
@@ -54,6 +54,8 @@ var policyByRoute = map[string][]string{
 	"/list-access-tokens":         {"client-readwrite", "client-readonly"},
 	"/delete-access-token":        {"client-readwrite"},
 	"/add-allowed-member":         {"internal"},
+	"/init-cluster":               {"internal"},
+	"/join-cluster":               {"internal"},
 	"/configure":                  {"client-readwrite", "internal"},
 	"/info":                       {"client-readwrite", "client-readonly", "crosscore", "crosscore-signblock", "monitoring", "internal"},
 

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -24,7 +24,6 @@ import (
 	"chain/errors"
 	"chain/log"
 	"chain/net/http/authz"
-	"chain/net/raft"
 	"chain/protocol"
 	"chain/protocol/bc"
 	"chain/protocol/state"
@@ -63,9 +62,7 @@ var (
 func Load(ctx context.Context, db pg.DB, sdb *sinkdb.DB) (*Config, error) {
 	c := new(Config)
 	found, err := sdb.Get(ctx, "/core/config", c)
-	if errors.Root(err) == raft.ErrUninitialized {
-		return nil, nil
-	} else if err != nil {
+	if err != nil {
 		return nil, errors.Wrap(err)
 	} else if found {
 		return c, nil

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -52,7 +52,7 @@ var (
 		MockHSM       bool `json:"is_mockhsm"`
 		Reset         bool `json:"is_reset"`
 		HTTPOk        bool `json:"is_http_ok"`
-		ClusterInit   bool `json:"is_cluster_init"`
+		InitCluster   bool `json:"is_init_cluster"`
 	}
 )
 

--- a/core/core.go
+++ b/core/core.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -150,6 +152,37 @@ func (a *API) configure(ctx context.Context, x *config.Config) error {
 	closeConnOK(httpjson.ResponseWriter(ctx), httpjson.Request(ctx))
 	execSelf("")
 	panic("unreached")
+}
+
+func (a *API) initCluster(ctx context.Context) error {
+	err := a.sdb.RaftService().Init()
+	if err != nil {
+		return err
+	}
+
+	// TODO(jackson): make adding this process's address
+	// atomic with initializing the cluster
+
+	// add this process's address as an allowed member
+	err = a.addAllowedMember(ctx, struct{ Addr string }{a.addr})
+	return err
+}
+
+func (a *API) joinCluster(ctx context.Context, x struct {
+	BootAddress string `json:"boot_address"`
+}) error {
+	// validate the format of the boot address
+	_, _, err := net.SplitHostPort(x.BootAddress)
+	if err != nil {
+		newerr := errors.Sub(errInvalidAddr, err)
+		if addrErr, ok := err.(*net.AddrError); ok {
+			newerr = errors.WithDetail(newerr, addrErr.Err)
+		}
+		return newerr
+	}
+
+	bootURL := fmt.Sprintf("https://%s", x.BootAddress)
+	return a.sdb.RaftService().Join(bootURL)
 }
 
 func closeConnOK(w http.ResponseWriter, req *http.Request) {

--- a/core/errors.go
+++ b/core/errors.go
@@ -91,7 +91,7 @@ var errorFormatter = httperror.Formatter{
 		errMissingAddr:                 {400, "CH160", "Address is missing"},
 		errInvalidAddr:                 {400, "CH161", "Address is invalid"},
 		raft.ErrAddressNotAllowed:      {400, "CH162", "Address is not allowed"},
-		raft.ErrUninitialized:          {400, "CH163", "No cluster configured"},
+		raft.ErrUninitialized:          {400, "CH163", "Cluster not initialized"},
 		raft.ErrExistingCluster:        {400, "CH164", "Already connected to a cluster"},
 		raft.ErrPeerUninitialized:      {400, "CH165", "Peer node is uninitialized"},
 

--- a/core/errors.go
+++ b/core/errors.go
@@ -92,6 +92,8 @@ var errorFormatter = httperror.Formatter{
 		errInvalidAddr:                 {400, "CH161", "Address is invalid"},
 		raft.ErrAddressNotAllowed:      {400, "CH162", "Address is not allowed"},
 		raft.ErrUninitialized:          {400, "CH163", "No cluster configured"},
+		raft.ErrExistingCluster:        {400, "CH164", "Already connected to a cluster"},
+		raft.ErrPeerUninitialized:      {400, "CH165", "Peer node is uninitialized"},
 
 		// Signers error namespace (2xx)
 		signers.ErrBadQuorum: {400, "CH200", "Quorum must be greater than 1 and less than or equal to the length of xpubs"},

--- a/core/run.go
+++ b/core/run.go
@@ -129,13 +129,10 @@ func RunUnconfigured(ctx context.Context, db pg.DB, sdb *sinkdb.DB, routableAddr
 		accessTokens: &accesstoken.CredentialStore{DB: db},
 		grants:       authz.NewStore(sdb, GrantPrefix),
 		mux:          http.NewServeMux(),
+		addr:         routableAddress,
 	}
 	for _, opt := range opts {
 		opt(a)
-	}
-	err := a.addAllowedMember(ctx, struct{ Addr string }{routableAddress})
-	if err != nil {
-		panic("failed to add self to member list: " + err.Error())
 	}
 
 	// Construct the complete http.Handler once.
@@ -218,11 +215,6 @@ func Run(
 	// When this cored becomes leader, run a.lead to perform
 	// leader-only Core duties.
 	a.leader = leader.Run(ctx, db, routableAddress, a.lead)
-
-	err = a.addAllowedMember(ctx, struct{ Addr string }{routableAddress})
-	if err != nil {
-		return nil, err
-	}
 
 	// Construct the complete http.Handler once.
 	a.buildHandler()

--- a/docker/ci/bin/setup-core
+++ b/docker/ci/bin/setup-core
@@ -20,11 +20,10 @@ waitForLeader() {(
 )}
 
 PATH=$(go env GOPATH)/bin:$PATH:$CHAIN/bin
-go install -tags 'http_ok localhost_auth' chain/cmd/{cored,corectl}
+go install -tags 'http_ok localhost_auth init_cluster' chain/cmd/{cored,corectl}
 initlog=`mktemp`
 cored 2>&1 | tee $initlog &
 
 corectl wait
-corectl init
 waitForLeader
 corectl config-generator

--- a/docker/ci/bin/setup-core
+++ b/docker/ci/bin/setup-core
@@ -23,5 +23,8 @@ PATH=$(go env GOPATH)/bin:$PATH:$CHAIN/bin
 go install -tags 'http_ok localhost_auth' chain/cmd/{cored,corectl}
 initlog=`mktemp`
 cored 2>&1 | tee $initlog &
+
+corectl wait
+corectl init
 waitForLeader
 corectl config-generator

--- a/docs/core/reference/corectl.md
+++ b/docs/core/reference/corectl.md
@@ -51,6 +51,8 @@ $ go install chain/cmd/corectl
 * [reset](#reset)
 * [grant](#grant)
 * [revoke](#revoke)
+* [init](#init)
+* [join](#join)
 * [allow-address](#allow-address)
 * [wait](#wait)
 
@@ -183,6 +185,31 @@ It must take one of three forms:
    * `OU=[name]` to affect an X.509 Organizational Unit
 
    The type of guard (before the = sign) is case-insensitive.
+
+
+### `init`
+
+Creates a new Chain Core cluster.
+
+```
+corectl init
+```
+
+
+### `join`
+
+Connects the Chain Core process to an existing Chain Core cluster.
+
+`join` should only be used for multiserver Chain Cores.
+
+```
+corectl join [address]
+```
+
+Argument:
+
+* **address**: The boot address, in `host:port` format.
+
 
 ### `allow-address`
 

--- a/docs/core/reference/cored.md
+++ b/docs/core/reference/cored.md
@@ -83,13 +83,6 @@ the limit will receive an HTTP 429 response.
 
     Can be stacked with **RATELIMIT_TOKEN**.
 
-* **BOOTURL**: Setting this value causes the `cored` process to join an
-existing Chain Core cluster if it's not already a member. If it is already
-a member of a cluster, this has no effect.
-
-    This should be the URL of any `cored` process already in the cluster,
-    or a load balancer that forwards requests to any node.
-
 ## Mutual TLS
 
 Chain Core 1.2 introduces support for mutual TLS authentication. This means both Chain Core and the client SDKs can authenticate each other using X.509 certificates and the TLS protocol. Previously, client authentication was facilitated through the use of access tokens and HTTP Basic Auth. While still supported, client access tokens are now deprecated.

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3169";
+	public final String Id = "main/rev3170";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3169"
+const ID string = "main/rev3170"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3169"
+export const rev_id = "main/rev3170"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3169".freeze
+	ID = "main/rev3170".freeze
 end


### PR DESCRIPTION
Remove the BOOTURL environment variable from cored. If there is no
existing raft cluster configuration, start cored but return an error
from all RPCs indicating that the process's cluster needs to be
initialized.

The operator can call the /init-cluster or /join-cluster endpoints to
start a new Chain Core cluster or join an existing cluster.

Introduce a new 'init_cluster' build tag to automatically initialize
a new cluster if one doesn't exist in cmd/cored. Use this new build tag
when building Developer Edition.