### PR TITLE
vendor/golang.org/x/crypto: add cSHAKE, KMAC and TupleHash

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3232";
+	public final String Id = "main/rev3233";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3232"
+const ID string = "main/rev3233"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3232"
+export const rev_id = "main/rev3233"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3232".freeze
+	ID = "main/rev3233".freeze
 end

--- a/vendor/golang.org/x/crypto/sha3/cshake.go
+++ b/vendor/golang.org/x/crypto/sha3/cshake.go
@@ -105,7 +105,7 @@ func rightEncode(d *state, value uint64) int {
 
 // leftEncode encodes integer in a variable-length encoding
 // unambiguously parseable from the beginning of a string.
-// Used to encode stringsfor all cSHAKE functions.
+// Used to encode strings for all cSHAKE functions.
 func leftEncode(d *state, value uint64) int {
 	input := d.varintbuf[:]
 	copy(input, zero[:])

--- a/vendor/golang.org/x/crypto/sha3/cshake.go
+++ b/vendor/golang.org/x/crypto/sha3/cshake.go
@@ -1,0 +1,127 @@
+package sha3
+
+import "encoding/binary"
+
+// NewCShake128 creates a new cSHAKE128 variable-output-length customizable ShakeHash.
+// Its generic security strength is 128 bits against all attacks
+// if at least 32 bytes of its output are used.
+// n is a customization string for derived functions specified by NIST.
+// Set n to an empty string if you are building your own derived function.
+// s is a user-defined customization string.
+func NewCShake128(n []byte, s []byte) ShakeHash {
+	return newCShake(128, n, s)
+}
+
+// NewCShake256 creates a new cSHAKE256 variable-output-length customizable ShakeHash.
+// Its generic security strength is 256 bits against all attacks
+// if at least 64 bytes of its output are used.
+// n is a customization string for derived functions specified by NIST.
+// Set n to an empty string if you are building your own derived function.
+// s is a user-defined customization string.
+func NewCShake256(n []byte, s []byte) ShakeHash {
+	return newCShake(256, n, s)
+}
+
+// CShakeSum128 writes an arbitrary-length digest of data into hash.
+// n is a customization string for derived functions specified by NIST.
+// Set n to an empty string if you are building your own derived function.
+// s is a user-defined customization string.
+func CShakeSum128(hash, data, n, s []byte) {
+	h := NewCShake128(n, s)
+	h.Write(data)
+	h.Read(hash)
+}
+
+// CShakeSum256 writes an arbitrary-length digest of data into hash.
+// n is a customization string for derived functions specified by NIST.
+// Set n to an empty string if you are building your own derived function.
+// s is a user-defined customization string.
+func CShakeSum256(hash, data, n, s []byte) {
+	h := NewCShake256(n, s)
+	h.Write(data)
+	h.Read(hash)
+}
+
+var zero [maxRate]byte
+
+func newCShake(securitybits int, n []byte, s []byte) (d *state) {
+	if len(n) == 0 && len(s) == 0 {
+		if securitybits == 128 {
+			return &state{rate: 168, dsbyte: 0x1f} // regular SHAKE-128
+		} else if securitybits == 256 {
+			return &state{rate: 136, dsbyte: 0x1f} // regular SHAKE-256
+		} else {
+			panic("invalid security level for cSHAKE")
+		}
+	}
+	if securitybits == 128 {
+		d = &state{rate: 168, dsbyte: 0x04}
+	} else if securitybits == 256 {
+		d = &state{rate: 136, dsbyte: 0x04}
+	} else {
+		panic("invalid security level for cSHAKE")
+	}
+	d.initCShake(n, s)
+	return d
+}
+
+// The initialization of cSHAKE
+func (d *state) initCShake(n []byte, s []byte) {
+	var c int
+	c += leftEncode(d, uint64(d.rate))
+	c += encodeString(d, n)
+	c += encodeString(d, s)
+	d.Write(zero[:d.rate-(c%d.rate)])
+}
+
+func encodeString(d *state, s []byte) int {
+	n := leftEncode(d, uint64(len(s)*8))
+	w, _ := d.Write(s)
+	return n + w
+}
+
+// rightEncode encodes integer in a variable-length encoding
+// unambiguously parseable from the end of a string.
+// Used by TupleHash and KMAC.
+func rightEncode(d *state, value uint64) int {
+	input := d.varintbuf[:]
+	copy(input, zero[:])
+	var offset uint
+	if value == 0 {
+		offset = 7
+	} else {
+		binary.BigEndian.PutUint64(input[0:], value)
+		for offset = 0; offset < 8; offset++ {
+			if input[offset] != 0 {
+				break
+			}
+		}
+	}
+	input[8] = byte(8 - offset)
+	b := input[offset:]
+	d.Write(b)
+	return len(b)
+}
+
+// leftEncode encodes integer in a variable-length encoding
+// unambiguously parseable from the beginning of a string.
+// Used to encode stringsfor all cSHAKE functions.
+func leftEncode(d *state, value uint64) int {
+	input := d.varintbuf[:]
+	copy(input, zero[:])
+	var offset uint
+	if value == 0 {
+		offset = 8
+	} else {
+		binary.BigEndian.PutUint64(input[1:], value)
+		for offset = 0; offset < 9; offset++ {
+			if input[offset] != 0 {
+				break
+			}
+		}
+	}
+	input[offset-1] = byte(9 - offset)
+	b := input[offset-1:]
+	d.Write(b)
+	return len(b)
+}

--- a/vendor/golang.org/x/crypto/sha3/cshake_test.go
+++ b/vendor/golang.org/x/crypto/sha3/cshake_test.go
@@ -1,0 +1,95 @@
+package sha3
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// TODO:
+// - tests for leftEncode and rightEncode - current test vectors only test a handful of values.
+// - tests for cSHAKE(X,L,N=nil,S=nil) == SHAKE(X,L)
+
+// Test vectors from http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/cSHAKE_samples.pdf
+func TestCShakeNISTSample1(t *testing.T) {
+	shake := NewCShake128([]byte(""), []byte("Email Signature"))
+	shake.Write([]byte{0x00, 0x01, 0x02, 0x03})
+	output := make([]byte, 32)
+	shake.Read(output)
+	expected := strings.Replace("C1 C3 69 25 B6 40 9A 04 F1 B5 04 FC BC A9 D8 2B 40 17 27 7C B5 ED 2B 20 65 FC 1D 38 14 D5 AA F5", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestCShakeNISTSample1: got %s, want %s", got, expected)
+	}
+}
+
+func TestCShakeNISTSample2(t *testing.T) {
+	shake := NewCShake128([]byte(""), []byte("Email Signature"))
+	data := make([]byte, 1600/8) // 1600 bits: "00 01 02 03 .. C4 C5 C6 C7"
+	for i := byte(0); i <= 0xc7; i++ {
+		data[i] = i
+	}
+	shake.Write(data)
+	output := make([]byte, 32)
+	shake.Read(output)
+	expected := strings.Replace("C5 22 1D 50 E4 F8 22 D9 6A 2E 88 81 A9 61 42 0F 29 4B 7B 24 FE 3D 20 94 BA ED 2C 65 24 CC 16 6B", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestCShakeNISTSample2: got %s, want %s", got, expected)
+	}
+}
+
+func TestCShakeNISTSample3(t *testing.T) {
+	shake := NewCShake256([]byte(""), []byte("Email Signature"))
+	shake.Write([]byte{0x00, 0x01, 0x02, 0x03})
+	output := make([]byte, 64)
+	shake.Read(output)
+	expected := strings.Replace("D0 08 82 8E 2B 80 AC 9D 22 18 FF EE 1D 07 0C 48 B8 E4 C8 7B FF 32 C9 69 9D 5B 68 96 EE E0 ED D1 64 02 0E 2B E0 56 08 58 D9 C0 0C 03 7E 34 A9 69 37 C5 61 A7 4C 41 2B B4 C7 46 46 95 27 28 1C 8C", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestCShakeNISTSample3: got %s, want %s", got, expected)
+	}
+}
+
+func TestCShakeNISTSample4(t *testing.T) {
+	shake := NewCShake256([]byte(""), []byte("Email Signature"))
+	data := make([]byte, 1600/8) // 1600 bits: "00 01 02 03 .. C4 C5 C6 C7"
+	for i := byte(0); i <= 0xc7; i++ {
+		data[i] = i
+	}
+	shake.Write(data)
+	output := make([]byte, 64)
+	shake.Read(output)
+	expected := strings.Replace("07 DC 27 B1 1E 51 FB AC 75 BC 7B 3C 1D 98 3E 8B 4B 85 FB 1D EF AF 21 89 12 AC 86 43 02 73 09 17 27 F4 2B 17 ED 1D F6 3E 8E C1 18 F0 4B 23 63 3C 1D FB 15 74 C8 FB 55 CB 45 DA 8E 25 AF B0 92 BB", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestCShakeNISTSample4: got %s, want %s", got, expected)
+	}
+}
+
+func BenchmarkLeftEncode(b *testing.B) {
+	d := &state{rate: 104, outputLen: 48, dsbyte: 0x06}
+	for i := 0; i < b.N; i++ {
+		leftEncode(d, 12345)
+	}
+}
+
+func BenchmarkRightEncode(b *testing.B) {
+	d := &state{rate: 104, outputLen: 48, dsbyte: 0x06}
+	for i := 0; i < b.N; i++ {
+		rightEncode(d, 12345)
+	}
+}
+
+func BenchmarkEncodeString(b *testing.B) {
+	d := &state{rate: 104, outputLen: 48, dsbyte: 0x06}
+	s := []byte("foo")
+	for i := 0; i < b.N; i++ {
+		encodeString(d, s)
+	}
+}
+
+func BenchmarkInitCShake(b *testing.B) {
+	d := &state{rate: 104, outputLen: 48, dsbyte: 0x06}
+	N := []byte("foo")
+	S := []byte("bar")
+	for i := 0; i < b.N; i++ {
+		d.initCShake(N, S)
+	}
+}

--- a/vendor/golang.org/x/crypto/sha3/kmac.go
+++ b/vendor/golang.org/x/crypto/sha3/kmac.go
@@ -1,0 +1,94 @@
+package sha3
+
+import "hash"
+
+type kmac struct { // implements hash.Hash and ShakeHash
+	d             *state
+	lengthEmitted bool
+}
+
+// NewKMAC128 creates an instance of Hash with a given key,
+// output length in bytes and a customization string s.
+func NewKMAC128(key []byte, length int, s []byte) hash.Hash {
+	return newKMAC(128, key, length, s)
+}
+
+// NewKMAC256 creates an instance of Hash with a given key,
+// output length in bytes and a customization string s.
+func NewKMAC256(key []byte, length int, s []byte) hash.Hash {
+	return newKMAC(256, key, length, s)
+}
+
+// NewKMACXOF128 provides an arbitrary-length output.
+func NewKMACXOF128(key []byte, s []byte) ShakeHash {
+	return newKMAC(128, key, 0, s)
+}
+
+// NewKMACXOF256 provides an arbitrary-length output.
+func NewKMACXOF256(key []byte, s []byte) ShakeHash {
+	return newKMAC(256, key, 0, s)
+}
+
+// BlockSize returns the rate of sponge underlying this hash function.
+func (k *kmac) BlockSize() int { return k.d.rate }
+
+// Size returns the output size of the hash function in bytes.
+func (k *kmac) Size() int { return k.d.outputLen }
+
+func (k *kmac) Reset() {
+	k.lengthEmitted = false
+	k.d.Reset()
+}
+
+func (k *kmac) Clone() ShakeHash {
+	return k.clone()
+}
+
+func (k *kmac) Write(p []byte) (written int, err error) {
+	return k.d.Write(p)
+}
+
+func (k *kmac) Read(out []byte) (n int, err error) {
+	n = 0
+	if !k.lengthEmitted {
+		n = k.encodeOutputLength()
+		k.lengthEmitted = true
+	}
+	m, err := k.d.Read(out)
+	return n + m, err
+}
+
+// Sum applies padding to the hash state and then squeezes out the desired
+// number of output bytes.
+func (k *kmac) Sum(in []byte) []byte {
+	// Make a copy of the original hash so that caller can keep writing
+	// and summing.
+	dup := k.clone()
+	hash := make([]byte, dup.d.outputLen)
+	dup.Read(hash)
+	return append(in, hash...)
+}
+
+func newKMAC(securitybits int, key []byte, length int, s []byte) *kmac {
+	k := kmac{d: newCShake(securitybits, []byte("KMAC"), s)}
+
+	k.d.outputLen = length
+
+	// bytepad(encode_string(K), 168):
+	var n int
+	n += leftEncode(k.d, uint64(k.d.rate))
+	n += encodeString(k.d, key)
+	k.d.Write(zero[:k.d.rate-(n%k.d.rate)])
+
+	return &k
+}
+
+func (k *kmac) encodeOutputLength() int {
+	return rightEncode(k.d, uint64(8*k.d.outputLen))
+}
+
+func (k *kmac) clone() *kmac {
+	k2 := *k
+	k2.d = k2.d.clone()
+	return &k2
+}

--- a/vendor/golang.org/x/crypto/sha3/kmac_test.go
+++ b/vendor/golang.org/x/crypto/sha3/kmac_test.go
@@ -1,0 +1,197 @@
+package sha3
+
+// Test vectors from:
+// - http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/KMAC_samples.pdf
+// - http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/KMACXOF_samples.pdf
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func TestKMACNISTSample1(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := []byte{0x00, 0x01, 0x02, 0x03}
+	outputLength := 32
+	hash := NewKMAC128(key, outputLength, []byte{})
+	hash.Write(data)
+	output := make([]byte, outputLength)
+	hash.Sum(output[:0])
+	expected := strings.Replace("E5 78 0B 0D 3E A6 F7 D3 A4 29 C5 70 6A A4 3A 00 FA DB D7 D4 96 28 83 9E 31 87 24 3F 45 6E E1 4E", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACNISTSample1: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACNISTSample2(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := []byte{0x00, 0x01, 0x02, 0x03}
+	outputLength := 32
+	hash := NewKMAC128(key, outputLength, []byte("My Tagged Application"))
+	hash.Write(data)
+	output := make([]byte, outputLength)
+	hash.Sum(output[:0])
+	expected := strings.Replace("3B 1F BA 96 3C D8 B0 B5 9E 8C 1A 6D 71 88 8B 71 43 65 1A F8 BA 0A 70 70 C0 97 9E 28 11 32 4A A5", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACNISTSample2: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACNISTSample3(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := make([]byte, 1600/8) // 1600 bits: "00 01 02 03 .. C4 C5 C6 C7"
+	for i := byte(0); i <= 0xc7; i++ {
+		data[i] = i
+	}
+	outputLength := 32
+	hash := NewKMAC128(key, outputLength, []byte("My Tagged Application"))
+	hash.Write(data)
+	output := make([]byte, outputLength)
+	hash.Sum(output[:0])
+	expected := strings.Replace("1F 5B 4E 6C CA 02 20 9E 0D CB 5C A6 35 B8 9A 15 E2 71 EC C7 60 07 1D FD 80 5F AA 38 F9 72 92 30", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACNISTSample3: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACNISTSample4(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := []byte{0x00, 0x01, 0x02, 0x03}
+	outputLength := 64
+	hash := NewKMAC256(key, outputLength, []byte("My Tagged Application"))
+	hash.Write(data)
+	output := make([]byte, outputLength)
+	hash.Sum(output[:0])
+	expected := strings.Replace("20 C5 70 C3 13 46 F7 03 C9 AC 36 C6 1C 03 CB 64 C3 97 0D 0C FC 78 7E 9B 79 59 9D 27 3A 68 D2 F7 F6 9D 4C C3 DE 9D 10 4A 35 16 89 F2 7C F6 F5 95 1F 01 03 F3 3F 4F 24 87 10 24 D9 C2 77 73 A8 DD", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACNISTSample4: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACNISTSample5(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := make([]byte, 1600/8) // 1600 bits: "00 01 02 03 .. C4 C5 C6 C7"
+	for i := byte(0); i <= 0xc7; i++ {
+		data[i] = i
+	}
+	outputLength := 64
+	hash := NewKMAC256(key, outputLength, []byte{})
+	hash.Write(data)
+	output := make([]byte, outputLength)
+	hash.Sum(output[:0])
+	expected := strings.Replace("75 35 8C F3 9E 41 49 4E 94 97 07 92 7C EE 0A F2 0A 3F F5 53 90 4C 86 B0 8F 21 CC 41 4B CF D6 91 58 9D 27 CF 5E 15 36 9C BB FF 8B 9A 4C 2E B1 78 00 85 5D 02 35 FF 63 5D A8 25 33 EC 6B 75 9B 69", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACNISTSample5: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACNISTSample6(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := make([]byte, 1600/8) // 1600 bits: "00 01 02 03 .. C4 C5 C6 C7"
+	for i := byte(0); i <= 0xc7; i++ {
+		data[i] = i
+	}
+	outputLength := 64
+	hash := NewKMAC256(key, outputLength, []byte("My Tagged Application"))
+	hash.Write(data)
+	output := make([]byte, outputLength)
+	hash.Sum(output[:0])
+	expected := strings.Replace("B5 86 18 F7 1F 92 E1 D5 6C 1B 8C 55 DD D7 CD 18 8B 97 B4 CA 4D 99 83 1E B2 69 9A 83 7D A2 E4 D9 70 FB AC FD E5 00 33 AE A5 85 F1 A2 70 85 10 C3 2D 07 88 08 01 BD 18 28 98 FE 47 68 76 FC 89 65", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACNISTSample6: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACXOFNISTSample1(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := []byte{0x00, 0x01, 0x02, 0x03}
+	outputLength := 32
+	shake := NewKMACXOF128(key, []byte{})
+	shake.Write(data)
+	output := make([]byte, outputLength)
+	shake.Read(output)
+	expected := strings.Replace("CD 83 74 0B BD 92 CC C8 CF 03 2B 14 81 A0 F4 46 0E 7C A9 DD 12 B0 8A 0C 40 31 17 8B AC D6 EC 35", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACXOFNISTSample1: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACXOFNISTSample2(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := []byte{0x00, 0x01, 0x02, 0x03}
+	outputLength := 32
+	shake := NewKMACXOF128(key, []byte("My Tagged Application"))
+	shake.Write(data)
+	output := make([]byte, outputLength)
+	shake.Read(output)
+	expected := strings.Replace("31 A4 45 27 B4 ED 9F 5C 61 01 D1 1D E6 D2 6F 06 20 AA 5C 34 1D EF 41 29 96 57 FE 9D F1 A3 B1 6C", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACXOFNISTSample2: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACXOFNISTSample3(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := make([]byte, 1600/8) // 1600 bits: "00 01 02 03 .. C4 C5 C6 C7"
+	for i := byte(0); i <= 0xc7; i++ {
+		data[i] = i
+	}
+	outputLength := 32
+	shake := NewKMACXOF128(key, []byte("My Tagged Application"))
+	shake.Write(data)
+	output := make([]byte, outputLength)
+	shake.Read(output)
+	expected := strings.Replace("47 02 6C 7C D7 93 08 4A A0 28 3C 25 3E F6 58 49 0C 0D B6 14 38 B8 32 6F E9 BD DF 28 1B 83 AE 0F", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACXOFNISTSample3: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACXOFNISTSample4(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := []byte{0x00, 0x01, 0x02, 0x03}
+	outputLength := 64
+	shake := NewKMACXOF256(key, []byte("My Tagged Application"))
+	shake.Write(data)
+	output := make([]byte, outputLength)
+	shake.Read(output)
+	expected := strings.Replace("17 55 13 3F 15 34 75 2A AD 07 48 F2 C7 06 FB 5C 78 45 12 CA B8 35 CD 15 67 6B 16 C0 C6 64 7F A9 6F AA 7A F6 34 A0 BF 8F F6 DF 39 37 4F A0 0F AD 9A 39 E3 22 A7 C9 20 65 A6 4E B1 FB 08 01 EB 2B", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACXOFNISTSample4: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACXOFNISTSample5(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := make([]byte, 1600/8) // 1600 bits: "00 01 02 03 .. C4 C5 C6 C7"
+	for i := byte(0); i <= 0xc7; i++ {
+		data[i] = i
+	}
+	outputLength := 64
+	shake := NewKMACXOF256(key, []byte{})
+	shake.Write(data)
+	output := make([]byte, outputLength)
+	shake.Read(output)
+	expected := strings.Replace("FF 7B 17 1F 1E 8A 2B 24 68 3E ED 37 83 0E E7 97 53 8B A8 DC 56 3F 6D A1 E6 67 39 1A 75 ED C0 2C A6 33 07 9F 81 CE 12 A2 5F 45 61 5E C8 99 72 03 1D 18 33 73 31 D2 4C EB 8F 8C A8 E6 A1 9F D9 8B", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACXOFNISTSample5: got %s, want %s", got, expected)
+	}
+}
+
+func TestKMACXOFNISTSample6(t *testing.T) {
+	key, _ := hex.DecodeString(strings.Replace("40 41 42 43 44 45 46 47 48 49 4A 4B 4C 4D 4E 4F 50 51 52 53 54 55 56 57 58 59 5A 5B 5C 5D 5E 5F", " ", "", -1))
+	data := make([]byte, 1600/8) // 1600 bits: "00 01 02 03 .. C4 C5 C6 C7"
+	for i := byte(0); i <= 0xc7; i++ {
+		data[i] = i
+	}
+	outputLength := 64
+	shake := NewKMACXOF256(key, []byte("My Tagged Application"))
+	shake.Write(data)
+	output := make([]byte, outputLength)
+	shake.Read(output)
+	expected := strings.Replace("D5 BE 73 1C 95 4E D7 73 28 46 BB 59 DB E3 A8 E3 0F 83 E7 7A 4B FF 44 59 F2 F1 C2 B4 EC EB B8 CE 67 BA 01 C6 2E 8A B8 57 8D 2D 49 9B D1 BB 27 67 68 78 11 90 02 0A 30 6A 97 DE 28 1D CC 30 30 5D", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestKMACXOFNISTSample5: got %s, want %s", got, expected)
+	}
+}

--- a/vendor/golang.org/x/crypto/sha3/sha3.go
+++ b/vendor/golang.org/x/crypto/sha3/sha3.go
@@ -42,9 +42,12 @@ type state struct {
 	storage [maxRate]byte
 
 	// Specific to SHA-3 and SHAKE.
-	fixedOutput bool            // whether this is a fixed-ouput-length instance
+	fixedOutput bool            // whether this is a fixed-output-length instance
 	outputLen   int             // the default output size in bytes
 	state       spongeDirection // whether the sponge is absorbing or squeezing
+
+	// Specific to cSHAKE.
+	varintbuf [9]byte // temporary space for encoding integers in cSHAKE functions
 }
 
 // BlockSize returns the rate of sponge underlying this hash function.

--- a/vendor/golang.org/x/crypto/sha3/tuple_hash.go
+++ b/vendor/golang.org/x/crypto/sha3/tuple_hash.go
@@ -1,0 +1,41 @@
+package sha3
+
+import "io"
+
+// TupleHash128 hashes a tuple with a given customization string s.
+// Output is written to `out`. len(out) determines the output size.
+func TupleHash128(tuple [][]byte, s []byte, out []byte) {
+	shake := newTupleHash(128, tuple, s)
+	rightEncode(shake, uint64(len(out)*8))
+	shake.Read(out)
+}
+
+// TupleHash256 hashes a tuple with a given customization string s.
+// Output is written to `out`. len(out) determines the output size.
+func TupleHash256(tuple [][]byte, s []byte, out []byte) {
+	shake := newTupleHash(256, tuple, s)
+	rightEncode(shake, uint64(len(out)*8))
+	shake.Read(out)
+}
+
+// TupleHashXOF128 provides an arbitrary-length output.
+func TupleHashXOF128(tuple [][]byte, s []byte) io.Reader {
+	shake := newTupleHash(128, tuple, s)
+	rightEncode(shake, 0)
+	return shake
+}
+
+// TupleHashXOF256 provides an arbitrary-length output.
+func TupleHashXOF256(tuple [][]byte, s []byte) io.Reader {
+	shake := newTupleHash(256, tuple, s)
+	rightEncode(shake, 0)
+	return shake
+}
+
+func newTupleHash(securitybits int, tuple [][]byte, s []byte) (d *state) {
+	d = newCShake(securitybits, []byte("TupleHash"), s)
+	for _, item := range tuple {
+		encodeString(d, item)
+	}
+	return d
+}

--- a/vendor/golang.org/x/crypto/sha3/tuple_hash_test.go
+++ b/vendor/golang.org/x/crypto/sha3/tuple_hash_test.go
@@ -1,0 +1,201 @@
+package sha3
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+// Test vectors from:
+// - http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/TupleHash_samples.pdf
+// - http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/TupleHashXOF_samples.pdf
+
+func TestTupleHashNISTSample1(t *testing.T) {
+	outputLength := 32
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+	}
+	S := []byte{}
+	output := make([]byte, outputLength)
+	TupleHash128(tuples, S, output)
+	expected := strings.Replace("C5 D8 78 6C 1A FB 9B 82 11 1A B3 4B 65 B2 C0 04 8F A6 4E 6D 48 E2 63 26 4C E1 70 7D 3F FC 8E D1", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashNISTSample1: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashNISTSample2(t *testing.T) {
+	outputLength := 32
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+	}
+	S := []byte("My Tuple App")
+	output := make([]byte, outputLength)
+	TupleHash128(tuples, S, output)
+	expected := strings.Replace("75 CD B2 0F F4 DB 11 54 E8 41 D7 58 E2 41 60 C5 4B AE 86 EB 8C 13 E7 F5 F4 0E B3 55 88 E9 6D FB", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashNISTSample2: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashNISTSample3(t *testing.T) {
+	outputLength := 32
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+		[]byte{0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28},
+	}
+	S := []byte("My Tuple App")
+	output := make([]byte, outputLength)
+	TupleHash128(tuples, S, output)
+	expected := strings.Replace("E6 0F 20 2C 89 A2 63 1E DA 8D 4C 58 8C A5 FD 07 F3 9E 51 51 99 8D EC CF 97 3A DB 38 04 BB 6E 84", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashNISTSample3: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashNISTSample4(t *testing.T) {
+	outputLength := 64
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+	}
+	S := []byte{}
+	output := make([]byte, outputLength)
+	TupleHash256(tuples, S, output)
+	expected := strings.Replace("CF B7 05 8C AC A5 E6 68 F8 1A 12 A2 0A 21 95 CE 97 A9 25 F1 DB A3 E7 44 9A 56 F8 22 01 EC 60 73 11 AC 26 96 B1 AB 5E A2 35 2D F1 42 3B DE 7B D4 BB 78 C9 AE D1 A8 53 C7 86 72 F9 EB 23 BB E1 94", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashNISTSample4: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashNISTSample5(t *testing.T) {
+	outputLength := 64
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+	}
+	S := []byte("My Tuple App")
+	output := make([]byte, outputLength)
+	TupleHash256(tuples, S, output)
+	expected := strings.Replace("14 7C 21 91 D5 ED 7E FD 98 DB D9 6D 7A B5 A1 16 92 57 6F 5F E2 A5 06 5F 3E 33 DE 6B BA 9F 3A A1 C4 E9 A0 68 A2 89 C6 1C 95 AA B3 0A EE 1E 41 0B 0B 60 7D E3 62 0E 24 A4 E3 BF 98 52 A1 D4 36 7E", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashNISTSample5: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashNISTSample6(t *testing.T) {
+	outputLength := 64
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+		[]byte{0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28},
+	}
+	S := []byte("My Tuple App")
+	output := make([]byte, outputLength)
+	TupleHash256(tuples, S, output)
+	expected := strings.Replace("45 00 0B E6 3F 9B 6B FD 89 F5 47 17 67 0F 69 A9 BC 76 35 91 A4 F0 5C 50 D6 88 91 A7 44 BC C6 E7 D6 D5 B5 E8 2C 01 8D A9 99 ED 35 B0 BB 49 C9 67 8E 52 6A BD 8E 85 C1 3E D2 54 02 1D B9 E7 90 CE", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashNISTSample6: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashXOFNISTSample1(t *testing.T) {
+	outputLength := 32
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+	}
+	S := []byte{}
+	h := TupleHashXOF128(tuples, S)
+	output := make([]byte, outputLength)
+	h.Read(output)
+	expected := strings.Replace("2F 10 3C D7 C3 23 20 35 34 95 C6 8D E1 A8 12 92 45 C6 32 5F 6F 2A 3D 60 8D 92 17 9C 96 E6 84 88", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashXOFNISTSample1: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashXOFNISTSample2(t *testing.T) {
+	outputLength := 32
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+	}
+	S := []byte("My Tuple App")
+	h := TupleHashXOF128(tuples, S)
+	output := make([]byte, outputLength)
+	h.Read(output)
+	expected := strings.Replace("3F C8 AD 69 45 31 28 29 28 59 A1 8B 6C 67 D7 AD 85 F0 1B 32 81 5E 22 CE 83 9C 49 EC 37 4E 9B 9A", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashXOFNISTSample2: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashXOFNISTSample3(t *testing.T) {
+	outputLength := 32
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+		[]byte{0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28},
+	}
+	S := []byte("My Tuple App")
+	h := TupleHashXOF128(tuples, S)
+	output := make([]byte, outputLength)
+	h.Read(output)
+	expected := strings.Replace("90 0F E1 6C AD 09 8D 28 E7 4D 63 2E D8 52 F9 9D AA B7 F7 DF 4D 99 E7 75 65 78 85 B4 BF 76 D6 F8", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashXOFNISTSample3: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashXOFNISTSample4(t *testing.T) {
+	outputLength := 64
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+	}
+	S := []byte{}
+	h := TupleHashXOF256(tuples, S)
+	output := make([]byte, outputLength)
+	h.Read(output)
+	expected := strings.Replace("03 DE D4 61 0E D6 45 0A 1E 3F 8B C4 49 51 D1 4F BC 38 4A B0 EF E5 7B 00 0D F6 B6 DF 5A AE 7C D5 68 E7 73 77 DA F1 3F 37 EC 75 CF 5F C5 98 B6 84 1D 51 DD 20 7C 99 1C D4 5D 21 0B A6 0A C5 2E B9", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashXOFNISTSample4: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashXOFNISTSample5(t *testing.T) {
+	outputLength := 64
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+	}
+	S := []byte("My Tuple App")
+	h := TupleHashXOF256(tuples, S)
+	output := make([]byte, outputLength)
+	h.Read(output)
+	expected := strings.Replace("64 83 CB 3C 99 52 EB 20 E8 30 AF 47 85 85 1F C5 97 EE 3B F9 3B B7 60 2C 0E F6 A6 5D 74 1A EC A7 E6 3C 3B 12 89 81 AA 05 C6 D2 74 38 C7 9D 27 54 BB 1B 71 91 F1 25 D6 62 0F CA 12 CE 65 8B 24 42", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashXOFNISTSample5: got %s, want %s", got, expected)
+	}
+}
+
+func TestTupleHashXOFNISTSample6(t *testing.T) {
+	outputLength := 64
+	tuples := [][]byte{
+		[]byte{0x00, 0x01, 0x02},
+		[]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+		[]byte{0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28},
+	}
+	S := []byte("My Tuple App")
+	h := TupleHashXOF256(tuples, S)
+	output := make([]byte, outputLength)
+	h.Read(output)
+	expected := strings.Replace("0C 59 B1 14 64 F2 33 6C 34 66 3E D5 1B 2B 95 0B EC 74 36 10 85 6F 36 C2 8D 1D 08 8D 8A 24 46 28 4D D0 98 30 A6 A1 78 DC 75 23 76 19 9F AE 93 5D 86 CF DE E5 91 3D 49 22 DF D3 69 B6 6A 53 C8 97", " ", "", -1)
+	if got := strings.ToUpper(hex.EncodeToString(output)); got != expected {
+		t.Errorf("TestTupleHashXOFNISTSample6: got %s, want %s", got, expected)
+	}
+}


### PR DESCRIPTION
Upstream SHA1: 01149f4f7c0fce7c9a9dde8465f684ed34bb5eb5

Upstream URL: https://github.com/chain/golang-crypto/tree/cshake/sha3

Requirement for Confidential Assets spec.

Discussion: https://groups.google.com/forum/#!topic/golang-dev/e2q_nHWGWyE