### PR TITLE
net/raft: always update AppliedIndex

### DIFF
--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -34,6 +34,13 @@ func newState() *state {
 	}
 }
 
+// SetAppliedIndex sets the applied index to the provided index.
+func (s *state) SetAppliedIndex(index uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.appliedIndex = index
+}
+
 // SetPeerAddr sets the address for the given peer.
 func (s *state) SetPeerAddr(id uint64, addr string) {
 	s.mu.Lock()

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3215";
+	public final String Id = "main/rev3216";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3215"
+const ID string = "main/rev3216"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3215"
+export const rev_id = "main/rev3216"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3215".freeze
+	ID = "main/rev3216".freeze
 end


### PR DESCRIPTION
Always update the state's applied index, even if there is no change to
the state. Otherwise, triggerSnapshot will create a snapshot at an index
less than the true applied index. This can result in less than
`nSnapCatchupEntries` entries being available.

Also, document that `nSnapCatchupEntries` must be <= `snapCount`.

We might want to consider making snapCount and nSnapCatchupEntries
fields on Service so that we can write snapshot tests without simulating
a 10,000 entries.