### PR TITLE
database/sinkdb: use map key existence for Exists

### DIFF
--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -156,9 +156,9 @@ func (s *state) get(key string) ([]byte, Version) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	b := s.state[key]
+	b, ok := s.state[key]
 	n := s.version[key]
-	return b, Version{key, n}
+	return b, Version{key, ok, n}
 }
 
 // AppliedIndex returns the raft log index (applied index) of current state

--- a/database/sinkdb/version.go
+++ b/database/sinkdb/version.go
@@ -5,13 +5,16 @@ package sinkdb
 // Every time a key is set, its version changes.
 type Version struct {
 	key string
+	ok  bool
 	n   uint64 // raft log index
 }
 
 // Exists returns whether v's key exists
 // when it was read.
 func (v Version) Exists() bool {
-	return v.n != 0
+	// TODO(jackson): use v.n != 0 once we've backfilled versions
+	// for Chain Core 1.2.x snapshots.
+	return v.ok
 }
 
 // Key returns the key for which v is valid.

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3203";
+	public final String Id = "main/rev3204";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3203"
+const ID string = "main/rev3204"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3203"
+export const rev_id = "main/rev3204"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3203".freeze
+	ID = "main/rev3204".freeze
 end


### PR DESCRIPTION
For now use the existence of the key in the state map for
Version.Exists. Once we have a backfill for Chain Core 1.2.x
snapshots that omit versions, we can use the version check
instead.