### PR TITLE
core: add /evict rpc endpoint

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -63,6 +63,7 @@ var commands = map[string]*command{
 	"revoke":               {revoke},
 	"join":                 {joinCluster},
 	"init":                 {initCluster},
+	"evict":                {evictNode},
 	"allow-address":        {allowRaftMember},
 	"wait":                 {wait},
 }
@@ -403,6 +404,19 @@ func joinCluster(client *rpc.Client, args []string) {
 
 	req := map[string]string{"boot_address": args[0]}
 	err := client.Call(context.Background(), "/join-cluster", req, nil)
+	dieOnRPCError(err)
+}
+
+// evictNode evicts a Chain Core cored process from the cluster.
+// It does not modify the allowed-member list.
+func evictNode(client *rpc.Client, args []string) {
+	const usage = "usage: corectl evict [node address]"
+	if len(args) != 1 {
+		fatalln(usage)
+	}
+
+	req := map[string]string{"node_address": args[0]}
+	err := client.Call(context.Background(), "/evict", req, nil)
 	dieOnRPCError(err)
 }
 

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -249,6 +249,13 @@ func main() {
 		err := server.Serve(listener)
 		chainlog.Fatalkv(ctx, chainlog.KeyError, errors.Wrap(err, "Serve"))
 	}()
+
+	// Verify that we're connected to the rest of the cluster, if initialized.
+	err = errors.Root(sdb.Ping())
+	if err == context.DeadlineExceeded {
+		chainlog.Fatalkv(ctx, chainlog.KeyError, "Unable to reach rest of raft cluster. Was the node evicted?")
+	}
+
 	resetIfAllowedAndRequested(db, sdb)
 
 	conf, err := config.Load(ctx, db, sdb)

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -254,6 +254,8 @@ func main() {
 	err = errors.Root(sdb.Ping())
 	if err == context.DeadlineExceeded {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, "Unable to reach rest of raft cluster. Was the node evicted?")
+	} else if err != nil && err != raft.ErrUninitialized {
+		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 
 	resetIfAllowedAndRequested(db, sdb)

--- a/core/api.go
+++ b/core/api.go
@@ -181,6 +181,7 @@ func (a *API) buildHandler() {
 	m.Handle("/add-allowed-member", jsonHandler(a.addAllowedMember))
 	m.Handle("/init-cluster", jsonHandler(a.initCluster))
 	m.Handle("/join-cluster", jsonHandler(a.joinCluster))
+	m.Handle("/evict", jsonHandler(a.evict))
 	m.Handle("/configure", jsonHandler(a.configure))
 	m.Handle("/info", jsonHandler(a.info))
 

--- a/core/authz.go
+++ b/core/authz.go
@@ -56,6 +56,7 @@ var policyByRoute = map[string][]string{
 	"/add-allowed-member":         {"internal"},
 	"/init-cluster":               {"internal"},
 	"/join-cluster":               {"internal"},
+	"/evict":                      {"internal"},
 	"/configure":                  {"client-readwrite", "internal"},
 	"/info":                       {"client-readwrite", "client-readonly", "crosscore", "crosscore-signblock", "monitoring", "internal"},
 

--- a/core/errors.go
+++ b/core/errors.go
@@ -94,6 +94,7 @@ var errorFormatter = httperror.Formatter{
 		raft.ErrUninitialized:          {400, "CH163", "Cluster not initialized"},
 		raft.ErrExistingCluster:        {400, "CH164", "Already connected to a cluster"},
 		raft.ErrPeerUninitialized:      {400, "CH165", "Peer node is uninitialized"},
+		raft.ErrUnknownPeer:            {400, "CH166", "Unknown peer"},
 
 		// Signers error namespace (2xx)
 		signers.ErrBadQuorum: {400, "CH200", "Quorum must be greater than 1 and less than or equal to the length of xpubs"},

--- a/database/sinkdb/sinkdb.go
+++ b/database/sinkdb/sinkdb.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"sort"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 
@@ -32,6 +33,17 @@ func Open(laddr, dir string, httpClient *http.Client) (*DB, error) {
 type DB struct {
 	state *state
 	raft  *raft.Service
+}
+
+// Ping peforms an empty write to verify the connection to
+// the rest of the cluster.
+func (db *DB) Ping() error {
+	const timeout = 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	_, err := db.raft.Exec(ctx, db.state.EmptyWrite())
+	return err
 }
 
 // Exec executes the provided operations

--- a/database/sinkdb/sinkdb.go
+++ b/database/sinkdb/sinkdb.go
@@ -38,7 +38,7 @@ type DB struct {
 // Ping peforms an empty write to verify the connection to
 // the rest of the cluster.
 func (db *DB) Ping() error {
-	const timeout = 30 * time.Second
+	const timeout = 5 * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -41,25 +41,38 @@ func (s *state) SetAppliedIndex(index uint64) {
 	s.appliedIndex = index
 }
 
-// SetPeerAddr sets the address for the given peer.
-func (s *state) SetPeerAddr(id uint64, addr string) {
+// Peers returns the current set of peer nodes. The returned
+// map must not be modified.
+func (s *state) Peers() map[uint64]string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.peers[id] = addr
+	return s.peers
 }
 
-// GetPeerAddr gets the current address for the given peer, if set.
-func (s *state) GetPeerAddr(id uint64) (addr string) {
+// SetPeerAddr sets the address for the given peer.
+func (s *state) SetPeerAddr(id uint64, addr string) {
+	newPeers := make(map[uint64]string)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.peers[id]
+	for nodeID, addr := range s.peers {
+		newPeers[nodeID] = addr
+	}
+	newPeers[id] = addr
+	s.peers = newPeers
 }
 
 // RemovePeerAddr deletes the current address for the given peer if it exists.
 func (s *state) RemovePeerAddr(id uint64) {
+	newPeers := make(map[uint64]string)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.peers, id)
+	for nodeID, addr := range s.peers {
+		if nodeID == id {
+			continue
+		}
+		newPeers[nodeID] = addr
+	}
+	s.peers = newPeers
 }
 
 // RestoreSnapshot decodes data and overwrites the contents of s.

--- a/database/sinkdb/state_test.go
+++ b/database/sinkdb/state_test.go
@@ -32,11 +32,11 @@ func TestSetPeerAddr(t *testing.T) {
 func TestGetPeerAddr(t *testing.T) {
 	s := newState()
 	s.SetPeerAddr(1, "1.2.3.4:567")
-	want := "1.2.3.4:567"
+	want := map[uint64]string{1: "1.2.3.4:567"}
 
-	got := s.GetPeerAddr(1)
+	got := s.Peers()
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("s.GetPeerAddr(1) = %s, want %s", got, want)
+		t.Errorf("s.GetPeerAddr(1) = %v, want %v", got, want)
 	}
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3245";
+	public final String Id = "main/rev3246";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3245"
+const ID string = "main/rev3246"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3245"
+export const rev_id = "main/rev3246"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3245".freeze
+	ID = "main/rev3246".freeze
 end

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -883,6 +883,8 @@ func (sv *Service) send(msgs []raftpb.Message) {
 
 // best effort. if it fails, oh well -- that's why we're using raft.
 func sendmsg(addr string, data []byte, client *http.Client) {
+	// TODO(jackson): Parse the error response and try to detect
+	// eviction.
 	url := "https://" + addr + "/raft/msg"
 	resp, err := client.Post(url, contentType, bytes.NewReader(data))
 	if err != nil {

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -67,6 +67,9 @@ var (
 	// ErrPeerUninitialized is returned when a peer node indicates it's
 	// not yet initialized.
 	ErrPeerUninitialized = errors.New("peer is uninitialized")
+
+	// ErrUnknownPeer is returned when the specified peer doesn't exist.
+	ErrUnknownPeer = errors.New("unknown peer")
 )
 
 var (
@@ -130,8 +133,8 @@ type State interface {
 	Snapshot() (data []byte, index uint64, err error)
 	RestoreSnapshot(data []byte, index uint64) error
 	SetAppliedIndex(index uint64)
+	Peers() map[uint64]string
 	SetPeerAddr(id uint64, addr string)
-	GetPeerAddr(id uint64) (addr string)
 	RemovePeerAddr(id uint64)
 	IsAllowedMember(addr string) bool
 	NextNodeID() (id, version uint64)
@@ -681,6 +684,35 @@ func (sv *Service) serveJoin(w http.ResponseWriter, req *http.Request) {
 	json.NewEncoder(w).Encode(nodeJoin{newID, snapData})
 }
 
+// Evict removes the node with the provided address from the raft cluster.
+// It does not modify the allowed member list.
+func (sv *Service) Evict(ctx context.Context, nodeAddr string) error {
+	if !sv.initialized() {
+		return ErrUninitialized
+	}
+
+	// Lookup the node ID of the node to evict.
+	err := sv.WaitRead(ctx)
+	if err != nil {
+		return err
+	}
+	var evictNodeID uint64
+	for nodeID, addr := range sv.state.Peers() {
+		if addr == nodeAddr {
+			evictNodeID = nodeID
+		}
+	}
+	if evictNodeID == 0 {
+		return errors.WithDetailf(ErrUnknownPeer, "The cluster has no peer with address %q.", nodeAddr)
+	}
+
+	return sv.raftNode.ProposeConfChange(ctx, raftpb.ConfChange{
+		ID:     atomic.AddUint64(&sv.confChangeID, 1),
+		Type:   raftpb.ConfChangeRemoveNode,
+		NodeID: evictNodeID,
+	})
+}
+
 // join attempts to join the cluster.
 // It requests an existing member to propose a configuration change
 // adding the local process as a new member, then retrieves its new ID
@@ -839,7 +871,7 @@ func (sv *Service) send(msgs []raftpb.Message) {
 			panic(err)
 		}
 		sv.stateMu.Lock()
-		addr := sv.state.GetPeerAddr(msg.To)
+		addr := sv.state.Peers()[msg.To]
 		sv.stateMu.Unlock()
 		if addr == "" {
 			log.Printkv(context.Background(), "no-addr-for-peer", msg.To)

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -588,7 +588,7 @@ func (sv *Service) wait(index uint64) {
 func (sv *Service) waitForNode(nodeID uint64) {
 	sv.stateMu.Lock()
 	defer sv.stateMu.Unlock()
-	for sv.state.GetPeerAddr(nodeID) == "" {
+	for sv.state.Peers()[nodeID] == "" {
 		sv.stateCond.Wait()
 	}
 }


### PR DESCRIPTION
Add an evict command to corectl to remove a node from a Chain Core
cluster.

On startup in cmd/cored, call sinkdb.DB.Ping to perform an empty write
to test the raft configuration. This helps handle the scenario where an
evicted node boots up without realizing it's been evicted. The other
nodes won't necessarily replicate the eviction entry to the node if
they've already moved on and forgotten the evicted node's address.

Addresses part of #1118.