### PR TITLE
net/raft: add unit test for cluster setup

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3254";
+	public final String Id = "main/rev3255";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3254"
+const ID string = "main/rev3255"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3254"
+export const rev_id = "main/rev3255"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3254".freeze
+	ID = "main/rev3255".freeze
 end

--- a/net/raft/raft_test.go
+++ b/net/raft/raft_test.go
@@ -2,11 +2,15 @@ package raft
 
 import (
 	"bytes"
+	"chain/net"
 	"context"
+	"crypto/x509"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -115,4 +119,120 @@ func TestStartUninitialized(t *testing.T) {
 	if err != ErrUninitialized {
 		t.Errorf("sv.Exec() = %s, want %s", err, ErrUninitialized)
 	}
+}
+
+func TestClusterSetup(t *testing.T) {
+	ctx := context.Background()
+
+	// Create three uninitialized raft services.
+	nodeA := newTestNode(t)
+	defer nodeA.cleanup()
+	nodeB := newTestNode(t)
+	defer nodeB.cleanup()
+	nodeC := newTestNode(t)
+	defer nodeC.cleanup()
+
+	// Initialize A, creating a fresh cluster.
+	must(t, nodeA.service.Init())
+
+	// Update the cluster to allow A, B and C's addresses.
+	var err error
+	_, err = nodeA.service.Exec(ctx, set("/allowed/"+nodeA.addr, "yes"))
+	must(t, err)
+	_, err = nodeA.service.Exec(ctx, set("/allowed/"+nodeB.addr, "yes"))
+	must(t, err)
+	_, err = nodeA.service.Exec(ctx, set("/allowed/"+nodeC.addr, "yes"))
+	must(t, err)
+
+	// Add B and C to the cluster.
+	must(t, nodeB.service.Join("https://"+nodeA.addr))
+	must(t, nodeC.service.Join("https://"+nodeA.addr))
+
+	// Try setting a value on nodeB.
+	_, err = nodeB.service.Exec(ctx, set("/foo", "bar"))
+	must(t, err)
+
+	// Try reading the value on nodeC's state.
+	must(t, nodeC.service.WaitRead(ctx))
+	got := nodeC.state.Data["/foo"]
+	if got != "bar" {
+		t.Errorf("reading /foo, nodeC got %q want %q", got, "bar")
+	}
+}
+
+func must(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type testNode struct {
+	dir    string
+	addr   string
+	server *httptest.Server
+	state  *state
+
+	wg      sync.WaitGroup
+	service *Service
+}
+
+func (n *testNode) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	n.wg.Wait()
+	n.service.ServeHTTP(rw, req)
+}
+
+func (n *testNode) cleanup() {
+	os.RemoveAll(n.dir)
+	n.server.Close()
+	// TODO(jackson): stop the Service too
+}
+
+// newTestNode creates a new local raft Service listening on a random
+// port on localhost. It uses the stdlib's httptest package's localhost
+// TLS certificates in both its server and client tls configs. It uses
+// a simple test kv store implementation for the raft Service's state.
+//
+// When finished with a node, call its cleanup method to stop the server
+// and remove its data directory.
+func newTestNode(t *testing.T) *testNode {
+	node := new(testNode)
+	node.wg.Add(1)
+
+	var err error
+	node.dir, err = ioutil.TempDir("", "raft_test.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a tls server first so that we can retrieve the address
+	// and tls certificates to pass in to raft.Start.
+	node.server = httptest.NewTLSServer(node)
+	node.addr = node.server.Listener.Addr().String()
+	node.state = newTestState()
+
+	// TODO(jackson): In Go 1.9+ use ts.Client()?:
+	cert, err := x509.ParseCertificate(node.server.TLS.Certificates[0].Certificate[0])
+	if err != nil {
+		node.cleanup()
+		t.Fatal(err)
+	}
+	tlsConfig := net.DefaultTLSConfig()
+	tlsConfig.RootCAs = x509.NewCertPool()
+	tlsConfig.RootCAs.AddCert(cert)
+	tlsConfig.Certificates = node.server.TLS.Certificates
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+
+	// Create the raft service, passing in the server's address
+	node.service, err = Start(node.addr, node.dir, httpClient, node.state)
+	if err != nil {
+		node.cleanup()
+		t.Fatal(err)
+	}
+
+	node.wg.Done()
+	return node
 }

--- a/net/raft/raft_test.go
+++ b/net/raft/raft_test.go
@@ -178,9 +178,9 @@ func (n *testNode) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 }
 
 func (n *testNode) cleanup() {
-	os.RemoveAll(n.dir)
 	n.server.Close()
-	// TODO(jackson): stop the Service too
+	n.service.Stop()
+	os.RemoveAll(n.dir)
 }
 
 // newTestNode creates a new local raft Service listening on a random

--- a/net/raft/state_test.go
+++ b/net/raft/state_test.go
@@ -1,0 +1,119 @@
+package raft
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+func newTestState() *state {
+	return &state{
+		NodeIDCounter: 2,
+		Peers:         make(map[uint64]string),
+		Data:          make(map[string]string),
+	}
+}
+
+// state provides a simple implementation of the State interface so that
+// internal tests within this package can create and destroy clusters. It
+// implements a really primitive kv store. Instructions and snapshots are
+// encoded using the stdlib gob package. A snapshot is just a gob-encoded
+// state struct.
+type state struct {
+	NodeIDCounter uint64
+	Index         uint64
+	Peers         map[uint64]string
+	Data          map[string]string
+}
+
+func (s *state) AppliedIndex() uint64 {
+	return s.Index
+}
+
+func (s *state) SetAppliedIndex(index uint64) {
+	s.Index = index
+}
+
+func (s *state) SetPeerAddr(id uint64, addr string) {
+	s.Peers[id] = addr
+}
+
+func (s *state) GetPeerAddr(id uint64) (addr string) {
+	return s.Peers[id]
+}
+
+func (s *state) RemovePeerAddr(id uint64) {
+	delete(s.Peers, id)
+}
+
+func (s *state) IsAllowedMember(addr string) bool {
+	_, ok := s.Data["/allowed/"+addr]
+	return ok
+}
+
+func (s *state) EmptyWrite() []byte {
+	return encodeInstruction(instruction{})
+}
+
+func (s *state) NextNodeID() (id, version uint64) {
+	return s.NodeIDCounter, s.Index
+}
+
+func (s *state) IncrementNextNodeID(oldID uint64, index uint64) []byte {
+	return encodeInstruction(instruction{
+		RequireIndex:  index,
+		SetNextNodeID: oldID + 1,
+	})
+}
+
+func (s *state) Apply(data []byte, index uint64) (satisfied bool) {
+	var inst instruction
+	err := gob.NewDecoder(bytes.NewReader(data)).Decode(&inst)
+	if err != nil {
+		panic(err)
+	}
+
+	if inst.RequireIndex != 0 && inst.RequireIndex != s.Index {
+		return false
+	}
+
+	s.Index = index
+	if inst.SetNextNodeID != 0 {
+		s.NodeIDCounter = inst.SetNextNodeID
+	}
+	for k, v := range inst.Set {
+		s.Data[k] = v
+	}
+	return true
+}
+
+func (s *state) Snapshot() (data []byte, index uint64, err error) {
+	var buf bytes.Buffer
+	err = gob.NewEncoder(&buf).Encode(s)
+	return buf.Bytes(), s.Index, err
+}
+
+func (s *state) RestoreSnapshot(data []byte, index uint64) error {
+	err := gob.NewDecoder(bytes.NewReader(data)).Decode(s)
+	return err
+}
+
+func set(k, v string) []byte {
+	return encodeInstruction(instruction{
+		Set: map[string]string{k: v},
+	})
+}
+
+func encodeInstruction(instr instruction) []byte {
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(instr)
+	if err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+type instruction struct {
+	RequireIndex  uint64
+	SetNextNodeID uint64
+	Set           map[string]string
+}

--- a/net/raft/state_test.go
+++ b/net/raft/state_test.go
@@ -8,7 +8,7 @@ import (
 func newTestState() *state {
 	return &state{
 		NodeIDCounter: 2,
-		Peers:         make(map[uint64]string),
+		PeersByID:     make(map[uint64]string),
 		Data:          make(map[string]string),
 	}
 }
@@ -21,7 +21,7 @@ func newTestState() *state {
 type state struct {
 	NodeIDCounter uint64
 	Index         uint64
-	Peers         map[uint64]string
+	PeersByID     map[uint64]string
 	Data          map[string]string
 }
 
@@ -34,15 +34,15 @@ func (s *state) SetAppliedIndex(index uint64) {
 }
 
 func (s *state) SetPeerAddr(id uint64, addr string) {
-	s.Peers[id] = addr
-}
-
-func (s *state) GetPeerAddr(id uint64) (addr string) {
-	return s.Peers[id]
+	s.PeersByID[id] = addr
 }
 
 func (s *state) RemovePeerAddr(id uint64) {
-	delete(s.Peers, id)
+	delete(s.PeersByID, id)
+}
+
+func (s *state) Peers() map[uint64]string {
+	return s.PeersByID
 }
 
 func (s *state) IsAllowedMember(addr string) bool {


### PR DESCRIPTION
Add a simple go test for creating a new three-node cluster. In Chain
Core, the database/sinkdb package provides the implementation to raft's
State interface. For this internal test (and future tests), this adds a
simple State key-value store implementation.

This new test takes test statement coverage in net/raft from 14.6% to
63.9%.