### PR TITLE
core: remove useTLS flag on API struct

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -79,7 +79,6 @@ type API struct {
 	generator       *generator.Generator
 	remoteGenerator *rpc.Client
 	indexTxs        bool
-	useTLS          bool
 	internalSubj    pkix.Name
 	httpClient      *http.Client
 

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -54,7 +54,6 @@ func TestForwardToLeader(t *testing.T) {
 	api := &API{
 		config: &config.Config{},
 		leader: alwaysFollower{leaderAddress: u.Host},
-		useTLS: true,
 		httpClient: &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{

--- a/core/membership.go
+++ b/core/membership.go
@@ -35,11 +35,6 @@ func (a *API) addAllowedMember(ctx context.Context, x struct{ Addr string }) err
 		return errors.Wrap(err)
 	}
 
-	// only create a grant if we're using TLS
-	if !a.useTLS {
-		return nil
-	}
-
 	data := map[string]interface{}{
 		"subject": map[string]string{
 			"CN": hostname,

--- a/core/run.go
+++ b/core/run.go
@@ -43,7 +43,6 @@ type RunOption func(*API)
 // If c is nil, TLS is disabled.
 func UseTLS(c *tls.Config) RunOption {
 	return func(a *API) {
-		a.useTLS = c != nil
 		a.httpClient = new(http.Client)
 		a.httpClient.Transport = &http.Transport{
 			DialContext: (&net.Dialer{

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3170";
+	public final String Id = "main/rev3171";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3170"
+const ID string = "main/rev3171"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3170"
+export const rev_id = "main/rev3171"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3170".freeze
+	ID = "main/rev3171".freeze
 end


### PR DESCRIPTION
The useTLS flag is unnecessary now that Chain Core always uses TLS for
internal RPCs.