### PR TITLE
sdk/node/test: add per-object tests for queryAll

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3222";
+	public final String Id = "main/rev3224";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3222"
+const ID string = "main/rev3224"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3222"
+export const rev_id = "main/rev3224"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3222".freeze
+	ID = "main/rev3224".freeze
 end

--- a/sdk/node/test/accessTokens.js
+++ b/sdk/node/test/accessTokens.js
@@ -64,6 +64,24 @@ describe('Access token', () => {
       .then(resp => expect(resp.items.map(item => item.id)).to.not.contain(tokenId))
   })
 
+  describe('queryAll', () => {
+    it('success example', () => {
+      let created
+      const queried = []
+
+      return createToken().then(token =>
+        created = token
+      ).then(() =>
+        client.accessTokens.queryAll({}, (token, next, done) => {
+          queried.push(token)
+          next()
+        })
+      ).then(() =>
+        expect(queried.find(token => token.id == created.id)).to.be.an('object')
+      )
+    })
+  })
+
   describe('Deprecated syntax', () => {
     let clientTokenId, networkTokenId
 

--- a/sdk/node/test/accessTokens.js
+++ b/sdk/node/test/accessTokens.js
@@ -70,14 +70,14 @@ describe('Access token', () => {
       const queried = []
 
       return createToken().then(token =>
-        created = token
+        created = token.id
       ).then(() =>
         client.accessTokens.queryAll({}, (token, next, done) => {
-          queried.push(token)
+          queried.push(token.id)
           next()
         })
       ).then(() =>
-        expect(queried.find(token => token.id == created.id)).to.be.an('object')
+        expect(queried).to.include(created)
       )
     })
   })

--- a/sdk/node/test/accounts.js
+++ b/sdk/node/test/accounts.js
@@ -131,14 +131,14 @@ describe('Account', () => {
         rootXpubs: [mockHsmKey.xpub],
         quorum: 1
       }).then(account =>
-        created = account
+        created = account.id
       ).then(() =>
         client.accounts.queryAll({}, (account, next, done) => {
-          queried.push(account)
+          queried.push(account.id)
           next()
         })
       ).then(() =>
-        expect(queried.find(account => account.id == created.id)).to.be.an('object')
+        expect(queried).to.include(created)
       )
     })
   })

--- a/sdk/node/test/accounts.js
+++ b/sdk/node/test/accounts.js
@@ -122,6 +122,27 @@ describe('Account', () => {
     })
   })
 
+  describe('queryAll', () => {
+    it('success example', () => {
+      let created
+      const queried = []
+
+      return client.accounts.create({
+        rootXpubs: [mockHsmKey.xpub],
+        quorum: 1
+      }).then(account =>
+        created = account
+      ).then(() =>
+        client.accounts.queryAll({}, (account, next, done) => {
+          queried.push(account)
+          next()
+        })
+      ).then(() =>
+        expect(queried.find(account => account.id == created.id)).to.be.an('object')
+      )
+    })
+  })
+
   // These just test that the callback is engaged correctly. Behavior is
   // tested in the promises test.
   describe('Callback support', () => {

--- a/sdk/node/test/assets.js
+++ b/sdk/node/test/assets.js
@@ -131,14 +131,14 @@ describe('Asset', () => {
         rootXpubs: [mockHsmKey.xpub],
         quorum: 1
       }).then(asset =>
-        created = asset
+        created = asset.id
       ).then(() =>
         client.assets.queryAll({}, (asset, next, done) => {
-          queried.push(asset)
+          queried.push(asset.id)
           next()
         })
       ).then(() => {
-        expect(queried.find(asset => asset.id == created.id)).to.be.an('object')
+        expect(queried).to.include(created)
       })
     })
   })

--- a/sdk/node/test/assets.js
+++ b/sdk/node/test/assets.js
@@ -122,6 +122,27 @@ describe('Asset', () => {
     })
   })
 
+  describe('queryAll', () => {
+    it('success example', () => {
+      let created
+      const queried = []
+
+      return client.assets.create({
+        rootXpubs: [mockHsmKey.xpub],
+        quorum: 1
+      }).then(asset =>
+        created = asset
+      ).then(() =>
+        client.assets.queryAll({}, (asset, next, done) => {
+          queried.push(asset)
+          next()
+        })
+      ).then(() => {
+        expect(queried.find(asset => asset.id == created.id)).to.be.an('object')
+      })
+    })
+  })
+
   // These just test that the callback is engaged correctly. Behavior is
   // tested in the promises test.
   describe('Callback support', () => {

--- a/sdk/node/test/mockHsmKeys.js
+++ b/sdk/node/test/mockHsmKeys.js
@@ -36,6 +36,26 @@ describe('MockHSM key', () => {
       })
   })
 
+  describe('queryAll', () => {
+    it('success example', () => {
+      let created
+      const queried = []
+
+      return client.mockHsm.keys.create({
+        alias: uuid.v4()
+      }).then(key =>
+        created = key
+      ).then(() =>
+        client.mockHsm.keys.queryAll({}, (key, next, done) => {
+          queried.push(key)
+          next()
+        })
+      ).then(() => {
+        expect(queried.find(key => key.alias == created.alias)).to.be.an('object')
+      })
+    })
+  })
+
   // These just test that the callback is engaged correctly. Behavior is
   // tested in the promises test.
   describe('Callback style', () => {

--- a/sdk/node/test/mockHsmKeys.js
+++ b/sdk/node/test/mockHsmKeys.js
@@ -44,14 +44,14 @@ describe('MockHSM key', () => {
       return client.mockHsm.keys.create({
         alias: uuid.v4()
       }).then(key =>
-        created = key
+        created = key.alias
       ).then(() =>
         client.mockHsm.keys.queryAll({}, (key, next, done) => {
-          queried.push(key)
+          queried.push(key.alias)
           next()
         })
       ).then(() => {
-        expect(queried.find(key => key.alias == created.alias)).to.be.an('object')
+        expect(queried).to.include(created)
       })
     })
   })

--- a/sdk/node/test/transactionFeeds.js
+++ b/sdk/node/test/transactionFeeds.js
@@ -126,14 +126,14 @@ describe('Transaction feed', () => {
       const queried = []
 
       return client.transactionFeeds.create({}).then(txfeed =>
-        created = txfeed
+        created = txfeed.id
       ).then(() =>
         client.transactionFeeds.queryAll({}, (txfeed, next, done) => {
-          queried.push(txfeed)
+          queried.push(txfeed.id)
           next()
         })
       ).then(() => {
-        expect(queried.find(txfeed => txfeed.id == created.id)).to.be.an('object')
+        expect(queried).to.include(created)
       })
     })
   })

--- a/sdk/node/test/transactionFeeds.js
+++ b/sdk/node/test/transactionFeeds.js
@@ -120,6 +120,24 @@ describe('Transaction feed', () => {
       })
   })
 
+  describe('queryAll', () => {
+    it('success example', () => {
+      let created
+      const queried = []
+
+      return client.transactionFeeds.create({}).then(txfeed =>
+        created = txfeed
+      ).then(() =>
+        client.transactionFeeds.queryAll({}, (txfeed, next, done) => {
+          queried.push(txfeed)
+          next()
+        })
+      ).then(() => {
+        expect(queried.find(txfeed => txfeed.id == created.id)).to.be.an('object')
+      })
+    })
+  })
+
   // These just test that the callback is engaged correctly. Behavior is
   // tested in the promises test.
   describe('Callback support', () => {

--- a/sdk/node/test/transactions.js
+++ b/sdk/node/test/transactions.js
@@ -207,14 +207,14 @@ describe('Transaction', () => {
       ).then(signed =>
         client.transactions.submit(signed)
       ).then(tx =>
-        created = tx
+        created = tx.id
       ).then(() =>
         client.transactions.queryAll({}, (tx, next, done) => {
-          queried.push(tx)
+          queried.push(tx.id)
           next()
         })
       ).then(() => {
-        expect(queried.find(tx => tx.id == created.id)).to.be.an('object')
+        expect(queried).to.include(created)
       })
     })
   })

--- a/sdk/node/test/transactions.js
+++ b/sdk/node/test/transactions.js
@@ -8,7 +8,7 @@ const chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
-import { balanceByAssetAlias, client, createAccount, createAsset, signer } from '../testHelpers/util'
+const { balanceByAssetAlias, client, createAccount, createAsset, signer } = require('../testHelpers/util')
 
 describe('Transaction', () => {
 
@@ -67,7 +67,7 @@ describe('Transaction', () => {
     let goldAlias, silverAlias, aliceAlias, bobAlias
 
     before(() => {
-      return  Promise.all([
+      return Promise.all([
         createAsset('gold'),
         createAsset('silver'),
         createAccount('alice'),
@@ -183,6 +183,40 @@ describe('Transaction', () => {
     )
     .then(issuance => signer.sign(issuance))
     .then(signed => expect(client.transactions.submit(signed)).to.be.rejectedWith('CH735'))
+  })
+
+  describe('queryAll', () => {
+    it('success example', () => {
+      let created
+      const queried = []
+
+      return Promise.all([
+        createAsset(),
+        createAccount()
+      ]).then(([asset, account]) =>
+        client.transactions.build(builder => {
+          builder.issue({assetAlias: asset.alias, amount: 1})
+          builder.controlWithAccount({
+            accountAlias: account.alias,
+            assetAlias: asset.alias,
+            amount: 1
+          })
+        })
+      ).then(txtpl =>
+        signer.sign(txtpl)
+      ).then(signed =>
+        client.transactions.submit(signed)
+      ).then(tx =>
+        created = tx
+      ).then(() =>
+        client.transactions.queryAll({}, (tx, next, done) => {
+          queried.push(tx)
+          next()
+        })
+      ).then(() => {
+        expect(queried.find(tx => tx.id == created.id)).to.be.an('object')
+      })
+    })
   })
 
   // These just test that the callback is engaged correctly. Behavior is


### PR DESCRIPTION
Does not include tests for objects that don't have individual test files
yet:

- utxos
- balances