### PR TITLE
core/query: annotate witness arguments

### DIFF
--- a/core/query/annotated.go
+++ b/core/query/annotated.go
@@ -27,21 +27,22 @@ type AnnotatedTx struct {
 }
 
 type AnnotatedInput struct {
-	Type            string             `json:"type"`
-	AssetID         bc.AssetID         `json:"asset_id"`
-	AssetAlias      string             `json:"asset_alias,omitempty"`
-	AssetDefinition *json.RawMessage   `json:"asset_definition"`
-	AssetTags       *json.RawMessage   `json:"asset_tags,omitempty"`
-	AssetIsLocal    Bool               `json:"asset_is_local"`
-	Amount          uint64             `json:"amount"`
-	IssuanceProgram chainjson.HexBytes `json:"issuance_program,omitempty"`
-	ControlProgram  chainjson.HexBytes `json:"-"`
-	SpentOutputID   *bc.Hash           `json:"spent_output_id,omitempty"`
-	AccountID       string             `json:"account_id,omitempty"`
-	AccountAlias    string             `json:"account_alias,omitempty"`
-	AccountTags     *json.RawMessage   `json:"account_tags,omitempty"`
-	ReferenceData   *json.RawMessage   `json:"reference_data"`
-	IsLocal         Bool               `json:"is_local"`
+	Type            string               `json:"type"`
+	AssetID         bc.AssetID           `json:"asset_id"`
+	AssetAlias      string               `json:"asset_alias,omitempty"`
+	AssetDefinition *json.RawMessage     `json:"asset_definition"`
+	AssetTags       *json.RawMessage     `json:"asset_tags,omitempty"`
+	AssetIsLocal    Bool                 `json:"asset_is_local"`
+	Amount          uint64               `json:"amount"`
+	IssuanceProgram chainjson.HexBytes   `json:"issuance_program,omitempty"`
+	ControlProgram  chainjson.HexBytes   `json:"-"`
+	SpentOutputID   *bc.Hash             `json:"spent_output_id,omitempty"`
+	AccountID       string               `json:"account_id,omitempty"`
+	AccountAlias    string               `json:"account_alias,omitempty"`
+	AccountTags     *json.RawMessage     `json:"account_tags,omitempty"`
+	ReferenceData   *json.RawMessage     `json:"reference_data"`
+	IsLocal         Bool                 `json:"is_local"`
+	Arguments       []chainjson.HexBytes `json:"arguments"` // experimental
 }
 
 type AnnotatedOutput struct {
@@ -142,12 +143,17 @@ func buildAnnotatedTransaction(orig *legacy.Tx, b *legacy.Block, indexInBlock ui
 
 func buildAnnotatedInput(tx *legacy.Tx, i uint32) *AnnotatedInput {
 	orig := tx.Inputs[i]
+	var jsonArgs []chainjson.HexBytes
+	for _, a := range orig.Arguments() {
+		jsonArgs = append(jsonArgs, a)
+	}
 	in := &AnnotatedInput{
 		AssetID:         orig.AssetID(),
 		Amount:          orig.Amount(),
 		AssetDefinition: &emptyJSONObject,
 		AssetTags:       &emptyJSONObject,
 		ReferenceData:   &emptyJSONObject,
+		Arguments:       jsonArgs,
 	}
 
 	if len(orig.ReferenceData) > 0 {

--- a/sdk/java/src/main/java/com/chain/api/Transaction.java
+++ b/sdk/java/src/main/java/com/chain/api/Transaction.java
@@ -233,6 +233,11 @@ public class Transaction {
      */
     @SerializedName("is_local")
     public String isLocal;
+
+    /**
+     * Witness arguments passed to the input.
+     */
+    public List<String> arguments;
   }
 
   /**

--- a/sdk/node/src/api/transactions.js
+++ b/sdk/node/src/api/transactions.js
@@ -97,6 +97,9 @@ function checkForError(resp) {
  *
  * @property {Boolean} isLocal
  * A flag indicating if the input is local.
+ *
+ * @property {String[]} arguments
+ * The witness arguments passed to the input.
  */
 
 /**
@@ -104,7 +107,7 @@ function checkForError(resp) {
  * creates others. An output is considered unspent when it has not yet been used
  * as an input to a new transaction. All asset units on a blockchain exist in
  * the unspent output set.
- * 
+ *
  * More info: {@link https://chain.com/docs/core/build-applications/unspent-outputs}
  * @typedef {Object} TransactionOutput
  * @global

--- a/sdk/ruby/lib/chain/transaction.rb
+++ b/sdk/ruby/lib/chain/transaction.rb
@@ -197,6 +197,11 @@ module Chain
       # A flag indicating if the input is local.
       # @return [Boolean]
       attrib :is_local
+
+      # @!attribute [r] arguments
+      # The witness arguments passed to the input.
+      # @return [Array<String>]
+      attrib :arguments
     end
 
     class Output < ResponseObject


### PR DESCRIPTION
This PR allows witness arguments to be viewed in the SDK. This is necessary for certain applications of Ivy for which a client needs to be able to inspect the values used to satisfy a contract.