### PR TITLE
net/http/authz: return sinkdb Op instead of executing

### DIFF
--- a/core/access_tokens.go
+++ b/core/access_tokens.go
@@ -52,7 +52,7 @@ func (a *API) createAccessToken(ctx context.Context, x struct{ ID, Type string }
 		// We've already returned if x.Type wasn't specified, so this must be a bad type.
 		return nil, accesstoken.ErrBadType
 	}
-	err = a.grants.Save(ctx, grant)
+	err = a.sdb.Exec(ctx, a.grants.Save(ctx, grant))
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -327,7 +327,7 @@ func migrateAccessTokens(ctx context.Context, db pg.DB, sdb *sinkdb.DB) error {
 		case "network":
 			grant.Policy = "crosscore"
 		}
-		err = store.Save(ctx, &grant)
+		err = sdb.Exec(ctx, store.Save(ctx, &grant))
 		if err != nil {
 			return errors.Wrap(err)
 		}

--- a/core/membership.go
+++ b/core/membership.go
@@ -46,12 +46,12 @@ func (a *API) addAllowedMember(ctx context.Context, x struct{ Addr string }) err
 		return errors.Wrap(err)
 	}
 
-	err = a.grants.Save(ctx, &authz.Grant{
+	err = a.sdb.Exec(ctx, a.grants.Save(ctx, &authz.Grant{
 		Policy:    "internal",
 		GuardType: "x509",
 		GuardData: guardData,
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
 		Protected: true,
-	})
+	}))
 	return errors.Wrap(err)
 }

--- a/database/sinkdb/op.go
+++ b/database/sinkdb/op.go
@@ -69,3 +69,11 @@ func AddAllowedMember(addr string) Op {
 		}},
 	}
 }
+
+// Error returns an Op representing an error condition.
+// Exec will return err, and have no effect,
+// when the returned Op is executed.
+// If err is nil, Error returns the zero Op.
+func Error(err error) Op {
+	return Op{err: err}
+}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3179";
+	public final String Id = "main/rev3180";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3179"
+const ID string = "main/rev3180"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3179"
+export const rev_id = "main/rev3180"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3179".freeze
+	ID = "main/rev3180".freeze
 end

--- a/net/http/authz/store.go
+++ b/net/http/authz/store.go
@@ -91,7 +91,7 @@ func (s *Store) Delete(ctx context.Context, policy string, delete func(*Grant) b
 		}
 	}
 
-	// We didn't match any grants, don't need to do an update. Return success
+	// We didn't match any grants, don't need to do an update. Return no-op.
 	if len(keep) == len(grantList.Grants) {
 		return sinkdb.Op{}
 	}


### PR DESCRIPTION
This will allow the caller to combine the returned Op
with other Ops into an atomic batch.