### PR TITLE
net/raft: only use HTTPS

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -170,7 +170,7 @@ func main() {
 	}
 
 	raftDir := filepath.Join(home, "raft") // TODO(kr): better name for this
-	sdb, err := sinkdb.Open(*listenAddr, raftDir, httpClient, tlsConfig != nil)
+	sdb, err := sinkdb.Open(*listenAddr, raftDir, httpClient)
 	if err != nil {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}

--- a/database/sinkdb/sinkdb.go
+++ b/database/sinkdb/sinkdb.go
@@ -17,9 +17,9 @@ import (
 var ErrConflict = errors.New("transaction conflict")
 
 // Open initializes the key-value store and returns a database handle.
-func Open(laddr, dir string, httpClient *http.Client, useTLS bool) (*DB, error) {
+func Open(laddr, dir string, httpClient *http.Client) (*DB, error) {
 	state := newState()
-	sv, err := raft.Start(laddr, dir, httpClient, useTLS, state)
+	sv, err := raft.Start(laddr, dir, httpClient, state)
 	if err != nil {
 		return nil, err
 	}

--- a/database/sinkdb/sinkdbtest/sinkdbtest.go
+++ b/database/sinkdb/sinkdbtest/sinkdbtest.go
@@ -23,7 +23,7 @@ func NewDB(t testing.TB) *sinkdb.DB {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sdb, err := sinkdb.Open("", tempDir, new(http.Client), false)
+	sdb, err := sinkdb.Open("", tempDir, new(http.Client))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/sinkdb/state_test.go
+++ b/database/sinkdb/state_test.go
@@ -47,7 +47,7 @@ func TestAllowedMember(t *testing.T) {
 	}
 	defer os.RemoveAll(raftDir)
 
-	sdb, err := Open("", raftDir, new(http.Client), false)
+	sdb, err := Open("", raftDir, new(http.Client))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3168";
+	public final String Id = "main/rev3169";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3168"
+const ID string = "main/rev3169"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3168"
+export const rev_id = "main/rev3169"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3168".freeze
+	ID = "main/rev3169".freeze
 end

--- a/net/raft/raft_test.go
+++ b/net/raft/raft_test.go
@@ -100,7 +100,7 @@ func TestStartUninitialized(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	sv, err := Start("", dir, http.DefaultClient, false, nil)
+	sv, err := Start("", dir, http.DefaultClient, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Developer Edition does not support multi-process Chain Cores. In EE,
processes are required to use TLS for authentication internally, so we
can remove the useTLS parameter to raft.Start.

Related to #1220.