### PR TITLE
bin/ccde-build-tags: new manifest for build tags

### DIFF
--- a/bin/ccde-build-tags
+++ b/bin/ccde-build-tags
@@ -1,0 +1,1 @@
+insecure_disable_https_redirect


### PR DESCRIPTION
Add build tags for Chain Core Developer Edition on this branch.