### PR TITLE
net/raft: wait for ConfChange to be applied

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3242";
+	public final String Id = "main/rev3243";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3242"
+const ID string = "main/rev3243"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3242"
+export const rev_id = "main/rev3243"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3242".freeze
+	ID = "main/rev3243".freeze
 end


### PR DESCRIPTION
When adding a new node to the cluster, wait for the conf change to be
committed and applied before taking a state snapshot and responding
to the new node.

Previously, Join had a race condition between the application of the
conf change entry and the taking of the snapshot. If the snapshot was
taken before the conf change was committed or applied, the new node
would try to boot its state machine from a state that did not include
itself in the configuration. It could mistakeningly think that it is a
single-node cluster and try to elect itself, panicking when its node
id doesn't exist in the progress list: See issue #1330.

Waiting for the conf change to be applied ensures that:
* The /raft/join endpoint only returns if adding the node to the cluster
  was committed.
* The snapshot returned from the /raft/join endpoint includes the new
  node in its configuration.

An alternative we might want to consider later: Return the peer list
from /raft/join and pass it to StartNode along with the new node ID
appended. This would remove the requirement of booting from a very fresh
snapshot. This is how etcd boots new nodes:
https://github.com/coreos/etcd/blob/750dc7f157c2d13e9b7d229ad749c1a4d62b0def/etcdserver/raft.go#L394-L400