### PR TITLE
net/http/authn: provide error details

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -277,7 +277,8 @@ func AuthHandler(handler http.Handler, sdb *sinkdb.DB, accessTokens *accesstoken
 		// TODO(tessr): check that this path exists; return early if this path isn't legit
 		req, err := authenticator.Authenticate(req)
 		if err != nil {
-			errorFormatter.Write(req.Context(), rw, errNotAuthenticated)
+			err = errors.Sub(errNotAuthenticated, err)
+			errorFormatter.Write(req.Context(), rw, err)
 			return
 		}
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3306";
+	public final String Id = "main/rev3307";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3306"
+const ID string = "main/rev3307"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3306"
+export const rev_id = "main/rev3307"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3306".freeze
+	ID = "main/rev3307".freeze
 end


### PR DESCRIPTION
Provide error details when a request fails to authenticate. If no
credentials were provided, indicate that in the error detail. Otherwise,
provide details on each invalid credential.

Examples:
```
$ CORE_URL=https://mba.local:1999 corectl create-token jackson
RPC error: CH009 Request could not be authenticated
Detail: Invalid credentials: x509: certificate specifies an incompatible key usage
```

```
$ CORE_URL=http://jackattack:almondmilk@mba.local:1999 corectl create-token jackson
RPC error: CH009 Request could not be authenticated
Detail: Invalid credentials: invalid token: "jackattack"
```

```
$ CORE_URL=http://mba.local:1999 corectl create-token jackson
RPC error: CH009 Request could not be authenticated
Detail: No authentication credentials provided.
```