### PR TITLE
database/sinkdb: add Close method

### DIFF
--- a/database/sinkdb/sinkdb_test.go
+++ b/database/sinkdb/sinkdb_test.go
@@ -1,0 +1,56 @@
+package sinkdb
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestRestartDB(t *testing.T) {
+	ctx := context.Background()
+
+	raftDir, err := ioutil.TempDir("", "sinkdb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(raftDir)
+
+	// Create a new fresh db and add an allowed member.
+	sdb1, err := Open("", raftDir, new(http.Client))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sdb1.Close()
+	err = sdb1.RaftService().Init()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = sdb1.Exec(ctx, AddAllowedMember("1234"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = sdb1.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-open the database and verify that the write is still there.
+	sdb2, err := Open("", raftDir, new(http.Client))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sdb2.Close()
+	err = sdb2.RaftService().WaitRead(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !sdb2.state.IsAllowedMember("1234") {
+		t.Error("expected allowed member to be persisted, but it wasn't")
+	}
+	err = sdb2.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/database/sinkdb/sinkdbtest/sinkdbtest.go
+++ b/database/sinkdb/sinkdbtest/sinkdbtest.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -31,6 +32,9 @@ func NewDB(t testing.TB) *sinkdb.DB {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// set a finalizer to close the DB to reclaim file descriptors, etc.
+	runtime.SetFinalizer(sdb, (*sinkdb.DB).Close)
 	return sdb
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3252";
+	public final String Id = "main/rev3253";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3252"
+const ID string = "main/rev3253"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3252"
+export const rev_id = "main/rev3253"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3252".freeze
+	ID = "main/rev3253".freeze
 end

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -105,7 +105,8 @@ type Service struct {
 	raftNode raft.Node
 	id       uint64
 
-	// stopping logic
+	// long-running goroutines should be started from startLocked,
+	// update sv.stopwg and stop when sv.stop is closed.
 	stopwg sync.WaitGroup // done when service exited
 	stop   chan struct{}  // stop requested when closed
 

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -105,6 +105,10 @@ type Service struct {
 	raftNode raft.Node
 	id       uint64
 
+	// stopping logic
+	stopwg sync.WaitGroup // done when service exited
+	stop   chan struct{}  // stop requested when closed
+
 	errMu sync.Mutex
 	err   error
 
@@ -212,6 +216,7 @@ func Start(laddr, dir string, httpClient *http.Client, state State) (*Service, e
 		rctxReq:     make(chan rctxReq),
 		wctxReq:     make(chan wctxReq),
 		client:      httpClient,
+		stop:        make(chan struct{}),
 	}
 	sv.stateCond.L = &sv.stateMu
 
@@ -254,8 +259,9 @@ func Start(laddr, dir string, httpClient *http.Client, state State) (*Service, e
 // startLocked begins the raft algorithm. It requires sv.startMu
 // to already be locked.
 func (sv *Service) startLocked() {
+	sv.stopwg.Add(2)
 	go sv.runUpdates()
-	go runTicks(sv.raftNode)
+	go sv.runTicks()
 }
 
 // initialized returns whether the service's raft cluster is
@@ -351,6 +357,27 @@ func (sv *Service) Join(bootURL string) error {
 	return nil
 }
 
+// Stop stops the Raft algorithm, stopping log replication. Once a
+// Service has been stopped, it's unusable. Stop must be called at
+// most once.
+func (sv *Service) Stop() error {
+	// signal the intention to stop
+	close(sv.stop)
+
+	// if the Service was never initialized, there are no
+	// goroutines to wait for and no open wal
+	if !sv.initialized() {
+		return nil
+	}
+
+	// wait for the service's goroutines to stop
+	sv.stopwg.Wait()
+
+	// once all the goroutines have stopped, it's safe to
+	// close the wal
+	return sv.wal.Close()
+}
+
 // Err returns a serious error preventing this process from
 // operating normally or making progress, if any.
 // Note that it is possible for a Service to recover automatically
@@ -419,6 +446,10 @@ func (sv *Service) runUpdates() {
 	writers := make(map[string]chan bool)
 	for {
 		select {
+		case <-sv.stop:
+			// stop requested
+			sv.stopwg.Done()
+			return
 		case rd := <-sv.raftNode.Ready():
 			replyReadIndex(rdIndices, rd.ReadStates)
 			sv.runUpdatesReady(rd, sv.wal, writers)
@@ -438,9 +469,17 @@ func (sv *Service) runUpdates() {
 	}
 }
 
-func runTicks(rn raft.Node) {
-	for range time.Tick(tickDur) {
-		rn.Tick()
+func (sv *Service) runTicks() {
+	ticks := time.Tick(tickDur)
+	for {
+		select {
+		case <-sv.stop:
+			// stop requested
+			sv.stopwg.Done()
+			return
+		case <-ticks:
+			sv.raftNode.Tick()
+		}
 	}
 }
 

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -374,7 +374,8 @@ func (sv *Service) Stop() error {
 	sv.stopwg.Wait()
 
 	// once all the goroutines have stopped, it's safe to
-	// close the wal
+	// close the wal and stop the state machine
+	sv.raftNode.Stop()
 	return sv.wal.Close()
 }
 


### PR DESCRIPTION
Add Close method to release resources associated with a sinkdb handle
and stop its raft service. Also use this Close method to write a basic unit
test for persistence.

Ideally, we could unit test without gracefully closing the database and the
raft WAL, but the WAL file lock won't be released until the process exits
and the file descriptors are released.