### PR TITLE
net/http/authz: remove unnecessary return param

### DIFF
--- a/core/access_tokens.go
+++ b/core/access_tokens.go
@@ -52,7 +52,7 @@ func (a *API) createAccessToken(ctx context.Context, x struct{ ID, Type string }
 		// We've already returned if x.Type wasn't specified, so this must be a bad type.
 		return nil, accesstoken.ErrBadType
 	}
-	_, err = a.grants.Save(ctx, grant)
+	err = a.grants.Save(ctx, grant)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -327,7 +327,7 @@ func migrateAccessTokens(ctx context.Context, db pg.DB, sdb *sinkdb.DB) error {
 		case "network":
 			grant.Policy = "crosscore"
 		}
-		_, err = store.Save(ctx, &grant)
+		err = store.Save(ctx, &grant)
 		if err != nil {
 			return errors.Wrap(err)
 		}

--- a/core/grants.go
+++ b/core/grants.go
@@ -129,12 +129,13 @@ func (a *API) createGrant(ctx context.Context, x apiGrant) (*apiGrant, error) {
 		return nil, errors.Wrap(err)
 	}
 
-	g, err := a.grants.Save(ctx, &authz.Grant{
+	g := &authz.Grant{
 		GuardType: x.GuardType,
 		GuardData: guardData,
 		Policy:    x.Policy,
 		Protected: false, // grants created through the createGrant RPC cannot be protected
-	})
+	}
+	err = a.grants.Save(ctx, g)
 	if err != nil {
 		return nil, err
 	}

--- a/core/membership.go
+++ b/core/membership.go
@@ -46,7 +46,7 @@ func (a *API) addAllowedMember(ctx context.Context, x struct{ Addr string }) err
 		return errors.Wrap(err)
 	}
 
-	_, err = a.grants.Save(ctx, &authz.Grant{
+	err = a.grants.Save(ctx, &authz.Grant{
 		Policy:    "internal",
 		GuardType: "x509",
 		GuardData: guardData,

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3173";
+	public final String Id = "main/rev3174";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3173"
+const ID string = "main/rev3174"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3173"
+export const rev_id = "main/rev3174"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3173".freeze
+	ID = "main/rev3174".freeze
 end

--- a/net/http/authz/store.go
+++ b/net/http/authz/store.go
@@ -44,7 +44,7 @@ func (s *Store) Load(ctx context.Context, policy []string) ([]*Grant, error) {
 // If a grant equivalent to g is already stored,
 // Save has no effect and returns a copy of the existing grant.
 // Otherwise, if successful, it returns g.
-func (s *Store) Save(ctx context.Context, g *Grant) (*Grant, error) {
+func (s *Store) Save(ctx context.Context, g *Grant) error {
 	key := s.keyPrefix + g.Policy
 	if g.CreatedAt == "" {
 		g.CreatedAt = time.Now().UTC().Format(time.RFC3339)
@@ -53,14 +53,14 @@ func (s *Store) Save(ctx context.Context, g *Grant) (*Grant, error) {
 	var grantList GrantList
 	_, err := s.sdb.Get(ctx, key, &grantList)
 	if err != nil {
-		return nil, errors.Wrap(err)
+		return errors.Wrap(err)
 	}
 
 	grants := grantList.Grants
 	for _, existing := range grants {
 		if EqualGrants(*existing, *g) {
-			// this grant already exists, return for idempotency
-			return existing, nil
+			// this grant already exists, do nothing
+			return nil
 		}
 	}
 
@@ -70,10 +70,7 @@ func (s *Store) Save(ctx context.Context, g *Grant) (*Grant, error) {
 	// TODO(tessr): Make this safe for concurrent updates. Will likely require a
 	// conditional write operation for raftDB
 	err = s.sdb.Exec(ctx, sinkdb.Set(s.keyPrefix+g.Policy, &GrantList{Grants: grants}))
-	if err != nil {
-		return nil, errors.Wrap(err)
-	}
-	return g, nil
+	return errors.Wrap(err)
 }
 
 // Delete deletes from policy all stored grants for which delete returns true.

--- a/net/http/authz/store.go
+++ b/net/http/authz/store.go
@@ -42,8 +42,7 @@ func (s *Store) Load(ctx context.Context, policy []string) ([]*Grant, error) {
 
 // Save stores g.
 // If a grant equivalent to g is already stored,
-// Save has no effect and returns a copy of the existing grant.
-// Otherwise, if successful, it returns g.
+// Save has no effect.
 func (s *Store) Save(ctx context.Context, g *Grant) error {
 	key := s.keyPrefix + g.Policy
 	if g.CreatedAt == "" {

--- a/net/http/authz/store.go
+++ b/net/http/authz/store.go
@@ -43,6 +43,8 @@ func (s *Store) Load(ctx context.Context, policy []string) ([]*Grant, error) {
 // Save stores g.
 // If a grant equivalent to g is already stored,
 // Save has no effect.
+// It also sets field CreatedAt to the time g is stored (the current time),
+// or to the time the original grant was stored, if there is one.
 func (s *Store) Save(ctx context.Context, g *Grant) error {
 	key := s.keyPrefix + g.Policy
 	if g.CreatedAt == "" {
@@ -59,6 +61,7 @@ func (s *Store) Save(ctx context.Context, g *Grant) error {
 	for _, existing := range grants {
 		if EqualGrants(*existing, *g) {
 			// this grant already exists, do nothing
+			g.CreatedAt = existing.CreatedAt
 			return nil
 		}
 	}


### PR DESCRIPTION
The caller doesn't need a copy of the existing grant;
it already has all that data at hand.