### PR TITLE
net/raft: respect context deadline in WaitRead

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3191";
+	public final String Id = "main/rev3192";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3191"
+const ID string = "main/rev3192"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3191"
+export const rev_id = "main/rev3192"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3191".freeze
+	ID = "main/rev3192".freeze
 end

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -509,10 +509,12 @@ func (sv *Service) WaitRead(ctx context.Context) error {
 
 	for {
 		err := sv.waitRead(ctx)
-		if isTimeout(err) {
-			continue
+		if !isTimeout(err) {
+			return err
 		}
-		return err
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 	}
 }
 


### PR DESCRIPTION
In WaitRead we ignore context.DeadlineExceeded errors returned from
waitRead because we use context.WithDeadline for timing out
individual retries. It's also possible that the parent context has
expired, so return the parent context's error if that happens.