### PR TITLE
sdk/node: ensure Node 4 compatibility

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3238";
+	public final String Id = "main/rev3239";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3238"
+const ID string = "main/rev3239"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3238"
+export const rev_id = "main/rev3239"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3238".freeze
+	ID = "main/rev3239".freeze
 end

--- a/sdk/node/src/util.js
+++ b/sdk/node/src/util.js
@@ -17,7 +17,7 @@ const sanitizeX509GuardData = guardData => {
   }
 
   const newSubject = {}
-  const oldSubject = Object.values(guardData)[0]
+  const oldSubject = guardData[keys[0]]
   for (let k in oldSubject) {
     const attrib = x509SubjectAttributes[k.toUpperCase()]
     if (!attrib) {


### PR DESCRIPTION
Removes the use of functions that are not compatible with Node 4.x.