### PR TITLE
docker/ci: Update Rust to nightly-2017-06-20

### DIFF
--- a/docker/ci/install/install-rust
+++ b/docker/ci/install/install-rust
@@ -3,7 +3,7 @@
 set -e
 
 # Pin to a specific nightly until we can get off nightly entirely
-RUST_VERSION="nightly-2017-06-15"
+RUST_VERSION="nightly-2017-06-20"
 
 # Pin to this version of rustfmt
 RUSTFMT_VERSION="0.9.0"

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3266";
+	public final String Id = "main/rev3267";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3266"
+const ID string = "main/rev3267"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3266"
+export const rev_id = "main/rev3267"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3266".freeze
+	ID = "main/rev3267".freeze
 end

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20170621
+box: chaindev/ci:20170621.1
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 


### PR DESCRIPTION
The PPC32 version of the previous nightly we were using seems slightly too old
to cross-compile our code.