### PR TITLE
docs/1.2: remove corectl init, corectl join

### DIFF
--- a/docs/1.2/core/reference/corectl.md
+++ b/docs/1.2/core/reference/corectl.md
@@ -51,8 +51,6 @@ $ go install chain/cmd/corectl
 * [reset](#reset)
 * [grant](#grant)
 * [revoke](#revoke)
-* [init](#init)
-* [join](#join)
 * [allow-address](#allow-address)
 * [wait](#wait)
 
@@ -185,31 +183,6 @@ It must take one of three forms:
    * `OU=[name]` to affect an X.509 Organizational Unit
 
    The type of guard (before the = sign) is case-insensitive.
-
-
-### `init`
-
-Creates a new Chain Core cluster.
-
-```
-corectl init
-```
-
-
-### `join`
-
-Connects the Chain Core process to an existing Chain Core cluster.
-
-`join` should only be used for multiserver Chain Cores.
-
-```
-corectl join [address]
-```
-
-Argument:
-
-* **address**: The boot address, in `host:port` format.
-
 
 ### `allow-address`
 

--- a/docs/1.2/core/reference/cored.md
+++ b/docs/1.2/core/reference/cored.md
@@ -83,6 +83,13 @@ the limit will receive an HTTP 429 response.
 
     Can be stacked with **RATELIMIT_TOKEN**.
 
+* **BOOTURL**: Setting this value causes the `cored` process to join an
+existing Chain Core cluster if it's not already a member. If it is already
+a member of a cluster, this has no effect.
+
+    This should be the URL of any `cored` process already in the cluster,
+    or a load balancer that forwards requests to any node.
+
 ## Mutual TLS
 
 Chain Core 1.2 introduces support for mutual TLS authentication. This means both Chain Core and the client SDKs can authenticate each other using X.509 certificates and the TLS protocol. Previously, client authentication was facilitated through the use of access tokens and HTTP Basic Auth. While still supported, client access tokens are now deprecated.

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3201";
+	public final String Id = "main/rev3202";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3201"
+const ID string = "main/rev3202"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3201"
+export const rev_id = "main/rev3202"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3201".freeze
+	ID = "main/rev3202".freeze
 end


### PR DESCRIPTION
These commands and their documentation were added in
d20cecb8ca646d547b9031f9db9180753245115d, in the 1.3 development branch.
When the documentation was reorganized, it seems that it was cut from
main and the documentation for these commands snuck in.