### PR TITLE
database/raft: wait for ConfChange to be applied

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "1.2-stable/rev3139";
+	public final String Id = "1.2-stable/rev3140";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "1.2-stable/rev3139"
+const ID string = "1.2-stable/rev3140"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "1.2-stable/rev3139"
+export const rev_id = "1.2-stable/rev3140"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "1.2-stable/rev3139".freeze
+	ID = "1.2-stable/rev3140".freeze
 end


### PR DESCRIPTION
When adding a new node to the cluster, wait for the conf change to be
committed and applied before taking a state snapshot and responding
to the new node.

Previously, Join had a race condition between the application of the
conf change entry and the taking of the snapshot. If the snapshot was
taken before the conf change was committed or applied, the new node
would try to boot its state machine from a state that did not include
itself in the configuration. It could mistakeningly think that it is a
single-node cluster and try to elect itself, panicking when its node
id doesn't exist in the progress list: See issue #1330.

Waiting for the conf change to be applied ensures that:
* The /raft/join endpoint only returns if adding the node to the cluster
  was committed.
* The snapshot returned from the /raft/join endpoint includes the new
  node in its configuration.

This is a backport fix for the 1.2.x release line.