### PR TITLE
core/asset: fix inserts for escaped strings

### DIFF
--- a/core/asset/block.go
+++ b/core/asset/block.go
@@ -107,7 +107,7 @@ func (reg *Registry) ProcessBlocks(ctx context.Context) {
 func (reg *Registry) indexAssets(ctx context.Context, b *legacy.Block) error {
 	var (
 		assetIDs         pq.ByteaArray
-		definitions      pq.StringArray
+		definitions      pq.ByteaArray
 		vmVersions       pq.Int64Array
 		issuancePrograms pq.ByteaArray
 		seen             = make(map[bc.AssetID]bool)
@@ -125,7 +125,7 @@ func (reg *Registry) indexAssets(ctx context.Context, b *legacy.Block) error {
 				definition := ii.AssetDefinition
 				seen[assetID] = true
 				assetIDs = append(assetIDs, assetID.Bytes())
-				definitions = append(definitions, string(definition))
+				definitions = append(definitions, definition)
 				vmVersions = append(vmVersions, int64(ii.VMVersion))
 				issuancePrograms = append(issuancePrograms, in.IssuanceProgram())
 			}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3186";
+	public final String Id = "main/rev3187";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3186"
+const ID string = "main/rev3187"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3186"
+export const rev_id = "main/rev3187"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3186".freeze
+	ID = "main/rev3187".freeze
 end


### PR DESCRIPTION
Passing the definition as a string can cause unexpected problems with
escaped strings, so we pass it as a byte array instead.