### PR TITLE
database/raft: always update AppliedIndex

### DIFF
--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -736,8 +736,6 @@ func (sv *Service) applyEntry(ent raftpb.Entry, writers map[string]chan bool) {
 			defer sv.stateMu.Unlock()
 			defer sv.stateCond.Broadcast()
 			sv.state.RemovePeerAddr(cc.NodeID)
-		default:
-			panic(fmt.Errorf("unknown confchange type: %v", cc.Type))
 		}
 	case raftpb.EntryNormal:
 		//raft will send empty request defaulted to EntryNormal on leader election

--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -719,31 +719,38 @@ func (sv *Service) applyEntry(ent raftpb.Entry, writers map[string]chan bool) {
 			panic(err)
 		}
 		sv.stateMu.Lock()
-		defer sv.stateMu.Unlock()
-		defer sv.stateCond.Broadcast()
 		sv.confState = *sv.raftNode.ApplyConfChange(cc)
 		sv.state.SetAppliedIndex(ent.Index)
+		sv.stateMu.Unlock()
 		switch cc.Type {
 		case raftpb.ConfChangeAddNode, raftpb.ConfChangeUpdateNode:
+			sv.stateMu.Lock()
+			defer sv.stateMu.Unlock()
+			defer sv.stateCond.Broadcast()
 			sv.state.SetPeerAddr(cc.NodeID, string(cc.Context))
 		case raftpb.ConfChangeRemoveNode:
 			if cc.NodeID == sv.id {
 				panic(errors.New("removed from cluster"))
 			}
+			sv.stateMu.Lock()
+			defer sv.stateMu.Unlock()
+			defer sv.stateCond.Broadcast()
 			sv.state.RemovePeerAddr(cc.NodeID)
 		default:
 			panic(fmt.Errorf("unknown confchange type: %v", cc.Type))
 		}
 	case raftpb.EntryNormal:
-		sv.stateMu.Lock()
-		defer sv.stateCond.Broadcast()
-		defer sv.stateMu.Unlock()
 		//raft will send empty request defaulted to EntryNormal on leader election
 		//we need to handle that here
 		if ent.Data == nil {
+			sv.stateMu.Lock()
 			sv.state.SetAppliedIndex(ent.Index)
+			sv.stateMu.Unlock()
 			break
 		}
+		sv.stateMu.Lock()
+		defer sv.stateCond.Broadcast()
+		defer sv.stateMu.Unlock()
 		var p proposal
 		err := json.Unmarshal(ent.Data, &p)
 		if err != nil {

--- a/database/raft/state/state.go
+++ b/database/raft/state/state.go
@@ -31,6 +31,11 @@ func New() *State {
 	}
 }
 
+// SetAppliedIndex updates the applied index.
+func (s *State) SetAppliedIndex(index uint64) {
+	s.appliedIndex = index
+}
+
 // SetPeerAddr sets the address for the given peer.
 func (s *State) SetPeerAddr(id uint64, addr string) {
 	s.peers[id] = addr

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "1.2-stable/rev3134";
+	public final String Id = "1.2-stable/rev3135";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.2-stable/rev3134"
+const ID string = "1.2-stable/rev3135"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "1.2-stable/rev3134"
+export const rev_id = "1.2-stable/rev3135"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "1.2-stable/rev3134".freeze
+	ID = "1.2-stable/rev3135".freeze
 end


### PR DESCRIPTION
Always update the state's applied index, even if there is no change to
the state. Otherwise, triggerSnapshot will create a snapshot at an index
less than the true applied index. This can result in less than
`nSnapCatchupEntries` entries being available.

This is a fix for the 1.2 branch.