### PR TITLE
net/raft: add default WaitRead timeout

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3195";
+	public final String Id = "main/rev3196";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3195"
+const ID string = "main/rev3196"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3195"
+export const rev_id = "main/rev3196"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3195".freeze
+	ID = "main/rev3196".freeze
 end

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -503,6 +503,13 @@ func (sv *Service) allocNodeID(ctx context.Context) (uint64, error) {
 // won't have changed the value again, but it is guaranteed not to
 // read stale data.)
 func (sv *Service) WaitRead(ctx context.Context) error {
+	const defaultTimeout = 30 * time.Second
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, defaultTimeout)
+		defer cancel()
+	}
+
 	if !sv.initialized() {
 		return ErrUninitialized
 	}


### PR DESCRIPTION
If no context deadline is set, use a 30 second timeout in WaitRead.
Otherwise, WaitRead may block forever.