### PR TITLE
dashboard: remove markdown dependency

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -35,7 +35,6 @@
     "react-autosuggest": "~6.0.4",
     "react-bootstrap": "~0.30.3",
     "react-dom": "~15.5.0",
-    "react-markdown": "^2.5.0",
     "react-redux": "~4.4.5",
     "react-router": "~2.6.0",
     "react-router-redux": "~4.0.5",

--- a/dashboard/src/features/shared/components/SelectField.jsx
+++ b/dashboard/src/features/shared/components/SelectField.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import FieldLabel from './FieldLabel/FieldLabel'
 import pick from 'lodash/pick'
-import ReactMarkdown from 'react-markdown'
 
 const SELECT_FIELD_PROPS = [
   'value',
@@ -35,7 +34,7 @@ class SelectField extends React.Component {
         </select>
 
         {touched && error && <span className='text-danger'><strong>{error}</strong></span>}
-        {this.props.hint && <span className='help-block'><ReactMarkdown source={this.props.hint} /></span>}
+        {this.props.hint && <span className='help-block'>{this.props.hint}</span>}
       </div>
     )
   }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3224";
+	public final String Id = "main/rev3225";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3224"
+const ID string = "main/rev3225"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3224"
+export const rev_id = "main/rev3225"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3224".freeze
+	ID = "main/rev3225".freeze
 end


### PR DESCRIPTION
An earlier design used markdown formatting for
conveying important information. It has since been
redesigned.