### PR TITLE
Makefile: add convenience tasks for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,32 @@
 SNAPPY = $(CHAIN)/vendor/github.com/google/snappy
 ROCKSDB = $(CHAIN)/vendor/github.com/facebook/rocksdb
+DB_DEV = core
+RAFT_DEV = $(HOME)/.chaincore/raft
 
-null:
-	@echo Please specify a make target.
+default: run
+
+## run a development version of Chain Core at http://localhost:1999
+run:
+	cored
+
+## reset the development database
+resetdb:
+	-dropdb $(DB_DEV)
+	createdb $(DB_DEV)
+	rm -rf $(RAFT_DEV)
+
+## delete the development database, re-configure core, and run server
+rerun: build-dev corectl resetdb
+	sh -c "corectl wait; corectl config-generator" &
+	cored
+
+## run development dashboard at http://localhost:3000
+dashserver:
+	npm --prefix dashboard start
+
+## run development documentation server at http://localhost:8080
+docserver: md2html
+	md2html serve
 
 ## builds chain core with c dependencies, for development environments
 build-dev: build-lib
@@ -19,3 +43,9 @@ build-lib:
 clean:
 	rm -rf $(SNAPPY)/build
 	rm -f $(ROCKSDB)/librocksdb.a
+
+corectl:
+	go install chain/cmd/corectl
+
+md2html:
+	go install chain/cmd/md2html

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ rerun: build-dev corectl resetdb
 	cored
 
 ## run development dashboard at http://localhost:3000
-dashserver:
+dashserve:
 	npm --prefix dashboard start
 
 ## run development documentation server at http://localhost:8080
-docserver: md2html
+docserve: md2html
 	md2html serve
 
 ## builds chain core with c dependencies, for development environments

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ RAFT_DEV = $(HOME)/.chaincore/raft
 default: run
 
 ## run a development version of Chain Core at http://localhost:1999
-run:
+run: build-dev
 	cored
 
 ## reset the development database

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SNAPPY = $(CHAIN)/vendor/github.com/google/snappy
 ROCKSDB = $(CHAIN)/vendor/github.com/facebook/rocksdb
 DB_DEV = core
-RAFT_DEV = $(HOME)/.chaincore/raft
+RAFT_DEV = $(or $(CHAIN_CORE_HOME), $(HOME)/.chaincore)/raft
 
 default: run
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3262";
+	public final String Id = "main/rev3263";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3262"
+const ID string = "main/rev3263"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3262"
+export const rev_id = "main/rev3263"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3262".freeze
+	ID = "main/rev3263".freeze
 end


### PR DESCRIPTION
This commit adds convenience Make tasks for rapid iteration:

- `make`/`make run`: Run Chain Core
- `make resetdb`: Delete contents of development databases in both Postgres and the Chain Core data directory
- `make rerun`: Delete contents of development databases, configure the local core as a generator, and run Chain Core
- `make dashserve`: Run the development dashboard at http://localhost:3000
- `make docserve`: Run the development documentation server at http://localhost:8080