### PR TITLE
net/tls.go: Prefer X25519 over NIST P-256

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3237";
+	public final String Id = "main/rev3238";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3237"
+const ID string = "main/rev3238"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3237"
+export const rev_id = "main/rev3238"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3237".freeze
+	ID = "main/rev3238".freeze
 end

--- a/net/tls.go
+++ b/net/tls.go
@@ -14,8 +14,8 @@ func DefaultTLSConfig() *tls.Config {
 		PreferServerCipherSuites: true,
 		// Only use curves which have constant-time implementations
 		CurvePreferences: []tls.CurveID{
-			tls.CurveP256,
 			tls.X25519,
+			tls.CurveP256,
 		},
 	}
 }


### PR DESCRIPTION
X25519 should be faster and less likely to experience timing sidechannels.
(See CVE-2016-7056 for a recent practical key recovery attack against P-256)