### PR TITLE
docker/ci: Update Rust to nightly-2017-06-15

### DIFF
--- a/docker/ci/install/install-protobuf
+++ b/docker/ci/install/install-protobuf
@@ -2,11 +2,19 @@
 
 set -e
 
+: ${GOPATH:?must be set}
+
+# Install protobuf
 curl -LO https://s3.amazonaws.com/chain-qa/protobuf-3.1.0.tar.gz
 tar xvzf protobuf-3.1.0.tar.gz
 chmod +x protobuf-3.1.0/protoc
 cp protobuf-3.1.0/protoc /usr/local/bin
 cp -a protobuf-3.1.0/libproto* /usr/local/lib
 rm -rf protobuf-3.1.0 protobuf-3.1.0.tar.gz
-go get -u github.com/golang/protobuf/proto
-go get -u github.com/golang/protobuf/protoc-gen-go
+
+# Install protoc-gen-go
+git clone https://github.com/golang/protobuf $(go env GOPATH)/src/github.com/golang/protobuf/
+cd $(go env GOPATH)/src/github.com/golang/protobuf/
+git reset --hard 18c9bb3261723cd5401db4d0c9fbc5c3b6c70fe8 # pin to this golang/protobuf commit hash
+go install github.com/golang/protobuf/proto
+go install github.com/golang/protobuf/protoc-gen-go

--- a/docker/ci/install/install-rust
+++ b/docker/ci/install/install-rust
@@ -3,15 +3,15 @@
 set -e
 
 # Pin to a specific nightly until we can get off nightly entirely
-RUST_VERSION="nightly-2017-04-16"
+RUST_VERSION="nightly-2017-06-15"
 
 # Pin to this version of rustfmt
-RUSTFMT_VERSION="0.8.3"
+RUSTFMT_VERSION="0.9.0"
 
 # Pin to this version of clippy
-CLIPPY_VERSION="0.0.124"
+CLIPPY_VERSION="0.0.140"
 
-# Pin to this version of cargo-audiot
+# Pin to this version of cargo-audit
 CARGO_AUDIT_VERSION="0.2.0"
 
 curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3256";
+	public final String Id = "main/rev3257";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3256"
+const ID string = "main/rev3257"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3256"
+export const rev_id = "main/rev3257"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3256".freeze
+	ID = "main/rev3257".freeze
 end

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20170502
+box: chaindev/ci:20170619.1
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 


### PR DESCRIPTION
This includes some pretty major upstream changes that affect us: libcollections was merged into liballoc, and that's where we get all of our heap-allocated data structures.

Also bumps rustfmt to 0.9.0, which includes a number of changes to the rustfmt style guide.

Lastly, bumps clippy to 0.0.140, which is confirmed to build on this nightly release.