### PR TITLE
docs/future/core: document cluster commands

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -101,6 +101,7 @@ There are four build tags that change the behavior of the resulting binary:
   - `localhost_auth`: allows unauthenticated requests on the loopback device (localhost)
   - `no_mockhsm`: disables the MockHSM provided for development
   - `http_ok`: allows plain HTTP requests
+  - `init_cluster`: automatically creates a single process cluster
 
 The default build process creates a binary with three build tags enabled for a
 friendlier experience. To build from source with build tags, use the following
@@ -111,7 +112,7 @@ tag to build. The `main` branch is __not considered__ stable, and may
 contain in progress features or an inconsistent experience.
 
 ```sh
-$ go build -tags 'http_ok localhost_auth' chain/cmd/cored
+$ go build -tags 'http_ok localhost_auth init_cluster' chain/cmd/cored
 $ go build chain/cmd/corectl
 ```
 

--- a/bin/build-centos-rpm
+++ b/bin/build-centos-rpm
@@ -32,7 +32,7 @@ cleanup() {
 trap "cleanup" EXIT
 
 GOOS=linux GOARCH=amd64 go build\
-  -tags 'http_ok localhost_auth'\
+  -tags 'http_ok localhost_auth init_cluster'\
   -ldflags "$ldflags"\
   -o $CHAIN/docker/centos-rpm/cored\
   chain/cmd/cored

--- a/docs/future/core/reference/corectl.md
+++ b/docs/future/core/reference/corectl.md
@@ -47,6 +47,8 @@ CORE_URL=https://cored.example.com:9999 corectl create-token ...
 
 ## Commands
 
+* [init](#init)
+* [join](#join)
 * [config-generator](#config-generator)
 * [config](#config)
 * [create-block-keypair](#create-block-keypair)
@@ -56,6 +58,31 @@ CORE_URL=https://cored.example.com:9999 corectl create-token ...
 * [revoke](#revoke)
 * [allow-address](#allow-address)
 * [wait](#wait)
+
+### `init`
+
+Creates a new Chain Core cluster. The cored process addressed by `CORE_URL` will
+be the first and only member of the new cluster. Additional members may be added
+using the `allow-address` and `join` commands.
+
+```
+corectl init
+```
+
+### `join`
+
+Connects the Chain Core process to an existing Chain Core cluster.
+
+`join` should only be used for multiserver Chain Cores.
+
+```
+corectl join [address]
+```
+
+Argument:
+
+* **address**: The boot address, in `host:port` format.
+
 
 ### `config-generator`
 

--- a/docs/future/core/reference/cored.md
+++ b/docs/future/core/reference/cored.md
@@ -83,13 +83,6 @@ the limit will receive an HTTP 429 response.
 
     Can be stacked with **RATELIMIT_TOKEN**.
 
-* **BOOTURL**: Setting this value causes the `cored` process to join an
-existing Chain Core cluster if it's not already a member. If it is already
-a member of a cluster, this has no effect.
-
-    This should be the URL of any `cored` process already in the cluster,
-    or a load balancer that forwards requests to any node.
-
 ## Mutual TLS
 
 Chain Core 1.2 introduces support for mutual TLS authentication. This means both Chain Core and the client SDKs can authenticate each other using X.509 certificates and the TLS protocol. Previously, client authentication was facilitated through the use of access tokens and HTTP Basic Auth. While still supported, client access tokens are now deprecated.

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3248";
+	public final String Id = "main/rev3249";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3248"
+const ID string = "main/rev3249"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3248"
+export const rev_id = "main/rev3249"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3248".freeze
+	ID = "main/rev3249".freeze
 end


### PR DESCRIPTION
Document the changes to cored and corectl for explicit cluster
management.

These changes were introduced in d20cecb8ca646d547b9031f9db9180753245115d.