### PR TITLE
database/sinkdb: return the version of a read key

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -61,10 +61,10 @@ var (
 // storage, the config will be added to sinkdb.
 func Load(ctx context.Context, db pg.DB, sdb *sinkdb.DB) (*Config, error) {
 	c := new(Config)
-	found, err := sdb.Get(ctx, "/core/config", c)
+	ver, err := sdb.Get(ctx, "/core/config", c)
 	if err != nil {
 		return nil, errors.Wrap(err)
-	} else if found {
+	} else if ver.Exists() {
 		return c, nil
 	}
 
@@ -211,10 +211,10 @@ func Configure(ctx context.Context, db pg.DB, sdb *sinkdb.DB, httpClient *http.C
 	// we start writing blocks to Postgres.
 	// TODO(jackson): make configuration idempotent so that we
 	// don't need this.
-	found, err := sdb.Get(ctx, "/core/config", &Config{})
+	ver, err := sdb.Get(ctx, "/core/config", &Config{})
 	if err != nil {
 		return errors.Wrap(err) // likely uninitialized
-	} else if found {
+	} else if ver.Exists() {
 		return errors.Wrap(sinkdb.ErrConflict) // already configured
 	}
 

--- a/database/sinkdb/sinkdb.go
+++ b/database/sinkdb/sinkdb.go
@@ -74,20 +74,20 @@ func (db *DB) Exec(ctx context.Context, ops ...Op) error {
 
 // Get performs a linearizable read of the provided key. The
 // read value is unmarshalled into v.
-func (db *DB) Get(ctx context.Context, key string, v proto.Message) (found bool, err error) {
-	err = db.raft.WaitRead(ctx)
+func (db *DB) Get(ctx context.Context, key string, v proto.Message) (Version, error) {
+	err := db.raft.WaitRead(ctx)
 	if err != nil {
-		return false, err
+		return Version{}, err
 	}
-	buf, found := db.state.get(key)
-	return found, proto.Unmarshal(buf, v)
+	buf, ver := db.state.get(key)
+	return ver, proto.Unmarshal(buf, v)
 }
 
 // GetStale performs a non-linearizable read of the provided key.
 // The value may be stale. The read value is unmarshalled into v.
-func (db *DB) GetStale(key string, v proto.Message) (found bool, err error) {
-	buf, found := db.state.get(key) // read directly from state
-	return found, proto.Unmarshal(buf, v)
+func (db *DB) GetStale(key string, v proto.Message) (Version, error) {
+	buf, ver := db.state.get(key) // read directly from state
+	return ver, proto.Unmarshal(buf, v)
 }
 
 // RaftService returns the raft service used for replication.

--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -150,12 +150,13 @@ func (s *state) Apply(data []byte, index uint64) (satisfied bool) {
 }
 
 // get performs a provisional read operation.
-func (s *state) get(key string) (value []byte, ok bool) {
+func (s *state) get(key string) ([]byte, Version) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	value, ok = s.state[key]
-	return
+	b := s.state[key]
+	n := s.version[key]
+	return b, Version{key, n}
 }
 
 // AppliedIndex returns the raft log index (applied index) of current state
@@ -179,8 +180,8 @@ func (s *state) NextNodeID() (id, version uint64) {
 }
 
 func (s *state) IsAllowedMember(addr string) bool {
-	_, ok := s.get(allowedMemberPrefix + "/" + addr)
-	return ok
+	_, ver := s.get(allowedMemberPrefix + "/" + addr)
+	return ver.Exists()
 }
 
 func (s *state) IncrementNextNodeID(oldID uint64, index uint64) (instruction []byte) {

--- a/database/sinkdb/version.go
+++ b/database/sinkdb/version.go
@@ -1,0 +1,15 @@
+package sinkdb
+
+// Version records the version of a particular key
+// when it is read.
+// Every time a key is set, its version changes.
+type Version struct {
+	key string
+	n   uint64 // raft log index
+}
+
+// Exists returns whether v's key exists
+// when it was read.
+func (v Version) Exists() bool {
+	return v.n != 0
+}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3187";
+	public final String Id = "main/rev3188";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3187"
+const ID string = "main/rev3188"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3187"
+export const rev_id = "main/rev3188"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3187".freeze
+	ID = "main/rev3188".freeze
 end

--- a/net/http/authz/store.go
+++ b/net/http/authz/store.go
@@ -30,10 +30,10 @@ func (s *Store) Load(ctx context.Context, policy []string) ([]*Grant, error) {
 	var grants []*Grant
 	for _, p := range policy {
 		var grantList GrantList
-		found, err := s.sdb.GetStale(s.keyPrefix+p, &grantList)
+		ver, err := s.sdb.GetStale(s.keyPrefix+p, &grantList)
 		if err != nil {
 			return nil, err
-		} else if found {
+		} else if ver.Exists() {
 			grants = append(grants, grantList.Grants...)
 		}
 	}
@@ -79,9 +79,9 @@ func (s *Store) Delete(ctx context.Context, policy string, delete func(*Grant) b
 	key := s.keyPrefix + policy
 
 	var grantList GrantList
-	found, err := s.sdb.Get(ctx, key, &grantList)
-	if err != nil || !found {
-		return sinkdb.Error(errors.Wrap(err)) // if !found, errors.Wrap(err) is nil
+	ver, err := s.sdb.Get(ctx, key, &grantList)
+	if err != nil || !ver.Exists() {
+		return sinkdb.Error(errors.Wrap(err)) // if !exists, errors.Wrap(err) is nil
 	}
 
 	var keep []*Grant


### PR DESCRIPTION
We replace the "found" bool with a Version object that
contains more information, and update the call sites to
use the new interface.

In the future, we can define a conditional Op, IfMatch,
that checks the key's version.