### PR TITLE
core: exec self in /join-cluster

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -182,7 +182,16 @@ func (a *API) joinCluster(ctx context.Context, x struct {
 	}
 
 	bootURL := fmt.Sprintf("https://%s", x.BootAddress)
-	return a.sdb.RaftService().Join(bootURL)
+	err = a.sdb.RaftService().Join(bootURL)
+	if err != nil {
+		return err
+	}
+
+	// The cluster we joined might already be configured. Exec self
+	// to restart cored and attempt to load the config.
+	closeConnOK(httpjson.ResponseWriter(ctx), httpjson.Request(ctx))
+	execSelf("")
+	panic("unreached")
 }
 
 func closeConnOK(w http.ResponseWriter, req *http.Request) {

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3200";
+	public final String Id = "main/rev3201";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3200"
+const ID string = "main/rev3201"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3200"
+export const rev_id = "main/rev3201"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3200".freeze
+	ID = "main/rev3201".freeze
 end


### PR DESCRIPTION
If the joined cluster is already configured, the process will still be
running as an unconfigured Core process. Exec self to restart and
reload the config, if any. In the long term, configuration should be
incremental and not require a process restart to pick up changes.