### PR TITLE
database/sinkdb: introduce All combinator

### DIFF
--- a/database/sinkdb/op.go
+++ b/database/sinkdb/op.go
@@ -22,6 +22,22 @@ type Op struct {
 	effects []*sinkpb.Op
 }
 
+// All encodes the atomic application of all its arguments.
+//
+// The returned Op is satisfied if all arguments would be satisfied.
+// Its effects (if satisfied) are the effects of the arguments, in order.
+func All(op ...Op) Op {
+	var outer Op
+	for _, inner := range op {
+		if inner.err != nil {
+			return inner
+		}
+		outer.conds = append(outer.conds, inner.conds...)
+		outer.effects = append(outer.effects, inner.effects...)
+	}
+	return outer
+}
+
 // IfNotExists encodes a conditional to make an instruction
 // successful only if the provided key does not exist.
 func IfNotExists(key string) Op {

--- a/database/sinkdb/op.go
+++ b/database/sinkdb/op.go
@@ -25,7 +25,7 @@ type Op struct {
 // All encodes the atomic application of all its arguments.
 //
 // The returned Op is satisfied if all arguments would be satisfied.
-// Its effects (if satisfied) are the effects of the arguments, in order.
+// Its effects (if satisfied) are the effects of the arguments.
 func All(op ...Op) Op {
 	var outer Op
 	for _, inner := range op {

--- a/database/sinkdb/sinkdb.go
+++ b/database/sinkdb/sinkdb.go
@@ -34,24 +34,20 @@ type DB struct {
 	raft  *raft.Service
 }
 
-// Exec executes the provided operations. If all of the provided conditionals
-// are met, all of the provided effects are applied atomically.
+// Exec executes the provided operations
+// after combining them with All.
 func (db *DB) Exec(ctx context.Context, ops ...Op) error {
-	instr := new(sinkpb.Instruction)
-	for _, op := range ops {
-		if op.err != nil {
-			return op.err
-		}
-		instr.Conditions = append(instr.Conditions, op.conds...)
-		instr.Operations = append(instr.Operations, op.effects...)
+	all := All(ops...)
+	if all.err != nil {
+		return all.err
 	}
 
 	// Disallow multiple writes to the same key.
-	sort.Slice(instr.Operations, func(i, j int) bool {
-		return instr.Operations[i].Key < instr.Operations[j].Key
+	sort.Slice(all.effects, func(i, j int) bool {
+		return all.effects[i].Key < all.effects[j].Key
 	})
 	var lastKey string
-	for _, e := range instr.Operations {
+	for _, e := range all.effects {
 		if e.Key == lastKey {
 			err := errors.New("duplicate write")
 			return errors.Wrap(err, e.Key)
@@ -59,7 +55,10 @@ func (db *DB) Exec(ctx context.Context, ops ...Op) error {
 		lastKey = e.Key
 	}
 
-	encoded, err := proto.Marshal(instr)
+	encoded, err := proto.Marshal(&sinkpb.Instruction{
+		Conditions: all.conds,
+		Operations: all.effects,
+	})
 	if err != nil {
 		return err
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3184";
+	public final String Id = "main/rev3185";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3184"
+const ID string = "main/rev3185"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3184"
+export const rev_id = "main/rev3185"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3184".freeze
+	ID = "main/rev3185".freeze
 end


### PR DESCRIPTION
This will allow clients to combine conditions and
effects in constructors for composite operations, with
an interface convenient for other packages to use in a
call to Exec.

Consider a hypothetical create function:

    func create(key, value) sinkdb.Op {
        return sinkdb.All(
            sinkdb.IfNotExists(key),
            sinkdb.Set(key, value),
        )
    }

Create could return []Op, but Op is easier to
combine with further operations:

    db.Exec(ctx,
        create(key, value),
        sinkdb.Delete(key2),
    )