### PR TITLE
core: propagate raft errors

### DIFF
--- a/core/health.go
+++ b/core/health.go
@@ -24,6 +24,11 @@ func (a *API) health() (x struct {
 	Errors map[string]string `json:"errors"`
 }) {
 	x.Errors = make(map[string]string)
+
+	if err := a.sdb.RaftService().Err(); err != nil {
+		x.Errors["raft"] = err.Error()
+	}
+
 	a.healthMu.Lock()
 	defer a.healthMu.Unlock()
 	for name, s := range a.healthErrors {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3171";
+	public final String Id = "main/rev3172";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3171"
+const ID string = "main/rev3172"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3171"
+export const rev_id = "main/rev3172"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3171".freeze
+	ID = "main/rev3172".freeze
 end


### PR DESCRIPTION
Propagate raft errors into the /info health object.

Fix #1219.