### PR TITLE
database/raft: save snapshot position first

### DIFF
--- a/database/raft/raft.go
+++ b/database/raft/raft.go
@@ -666,14 +666,14 @@ func (sv *Service) join(addr, baseURL string) (*wal.WAL, error) {
 	}
 
 	if !raft.IsEmptySnap(raftSnap) {
-		err := sv.saveSnapshot(&raftSnap)
-		if err != nil {
-			return nil, errors.Wrap(err)
-		}
-		err = wal.SaveSnapshot(walpb.Snapshot{
+		err := wal.SaveSnapshot(walpb.Snapshot{
 			Index: raftSnap.Metadata.Index,
 			Term:  raftSnap.Metadata.Term,
 		})
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+		err = sv.saveSnapshot(&raftSnap)
 		if err != nil {
 			return nil, errors.Wrap(err)
 		}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "1.2-stable/rev3137";
+	public final String Id = "1.2-stable/rev3138";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.2-stable/rev3137"
+const ID string = "1.2-stable/rev3138"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "1.2-stable/rev3137"
+export const rev_id = "1.2-stable/rev3138"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "1.2-stable/rev3137".freeze
+	ID = "1.2-stable/rev3138".freeze
 end


### PR DESCRIPTION
Save the snapshot position to the WAL before saving the snapshot data to
disk. On boot, we open the WAL at the most recently saved snapshot's
position. If we don't save the position to the WAL first, we might open
the WAL at a snapshot position that was never saved to the WAL.

This is a fix for the 1.2.x release line.

See coreos/etcd#8082, coreos/etcd#8088.