### PR TITLE
cmd/integtest: check out repos into working dir

### DIFF
--- a/cmd/integtest/doc.go
+++ b/cmd/integtest/doc.go
@@ -25,13 +25,15 @@ to assist in debugging a failed test.
 (Note, however, that the test process itself
 can write files anywhere.)
 
+It reads GitHub credentials from .netrc.
+
 It requires Postgres and Go installed.
 
 Test Environment
 
 This tool always sets some values for the test process:
 
-  CHAIN          from environment, or $HOME/go/src/chain
+  CHAIN          a clean checkout of the chain repo (and ${CHAIN}prv)
   DB_URL_TEST    the URL of a new, empty postgres cluster
   (working dir)  an empty scratch directory
 

--- a/cmd/integtest/doc.go
+++ b/cmd/integtest/doc.go
@@ -35,6 +35,7 @@ This tool always sets some values for the test process:
 
   CHAIN          a clean checkout of the chain repo (and ${CHAIN}prv)
   DB_URL_TEST    the URL of a new, empty postgres cluster
+  GOPATH         the Go workspace containing $CHAIN
   (working dir)  an empty scratch directory
 
 */

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3174";
+	public final String Id = "main/rev3175";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3174"
+const ID string = "main/rev3175"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3174"
+export const rev_id = "main/rev3175"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3174".freeze
+	ID = "main/rev3175".freeze
 end


### PR DESCRIPTION
Don't inherit the Unix user's GOPATH and CHAIN
variables. Instead, maintain a dedicated Go workspace
with a checkout of the repos in $HOME/integration.