### PR TITLE
net: fix Dial for Unix domain sockets

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3167";
+	public final String Id = "main/rev3168";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3167"
+const ID string = "main/rev3168"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3167"
+export const rev_id = "main/rev3168"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3167".freeze
+	ID = "main/rev3168".freeze
 end

--- a/net/lookup_test.go
+++ b/net/lookup_test.go
@@ -1,0 +1,30 @@
+package net
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDialUnix(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "lookup-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tempdir)
+	path := filepath.Join(tempdir, "sock")
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go l.Accept()
+
+	d := &Dialer{}
+	c, err := d.Dial("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Close()
+}

--- a/net/net.go
+++ b/net/net.go
@@ -63,12 +63,12 @@ func (d *Dialer) DialTimeout(network, addr string, timeout time.Duration) (net.C
 // uses package etcdname in addition to the local resolver.
 // See func Dial for a description of the network and addr parameters.
 func (d *Dialer) Dial(network, addr string) (net.Conn, error) {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, err
-	}
-
 	if knownNetworks[network] {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+
 		addrs, source, err := lookupHost(host)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Be sure to call SplitHostPort only on address types
where it is known to be meaningful. A Unix domain socket
uses a filepath as the address and SplitHostPort will
return an error.