### PR TITLE
bin/build-cored-release: fix rev-parse bug

### DIFF
--- a/bin/build-cored-release
+++ b/bin/build-cored-release
@@ -37,6 +37,7 @@ mkdir -p $newChain
 git clone $CHAIN $newChain
 cd $newChain
 git checkout $releaseRef
+commit=`git rev-parse HEAD`
 cd - # on some platforms (e.g. Windows), the cleanup trap cannot proceed unless we navigate away from the tempdir
 
 # Cross-compilation args for cored and corectl
@@ -47,7 +48,6 @@ export GOARCH
 
 echo "building cored..."
 
-commit=`git rev-parse HEAD`
 DATE=${DATE:-`date +%s`} # date can be set via envvar
 ldflags="-X main.buildTag=$releaseRef -X main.buildCommit=$commit -X main.buildDate=$DATE"
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3249";
+	public final String Id = "main/rev3250";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3249"
+const ID string = "main/rev3250"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3249"
+export const rev_id = "main/rev3250"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3249".freeze
+	ID = "main/rev3250".freeze
 end


### PR DESCRIPTION
`git rev-parse HEAD` needs to be run before navigating away from
the temporary git repo.