### PR TITLE
database/sinkdb: disallow multiple writes to a key in a batch

### DIFF
--- a/database/sinkdb/sinkdb.go
+++ b/database/sinkdb/sinkdb.go
@@ -51,12 +51,12 @@ func (db *DB) Exec(ctx context.Context, ops ...Op) error {
 		return instr.Operations[i].Key < instr.Operations[j].Key
 	})
 	var lastKey string
-	for _, pbop := range instr.Operations {
-		if pbop.Key == lastKey {
+	for _, e := range instr.Operations {
+		if e.Key == lastKey {
 			err := errors.New("duplicate write")
-			return errors.Wrap(err, pbop.Key)
+			return errors.Wrap(err, e.Key)
 		}
-		lastKey = pbop.Key
+		lastKey = e.Key
 	}
 
 	encoded, err := proto.Marshal(instr)

--- a/database/sinkdb/sinkdb.go
+++ b/database/sinkdb/sinkdb.go
@@ -3,12 +3,13 @@ package sinkdb
 
 import (
 	"context"
-	"errors"
 	"net/http"
+	"sort"
 
 	"github.com/golang/protobuf/proto"
 
 	"chain/database/sinkdb/internal/sinkpb"
+	"chain/errors"
 	"chain/net/raft"
 )
 
@@ -44,6 +45,20 @@ func (db *DB) Exec(ctx context.Context, ops ...Op) error {
 		instr.Conditions = append(instr.Conditions, op.conds...)
 		instr.Operations = append(instr.Operations, op.effects...)
 	}
+
+	// Disallow multiple writes to the same key.
+	sort.Slice(instr.Operations, func(i, j int) bool {
+		return instr.Operations[i].Key < instr.Operations[j].Key
+	})
+	var lastKey string
+	for _, pbop := range instr.Operations {
+		if pbop.Key == lastKey {
+			err := errors.New("duplicate write")
+			return errors.Wrap(err, pbop.Key)
+		}
+		lastKey = pbop.Key
+	}
+
 	encoded, err := proto.Marshal(instr)
 	if err != nil {
 		return err

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3182";
+	public final String Id = "main/rev3183";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3182"
+const ID string = "main/rev3183"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3182"
+export const rev_id = "main/rev3183"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3182".freeze
+	ID = "main/rev3183".freeze
 end


### PR DESCRIPTION
It is extremely error-prone to write the same key more
than once in a batch. So we disallow it.