### PR TITLE
docker/ci: fix java installation

### DIFF
--- a/docker/ci/install/install-java
+++ b/docker/ci/install/install-java
@@ -2,16 +2,14 @@
 
 set -e
 
-curl -L0 -o jdk-7u79-linux-x64.tar.gz -H \
-  "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" \
-  http://download.oracle.com/otn-pub/java/jdk/7u79-b15/jdk-7u79-linux-x64.tar.gz
-tar -C /opt -xzf jdk-7u79-linux-x64.tar.gz
-rm jdk-7u79-linux-x64.tar.gz
-cd /opt/jdk1.7.0_79/
-alternatives --install /usr/bin/java java /opt/jdk1.7.0_79/bin/java 2
+curl -L0 -o jdk-7u80-linux-x64.tar.gz https://s3.amazonaws.com/chain-qa/jdk-7u80-linux-x64.tar.gz
+tar -C /opt -xzf jdk-7u80-linux-x64.tar.gz
+rm jdk-7u80-linux-x64.tar.gz
+cd /opt/jdk1.7.0_80/
+alternatives --install /usr/bin/java java /opt/jdk1.7.0_80/bin/java 2
 alternatives --auto java
-alternatives --install /usr/bin/jar jar /opt/jdk1.7.0_79/bin/jar 2
-alternatives --install /usr/bin/javac javac /opt/jdk1.7.0_79/bin/javac 2
-alternatives --install /usr/bin/javaws javaws /opt/jdk1.7.0_79/bin/javaws 2
-alternatives --set jar /opt/jdk1.7.0_79/bin/jar
-alternatives --set javac /opt/jdk1.7.0_79/bin/javac
+alternatives --install /usr/bin/jar jar /opt/jdk1.7.0_80/bin/jar 2
+alternatives --install /usr/bin/javac javac /opt/jdk1.7.0_80/bin/javac 2
+alternatives --install /usr/bin/javaws javaws /opt/jdk1.7.0_80/bin/javaws 2
+alternatives --set jar /opt/jdk1.7.0_80/bin/jar
+alternatives --set javac /opt/jdk1.7.0_80/bin/javac

--- a/docker/ci/install/install-java
+++ b/docker/ci/install/install-java
@@ -3,6 +3,11 @@
 set -e
 
 curl -L0 -o jdk-7u80-linux-x64.tar.gz https://s3.amazonaws.com/chain-qa/jdk-7u80-linux-x64.tar.gz
+
+sha256sum -c - <<-EOF
+bad9a731639655118740bee119139c1ed019737ec802a630dd7ad7aab4309623  jdk-7u80-linux-x64.tar.gz
+EOF
+
 tar -C /opt -xzf jdk-7u80-linux-x64.tar.gz
 rm jdk-7u80-linux-x64.tar.gz
 cd /opt/jdk1.7.0_80/

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3180";
+	public final String Id = "main/rev3181";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3180"
+const ID string = "main/rev3181"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3180"
+export const rev_id = "main/rev3181"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3180".freeze
+	ID = "main/rev3181".freeze
 end


### PR DESCRIPTION
Downloads of JDK 7 are now behind a registration wall. This commit uses
a copy that is cached to the chain-qa S3 bucket.