### PR TITLE
core/query: validate reference data

### DIFF
--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -31,7 +31,10 @@ type Saver interface {
 func Annotated(a *Asset) (*query.AnnotatedAsset, error) {
 	jsonTags := json.RawMessage(`{}`)
 	jsonDefinition := json.RawMessage(`{}`)
-	if len(a.RawDefinition()) > 0 {
+
+	// a.RawDefinition is the asset definition as it appears on the
+	// blockchain, so it's untrusted and may not be valid json.
+	if pg.IsValidJSONB(a.RawDefinition()) {
 		jsonDefinition = json.RawMessage(a.RawDefinition())
 	}
 	if a.Tags != nil {

--- a/core/query/annotated.go
+++ b/core/query/annotated.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"chain/crypto/ed25519/chainkd"
+	"chain/database/pg"
 	chainjson "chain/encoding/json"
 	"chain/protocol/bc"
 	"chain/protocol/bc/legacy"
@@ -126,11 +127,10 @@ func buildAnnotatedTransaction(orig *legacy.Tx, b *legacy.Block, indexInBlock ui
 		Inputs:                 make([]*AnnotatedInput, 0, len(orig.Inputs)),
 		Outputs:                make([]*AnnotatedOutput, 0, len(orig.Outputs)),
 	}
-	if len(orig.ReferenceData) > 0 {
+	if pg.IsValidJSONB(orig.ReferenceData) {
 		referenceData := json.RawMessage(orig.ReferenceData)
 		tx.ReferenceData = &referenceData
 	}
-
 	for i := range orig.Inputs {
 		tx.Inputs = append(tx.Inputs, buildAnnotatedInput(orig, uint32(i)))
 	}
@@ -149,8 +149,7 @@ func buildAnnotatedInput(tx *legacy.Tx, i uint32) *AnnotatedInput {
 		AssetTags:       &emptyJSONObject,
 		ReferenceData:   &emptyJSONObject,
 	}
-
-	if len(orig.ReferenceData) > 0 {
+	if pg.IsValidJSONB(orig.ReferenceData) {
 		referenceData := json.RawMessage(orig.ReferenceData)
 		in.ReferenceData = &referenceData
 	}
@@ -183,7 +182,7 @@ func buildAnnotatedOutput(tx *legacy.Tx, idx int) *AnnotatedOutput {
 		ControlProgram:  orig.ControlProgram,
 		ReferenceData:   &emptyJSONObject,
 	}
-	if len(orig.ReferenceData) > 0 {
+	if pg.IsValidJSONB(orig.ReferenceData) {
 		referenceData := json.RawMessage(orig.ReferenceData)
 		out.ReferenceData = &referenceData
 	}

--- a/core/query/index_test.go
+++ b/core/query/index_test.go
@@ -51,8 +51,11 @@ func TestAnnotatedTxsReferenceData(t *testing.T) {
 		"{\"client_id\": 1, \"device_name\": \"FooBar\ufffd\u0000\ufffd\u000f\ufffd\"}",
 		`{"client_id": 1, "device_name": "FooBar\ufffd\u0000\ufffd\u000f\ufffd"}`,
 		string(unicode.MaxRune + 1),
+		`"` + string(unicode.MaxRune+1) + `"`,
 		string(unicode.ReplacementChar),
-		string([]byte{0xff, 0xfe, 0xfd}), // from https://golang.org/pkg/unicode/utf8/#example_Valid
+		`"` + string(unicode.ReplacementChar) + `"`,
+		string([]byte{0xff, 0xfe, 0xfd}),
+		`"` + string([]byte{0xff, 0xfe, 0xfd}) + `"`,
 	}
 	for _, refData := range referenceData {
 		t.Run(refData, func(t *testing.T) {

--- a/core/query/index_test.go
+++ b/core/query/index_test.go
@@ -36,6 +36,7 @@ func TestAnnotatedTxsReferenceData(t *testing.T) {
 	ctx := context.Background()
 
 	referenceData := []string{
+		"",
 		"{}",
 		`{"hello": "world"}`,
 		"{\"\u0000\": \"world\"}",

--- a/core/query/index_test.go
+++ b/core/query/index_test.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"testing"
+	"unicode"
 
 	"chain/database/pg/pgtest"
 	"chain/protocol/bc/bctest"
@@ -28,5 +29,49 @@ func TestAnnotatedTxs(t *testing.T) {
 	}
 	if len(txs) != len(b.Transactions) {
 		t.Errorf("Got %d transactions, expected %d", len(txs), len(b.Transactions))
+	}
+}
+
+func TestAnnotatedTxsReferenceData(t *testing.T) {
+	ctx := context.Background()
+
+	referenceData := []string{
+		"{}",
+		`{"hello": "world"}`,
+		"{\"\u0000\": \"world\"}",
+		"{\"badString\":\"\u0000\"}",
+		`{"badString": "\u0000"}`,
+		`{"badString": "\u0001"}`,
+		`{"🤦‍♀️": "🤦‍♀️"}`,
+		`🤦‍♀️`,
+		"{",
+		"\u0000",
+		"\u0001",
+		"{\"client_id\": 1, \"device_name\": \"FooBar\ufffd\u0000\ufffd\u000f\ufffd\"}",
+		`{"client_id": 1, "device_name": "FooBar\ufffd\u0000\ufffd\u000f\ufffd"}`,
+		string(unicode.MaxRune + 1),
+		string(unicode.ReplacementChar),
+		string([]byte{0xff, 0xfe, 0xfd}), // from https://golang.org/pkg/unicode/utf8/#example_Valid
+	}
+	for _, refData := range referenceData {
+		t.Run(refData, func(t *testing.T) {
+			db := pgtest.NewTx(t)
+			c := prottest.NewChain(t)
+			indexer := NewIndexer(db, c, nil)
+
+			setRefData := func(tx *legacy.Tx) { tx.ReferenceData = []byte(refData) }
+			b := &legacy.Block{
+				Transactions: []*legacy.Tx{
+					bctest.NewIssuanceTx(t, prottest.Initial(t, c).Hash(), setRefData),
+				},
+			}
+			txs, err := indexer.insertAnnotatedTxs(ctx, b)
+			if err != nil {
+				t.Error(err)
+			}
+			if len(txs) != len(b.Transactions) {
+				t.Errorf("Got %d transactions, expected %d", len(txs), len(b.Transactions))
+			}
+		})
 	}
 }

--- a/core/query/index_test.go
+++ b/core/query/index_test.go
@@ -37,12 +37,9 @@ func TestAnnotatedTxsReferenceData(t *testing.T) {
 
 	referenceData := []string{
 		"",
-		"{}",
-		`{"hello": "world"}`,
 		"{\"\u0000\": \"world\"}",
 		"{\"badString\":\"\u0000\"}",
 		`{"badString": "\u0000"}`,
-		`{"badString": "\u0001"}`,
 		`{"🤦‍♀️": "🤦‍♀️"}`,
 		`🤦‍♀️`,
 		"{",
@@ -52,8 +49,6 @@ func TestAnnotatedTxsReferenceData(t *testing.T) {
 		`{"client_id": 1, "device_name": "FooBar\ufffd\u0000\ufffd\u000f\ufffd"}`,
 		string(unicode.MaxRune + 1),
 		`"` + string(unicode.MaxRune+1) + `"`,
-		string(unicode.ReplacementChar),
-		`"` + string(unicode.ReplacementChar) + `"`,
 		string([]byte{0xff, 0xfe, 0xfd}),
 		`"` + string([]byte{0xff, 0xfe, 0xfd}) + `"`,
 	}

--- a/database/pg/pg.go
+++ b/database/pg/pg.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/lib/pq"
 
@@ -66,7 +67,7 @@ func IsValidJSONB(b []byte) bool {
 	if err != nil {
 		return false
 	}
-	return !containsNullByte(v)
+	return utf8.Valid(b) && !containsNullByte(v)
 }
 
 func containsNullByte(v interface{}) (found bool) {

--- a/database/pg/pg.go
+++ b/database/pg/pg.go
@@ -9,8 +9,11 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
+	"fmt"
 	"net"
 	"net/url"
+	"strings"
 
 	"github.com/lib/pq"
 
@@ -50,6 +53,46 @@ func init() {
 func IsUniqueViolation(err error) bool {
 	pqErr, ok := err.(*pq.Error)
 	return ok && pqErr.Code.Name() == "unique_violation"
+}
+
+// IsValidJSONB returns true if the provided bytes may be stored
+// in a Postgres JSONB data type. It validates that b is a valid
+// json document and that it does not include the \u0000 escape
+// sequence:
+// https://www.postgresql.org/message-id/E1YHHV8-00032A-Em@gemulon.postgresql.org
+func IsValidJSONB(b []byte) bool {
+	var v interface{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return false
+	}
+	return !containsNullByte(v)
+}
+
+func containsNullByte(v interface{}) (found bool) {
+	const nullByte = '\u0000'
+	switch t := v.(type) {
+	case bool:
+		return false
+	case float64:
+		return false
+	case string:
+		return strings.ContainsRune(t, nullByte)
+	case []interface{}:
+		for _, v := range t {
+			found = found || containsNullByte(v)
+		}
+		return found
+	case map[string]interface{}:
+		for k, v := range t {
+			found = found || containsNullByte(k) || containsNullByte(v)
+		}
+		return found
+	case nil:
+		return false
+	default:
+		panic(fmt.Errorf("unknown json type %T", v))
+	}
 }
 
 func resolveURI(rawURI string) (string, error) {

--- a/database/pg/pg.go
+++ b/database/pg/pg.go
@@ -57,17 +57,14 @@ func IsUniqueViolation(err error) bool {
 }
 
 // IsValidJSONB returns true if the provided bytes may be stored
-// in a Postgres JSONB data type. It validates that b is a valid
-// json document and that it does not include the \u0000 escape
-// sequence:
+// in a Postgres JSONB data type. It validates that b is valid
+// utf-8 and valid json. It also verifies that it does not include
+// the \u0000 escape sequence, unsupported by the jsonb data type:
 // https://www.postgresql.org/message-id/E1YHHV8-00032A-Em@gemulon.postgresql.org
 func IsValidJSONB(b []byte) bool {
 	var v interface{}
 	err := json.Unmarshal(b, &v)
-	if err != nil {
-		return false
-	}
-	return utf8.Valid(b) && !containsNullByte(v)
+	return err == nil && utf8.Valid(b) && !containsNullByte(v)
 }
 
 func containsNullByte(v interface{}) (found bool) {

--- a/database/pg/pg_test.go
+++ b/database/pg/pg_test.go
@@ -32,3 +32,23 @@ func TestResolveURI(t *testing.T) {
 	}
 
 }
+
+func TestIsValidJSONB(t *testing.T) {
+	cases := map[string]bool{
+		`"hello"`: true,
+		`{`:       false,
+		`{"foo": ["bar", "baz"]}`:                true,
+		`{"bad": {"foo": "bar\u0000"}}`:          false,
+		`{"bad": {"foo\u0000": "bar"}}`:          false,
+		`{"bad": "\u0000"}`:                      false,
+		`["hello", "world", "what is \u0000p?"]`: false,
+	}
+
+	for b, want := range cases {
+		t.Run(b, func(t *testing.T) {
+			if got := IsValidJSONB([]byte(b)); got != want {
+				t.Errorf("got %t want %t", got, want)
+			}
+		})
+	}
+}

--- a/database/pg/pg_test.go
+++ b/database/pg/pg_test.go
@@ -37,11 +37,12 @@ func TestIsValidJSONB(t *testing.T) {
 	cases := map[string]bool{
 		`"hello"`: true,
 		`{`:       false,
-		`{"foo": ["bar", "baz"]}`:                true,
-		`{"bad": {"foo": "bar\u0000"}}`:          false,
-		`{"bad": {"foo\u0000": "bar"}}`:          false,
-		`{"bad": "\u0000"}`:                      false,
-		`["hello", "world", "what is \u0000p?"]`: false,
+		`{"foo": ["bar", "baz"]}`:                    true,
+		`{"bad": {"foo": "bar\u0000"}}`:              false,
+		`{"bad": {"foo\u0000": "bar"}}`:              false,
+		`{"bad": "\u0000"}`:                          false,
+		`["hello", "world", "what is \u0000p?"]`:     false,
+		`"` + string([]byte{0xff, 0xfe, 0xfd}) + `"`: false,
 	}
 
 	for b, want := range cases {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3176";
+	public final String Id = "main/rev3177";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3176"
+const ID string = "main/rev3177"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3176"
+export const rev_id = "main/rev3177"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3176".freeze
+	ID = "main/rev3177".freeze
 end


### PR DESCRIPTION
Ignore invalid json in reference data when indexing transactions, and skip
reference data that contains the null byte escape sequence. This
fixes two separate but related issues:

  1. A user could use Chain Core to create a transaction with the
  `\u0000` escape sequence inside a string within the reference data.
  Chain Core would allow the transaction, because `\u0000` is a valid
  escape sequence in a JSON string, but indexing the transaction
  would fail (#1239) due to Postgres jsonb limitations:
  https://www.postgresql.org/message-id/E1YHHV8-00032A-Em@gemulon.postgresql.org

  2. A non-Chain Core client could create transactions with any sort of
  invalid json, and Chain Core would fail to index them. These
  transactions would be impossible to create with Chain Core, but
  another but other Chain Protocol clients or a malicious user could
  create them.
