### PR TITLE
bin/upload-docs: fix upload paths

### DIFF
--- a/bin/upload-docs
+++ b/bin/upload-docs
@@ -23,7 +23,7 @@ docgenerate $sourcePath $generate_dest_path
 
 echo
 echo "Uploading docs...."
-aws s3 sync --delete $generate_dest_path $bucket_url/docs/$1
+aws s3 sync --delete $generate_dest_path $bucket_url/docs
 
 echo
 echo "Setting content type for extensionless files, this will take a while..."

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3192";
+	public final String Id = "main/rev3193";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3192"
+const ID string = "main/rev3193"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3192"
+export const rev_id = "main/rev3193"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3192".freeze
+	ID = "main/rev3193".freeze
 end


### PR DESCRIPTION
This bug is a legacy from the previous version of upload-docs, which
only uploaded a specific release directory.