### PR TITLE
wercker.yml: make branch compatible with node pipeline

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "1.1-stable/rev2767";
+	public final String Id = "1.1-stable/rev2768";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.1-stable/rev2767"
+const ID string = "1.1-stable/rev2768"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "1.1-stable/rev2767"
+export const rev_id = "1.1-stable/rev2768"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "1.1-stable/rev2767".freeze
+	ID = "1.1-stable/rev2768".freeze
 end

--- a/wercker.yml
+++ b/wercker.yml
@@ -41,6 +41,9 @@ java:
         code: |
           run-jfmt
 
+node:
+  steps: []
+
 ruby:
   steps:
     - bundle-install:


### PR DESCRIPTION
Wercker requires a pipeline specification in wercker.yml (however
trivial) to publish successful statuses to a PR. We are not backporting
Node SDK updates to older branches (yet), but this will allow us to
publish Node integration test statuses to PRs that merge into the
1.1-stable branch.