### PR TITLE
net/raft: advance ticks on cluster init

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3270";
+	public final String Id = "main/rev3271";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3270"
+const ID string = "main/rev3271"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3270"
+export const rev_id = "main/rev3271"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3270".freeze
+	ID = "main/rev3271".freeze
 end

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -293,25 +293,10 @@ func (sv *Service) Init() error {
 	peers := []raft.Peer{{ID: sv.id, Context: []byte(sv.laddr)}}
 	raftNode := raft.StartNode(sv.config(), peers)
 
-	advanceTicksUntilElection(raftNode, electionTick)
 	sv.raftNode = raftNode
 	sv.startLocked()
 
-	/*
-		// StartNode appends to the initial log a ConfChangeAddNode entry for
-		// each peer (in our case, just this node). We can't campaign until
-		// this entry is applied, so synchronously apply them before continuing.
-		rd := <-raftNode.Ready()
-		sv.runUpdatesReady(rd, sv.wal, map[string]chan bool{})
-
-		sv.startLocked()
-
-		// campaign immediately to avoid waiting electionTick ticks in tests
-		err = raftNode.Campaign(ctx)
-		if err != nil {
-			log.Error(ctx, err, "election failed") // ok to continue
-		}
-	*/
+	advanceTicksUntilElection(sv.raftNode, electionTick)
 
 	return nil
 }

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -293,21 +293,26 @@ func (sv *Service) Init() error {
 	peers := []raft.Peer{{ID: sv.id, Context: []byte(sv.laddr)}}
 	raftNode := raft.StartNode(sv.config(), peers)
 
+	advanceTicksUntilElection(raftNode, electionTick)
 	sv.raftNode = raftNode
-
-	// StartNode appends to the initial log a ConfChangeAddNode entry for
-	// each peer (in our case, just this node). We can't campaign until
-	// this entry is applied, so synchronously apply them before continuing.
-	rd := <-raftNode.Ready()
-	sv.runUpdatesReady(rd, sv.wal, map[string]chan bool{})
-
 	sv.startLocked()
 
-	// campaign immediately to avoid waiting electionTick ticks in tests
-	err = raftNode.Campaign(ctx)
-	if err != nil {
-		log.Error(ctx, err, "election failed") // ok to continue
-	}
+	/*
+		// StartNode appends to the initial log a ConfChangeAddNode entry for
+		// each peer (in our case, just this node). We can't campaign until
+		// this entry is applied, so synchronously apply them before continuing.
+		rd := <-raftNode.Ready()
+		sv.runUpdatesReady(rd, sv.wal, map[string]chan bool{})
+
+		sv.startLocked()
+
+		// campaign immediately to avoid waiting electionTick ticks in tests
+		err = raftNode.Campaign(ctx)
+		if err != nil {
+			log.Error(ctx, err, "election failed") // ok to continue
+		}
+	*/
+
 	return nil
 }
 
@@ -458,6 +463,12 @@ func (sv *Service) runTicks() {
 		case <-ticks:
 			sv.raftNode.Tick()
 		}
+	}
+}
+
+func advanceTicksUntilElection(raftNode raft.Node, electionTicks int) {
+	for i := 0; i < electionTicks-1; i++ {
+		raftNode.Tick()
 	}
 }
 


### PR DESCRIPTION
Advancing ticks until right before election to speed up tests when initializing a raft cluster (see https://github.com/coreos/etcd/pull/3184) . Changes the approach from #1242 to avoid errors from artificially changing the state machine.

There is some randomness in test timing now, since electionTimeout is randomized in the Raft algorithm (up to +/- 0.4s)

Addresses #1334 