### PR TITLE
net/http/authz: encapsulate grant storage

### DIFF
--- a/core/authz.go
+++ b/core/authz.go
@@ -1,7 +1,5 @@
 package core
 
-const GrantPrefix = "/core/grant/"
-
 var Policies = []string{
 	"client-readwrite",
 	"client-readonly",

--- a/core/authz_test.go
+++ b/core/authz_test.go
@@ -31,7 +31,7 @@ func TestAuthz(t *testing.T) {
 		mux:          http.NewServeMux(),
 		sdb:          sdb,
 		accessTokens: accessTokens,
-		grants:       authz.NewStore(sdb, GrantPrefix),
+		grants:       authz.NewStore(sdb),
 	}
 	api.buildHandler()
 	mux.Handle("/", api)

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -31,7 +31,6 @@ import (
 
 const (
 	autoBlockKeyAlias = "_CHAIN_CORE_AUTO_BLOCK_KEY"
-	GrantPrefix       = "/core/grant/" // this is also hardcoded in core/authz.go. meh.
 )
 
 var (
@@ -295,7 +294,7 @@ func tryGenerator(ctx context.Context, url, accessToken, blockchainID string, ht
 // TODO(tessr): make all of this atomic in raft, so we don't get halfway through
 // a postgres->raft migration and fail, losing the second half of the migration
 func migrateAccessTokens(ctx context.Context, db pg.DB, sdb *sinkdb.DB) error {
-	store := authz.NewStore(sdb, GrantPrefix)
+	store := authz.NewStore(sdb)
 	const q = `SELECT id, type, created FROM access_tokens`
 	var tokens []*accesstoken.Token
 	err := pg.ForQueryRows(ctx, db, q, func(id string, maybeType sql.NullString, created time.Time) {

--- a/core/grants_test.go
+++ b/core/grants_test.go
@@ -26,7 +26,7 @@ func TestCreatGrantValidation(t *testing.T) {
 		mux:          http.NewServeMux(),
 		sdb:          sdb,
 		accessTokens: accessTokens,
-		grants:       authz.NewStore(sdb, GrantPrefix),
+		grants:       authz.NewStore(sdb),
 	}
 
 	validCases := []apiGrant{
@@ -140,7 +140,7 @@ func TestDeleteGrants(t *testing.T) {
 		mux:          http.NewServeMux(),
 		sdb:          sdb,
 		accessTokens: accessTokens,
-		grants:       authz.NewStore(sdb, GrantPrefix),
+		grants:       authz.NewStore(sdb),
 	}
 
 	fixture := []apiGrant{
@@ -242,7 +242,7 @@ func TestDeleteGrantsByAccessToken(t *testing.T) {
 		mux:          http.NewServeMux(),
 		sdb:          sdb,
 		accessTokens: accessTokens,
-		grants:       authz.NewStore(sdb, GrantPrefix),
+		grants:       authz.NewStore(sdb),
 	}
 
 	// fixture data includes four grants:

--- a/core/run.go
+++ b/core/run.go
@@ -126,7 +126,7 @@ func RunUnconfigured(ctx context.Context, db pg.DB, sdb *sinkdb.DB, routableAddr
 		db:           db,
 		sdb:          sdb,
 		accessTokens: &accesstoken.CredentialStore{DB: db},
-		grants:       authz.NewStore(sdb, GrantPrefix),
+		grants:       authz.NewStore(sdb),
 		mux:          http.NewServeMux(),
 		addr:         routableAddress,
 	}
@@ -183,7 +183,7 @@ func Run(
 		txFeeds:      &txfeed.Tracker{DB: db},
 		indexer:      indexer,
 		accessTokens: &accesstoken.CredentialStore{DB: db},
-		grants:       authz.NewStore(sdb, GrantPrefix),
+		grants:       authz.NewStore(sdb),
 		config:       conf,
 		db:           db,
 		sdb:          sdb,


### PR DESCRIPTION
Hide grant storage details from core, keeping the grant prefix as an
unexported constant in net/http/authz. Always use authz.Store methods
for accessing and modifying grants.

As written, the list grants endpoint will perform a stale read. Not sure
how we feel about that.