### PR TITLE
cmd/docsync: new command

### DIFF
--- a/bin/upload-docs
+++ b/bin/upload-docs
@@ -8,6 +8,7 @@ then
 fi
 
 bucket_url=s3://$bucket
+bucket_prefix="docs/"
 
 generate_dest_path=`mktemp -d`
 trap "echo 'Error generating docs, cleaning up temp files...'; rm -rf $generate_dest_path" ERR
@@ -23,4 +24,4 @@ docgenerate $sourcePath $generate_dest_path
 
 echo
 echo "Uploading docs...."
-docsync $bucket $generate_dest_path
+docsync $bucket $bucket_prefix $generate_dest_path

--- a/bin/upload-docs
+++ b/bin/upload-docs
@@ -23,16 +23,18 @@ docgenerate $sourcePath $generate_dest_path
 
 echo
 echo "Uploading docs...."
-aws s3 sync --delete $generate_dest_path $bucket_url/docs
+docsync $bucket $generate_dest_path
 
-echo
-echo "Setting content type for extensionless files, this will take a while..."
-cd $generate_dest_path
-find . -type f ! -name "*.*" |
-  sed -e "s/^.\\///" |
-  xargs -I {} aws s3api copy-object \
-    --bucket $bucket \
-    --content-type "text/html" \
-    --copy-source $bucket/docs/{} \
-    --key docs/{} \
-    --metadata-directive "REPLACE" > /dev/null
+# aws s3 sync --delete $generate_dest_path $bucket_url/docs
+#
+# echo
+# echo "Setting content type for extensionless files, this will take a while..."
+# cd $generate_dest_path
+# find . -type f ! -name "*.*" |
+#   sed -e "s/^.\\///" |
+#   xargs -I {} aws s3api copy-object \
+#     --bucket $bucket \
+#     --content-type "text/html" \
+#     --copy-source $bucket/docs/{} \
+#     --key docs/{} \
+#     --metadata-directive "REPLACE" > /dev/null

--- a/bin/upload-docs
+++ b/bin/upload-docs
@@ -24,17 +24,3 @@ docgenerate $sourcePath $generate_dest_path
 echo
 echo "Uploading docs...."
 docsync $bucket $generate_dest_path
-
-# aws s3 sync --delete $generate_dest_path $bucket_url/docs
-#
-# echo
-# echo "Setting content type for extensionless files, this will take a while..."
-# cd $generate_dest_path
-# find . -type f ! -name "*.*" |
-#   sed -e "s/^.\\///" |
-#   xargs -I {} aws s3api copy-object \
-#     --bucket $bucket \
-#     --content-type "text/html" \
-#     --copy-source $bucket/docs/{} \
-#     --key docs/{} \
-#     --metadata-directive "REPLACE" > /dev/null

--- a/cmd/docsync/main.go
+++ b/cmd/docsync/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path"
+	"sort"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+func main() {
+	localKeys := mustListContents("/Users/jeff/go/src/chain/cmd/docsync/DO_NOT_COMMIT")
+	fmt.Println(len(localKeys))
+
+	region := "us-east-1"
+	sess := session.Must(session.NewSession(aws.NewConfig().WithRegion(region)))
+	svc := s3.New(sess)
+
+	var remoteKeys []string
+	err := svc.ListObjectsPages(&s3.ListObjectsInput{
+		Bucket: aws.String("chain.com"),
+		Prefix: aws.String("docs/"),
+	}, func(page *s3.ListObjectsOutput, lastPage bool) bool {
+		for _, obj := range page.Contents {
+			remoteKeys = append(remoteKeys, *obj.Key)
+		}
+		return true
+	})
+	if err != nil {
+		log.Fatalln("s3 list objects error:", err)
+	}
+
+	intersection, localOnly, remoteOnly := setAnalyze(localKeys, remoteKeys)
+	fmt.Println("local size:", len(localKeys))
+	fmt.Println("remote size:", len(remoteKeys))
+	fmt.Println("intersection:", len(intersection))
+	fmt.Println("local only:", len(localOnly))
+	fmt.Println("remote only:", len(remoteOnly))
+}
+
+func setAnalyze(a, b []string) (intersection []string, aOnly []string, bOnly []string) {
+	sort.Strings(append([]string{}, a...))
+	sort.Strings(append([]string{}, b...))
+
+	fmt.Println(a[0])
+	fmt.Println(b[0])
+
+	var i, j int
+
+	for {
+		if i == len(a) {
+			bOnly = append(bOnly, b[j:]...)
+			break
+		}
+
+		if j == len(b) {
+			aOnly = append(aOnly, a[i:]...)
+			break
+		}
+
+		if a[i] < b[j] {
+			aOnly = append(aOnly, a[i])
+			i++
+			continue
+		}
+
+		if b[j] < a[i] {
+			bOnly = append(bOnly, b[j])
+			j++
+			continue
+		}
+
+		// invariant: a[i] == b[j]
+		intersection = append(intersection, a[i])
+		i++
+		j++
+	}
+
+	return
+}
+
+func mustListContents(parentPath string) []string {
+	files, err := ioutil.ReadDir(parentPath)
+	if err != nil {
+		log.Fatalln("ReadDir error:", err)
+	}
+
+	var res []string
+	for _, f := range files {
+		n := f.Name()
+
+		if f.IsDir() {
+			descendants := mustListContents(path.Join(parentPath, n))
+			for _, d := range descendants {
+				res = append(res, path.Join(n, d))
+			}
+		} else {
+			res = append(res, n)
+		}
+	}
+
+	return res
+}

--- a/cmd/docsync/main.go
+++ b/cmd/docsync/main.go
@@ -13,7 +13,6 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"mime"
@@ -59,7 +58,7 @@ func main() {
 	for _, k := range localKeys {
 		var body []byte
 
-		path := fmt.Sprintf("%s/%s", localDir, k)
+		path := path.Join(localDir, k)
 		body, err = ioutil.ReadFile(path)
 		if err != nil {
 			log.Fatalln(err.Error())
@@ -88,7 +87,7 @@ func main() {
 
 	var prefixedLocalKeys []string
 	for _, k := range localKeys {
-		prefixedLocalKeys = append(prefixedLocalKeys, path.Join("docs", k))
+		prefixedLocalKeys = append(prefixedLocalKeys, bucketPrefix+k)
 	}
 
 	remoteOnly := setDiff(remoteKeys, prefixedLocalKeys)

--- a/cmd/docsync/main.go
+++ b/cmd/docsync/main.go
@@ -124,17 +124,12 @@ func setDiff(a, b []string) []string {
 		if a[i] < b[j] {
 			diff = append(diff, a[i])
 			i++
-			continue
-		}
-
-		if b[j] < a[i] {
+		} else if b[j] < a[i] {
 			j++
-			continue
+		} else { // a[i] == b[j]
+			i++
+			j++
 		}
-
-		// invariant: a[i] == b[j]
-		i++
-		j++
 	}
 
 	return diff

--- a/cmd/docsync/main.go
+++ b/cmd/docsync/main.go
@@ -56,8 +56,7 @@ func main() {
 		path := strings.Replace(k, "docs", os.Args[2], 1)
 		body, err = ioutil.ReadFile(path)
 		if err != nil {
-			fmt.Println(err.Error())
-			return
+			log.Fatalln(err.Error())
 		}
 
 		upload := &s3.PutObjectInput{
@@ -80,8 +79,7 @@ func main() {
 		_, err = svc.PutObject(upload)
 
 		if err != nil {
-			fmt.Println(err.Error())
-			return
+			log.Fatalln(err.Error())
 		}
 	}
 
@@ -96,8 +94,7 @@ func main() {
 		_, err = svc.DeleteObject(remove)
 
 		if err != nil {
-			fmt.Println(err.Error())
-			return
+			log.Fatalln(err.Error())
 		}
 	}
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3212";
+	public final String Id = "main/rev3213";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3212"
+const ID string = "main/rev3213"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3212"
+export const rev_id = "main/rev3213"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3212".freeze
+	ID = "main/rev3213".freeze
 end


### PR DESCRIPTION
Add support for zero-downtime doc deploys by uploading files one at a time 
with correct the content type, and removing files not present on the local 
system after the fact.