### PR TITLE
cmd/cored: make unconfigured cores poll for config

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -292,15 +292,9 @@ func main() {
 		h = core.RunUnconfigured(ctx, db, sdb, *listenAddr, opts...)
 
 		go func() {
-			ticker := time.Tick(5 * time.Second)
 			for {
-				select {
-				case <-ticker:
-					if conf != nil {
-						return
-					}
-					core.CheckConfigMaybeExec(ctx, sdb, *listenAddr)
-				}
+				core.CheckConfigMaybeExec(ctx, sdb, *listenAddr)
+				time.Sleep(5 * time.Second)
 			}
 		}()
 	}

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -296,7 +296,6 @@ func main() {
 			for {
 				select {
 				case <-ticker:
-					log.Println("Tick!")
 					if conf != nil {
 						return
 					}

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -290,6 +290,20 @@ func main() {
 		opts = append(opts, enableMockHSM(db)...)
 		chainlog.Printf(ctx, "Launching as unconfigured Core.")
 		h = core.RunUnconfigured(ctx, db, sdb, *listenAddr, opts...)
+
+		go func() {
+			ticker := time.Tick(5 * time.Second)
+			for {
+				select {
+				case <-ticker:
+					log.Println("Tick!")
+					if conf != nil {
+						return
+					}
+					core.CheckConfigMaybeExec(ctx, sdb, *listenAddr)
+				}
+			}
+		}()
 	}
 	coreHandler.Set(h)
 	chainlog.Printf(ctx, "Chain Core online and listening at %s", *listenAddr)

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -162,7 +162,7 @@ func deleteFromPG(ctx context.Context, db pg.DB) error {
 
 // Loads config status from sinkdb to see if other raft nodes have configured
 // so that uncofigured nodes can update.
-func UpdateConfigStatus(ctx context.Context, sdb *sinkdb.DB) (*Config, error) {
+func CheckConfigExists(ctx context.Context, sdb *sinkdb.DB) (*Config, error) {
 	c := new(Config)
 	ver, err := sdb.Get(ctx, "/core/config", c)
 	if err != nil {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -160,6 +160,19 @@ func deleteFromPG(ctx context.Context, db pg.DB) error {
 	return errors.Wrap(err, "deleting config stored in postgres")
 }
 
+// Loads config status from sinkdb to see if other raft nodes have configured
+// so that uncofigured nodes can update.
+func UpdateConfigStatus(ctx context.Context, sdb *sinkdb.DB) (*Config, error) {
+	c := new(Config)
+	ver, err := sdb.Get(ctx, "/core/config", c)
+	if err != nil {
+		return nil, errors.Wrap(err)
+	} else if ver.Exists() {
+		return c, nil
+	}
+	return nil, nil
+}
+
 // Configure configures the core by writing to the database.
 // If running in a cored process,
 // the caller must ensure that the new configuration is properly reloaded,

--- a/core/core.go
+++ b/core/core.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"fmt"
-	stdlog "log"
 	"net"
 	"net/http"
 	"strings"
@@ -163,9 +162,6 @@ func CheckConfigMaybeExec(ctx context.Context, sdb *sinkdb.DB, nodeAddr string) 
 		log.Fatalkv(ctx, log.KeyError, err)
 	}
 	if conf != nil {
-		stdlog.Println("Evicting and execself")
-		// TODO(vniu): do we need to update processID tktk
-		sdb.RaftService().Evict(ctx, nodeAddr)
 		execSelf("")
 	}
 }

--- a/core/core.go
+++ b/core/core.go
@@ -157,7 +157,7 @@ func (a *API) configure(ctx context.Context, x *config.Config) error {
 }
 
 func CheckConfigMaybeExec(ctx context.Context, sdb *sinkdb.DB, nodeAddr string) {
-	conf, err := config.UpdateConfigStatus(ctx, sdb)
+	conf, err := config.CheckConfigExists(ctx, sdb)
 	if err != nil && errors.Root(err) != raft.ErrUninitialized {
 		log.Fatalkv(ctx, log.KeyError, err)
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3269";
+	public final String Id = "main/rev3270";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3269"
+const ID string = "main/rev3270"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3269"
+export const rev_id = "main/rev3270"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3269".freeze
+	ID = "main/rev3270".freeze
 end

--- a/net/raft/dev/run-additional-node.sh
+++ b/net/raft/dev/run-additional-node.sh
@@ -12,7 +12,7 @@ leader_address=localhost:1999
 address=localhost:$port
 db_url=postgres:///core0?sslmode=disable
 
-mkdir $HOME/.chaincore$port/
+mkdir -p $HOME/.chaincore$port/
 cp $CHAIN_CORE_HOME/tls.* $HOME/.chaincore$port/
 
 export CHAIN_CORE_HOME=$HOME/.chaincore$port

--- a/net/raft/dev/run-bootstrapped-node.sh
+++ b/net/raft/dev/run-bootstrapped-node.sh
@@ -4,7 +4,7 @@
 set -meo pipefail
 
 # Move TLS certs to chaincore0
-mkdir $HOME/.chaincore0
+mkdir -p $HOME/.chaincore0
 cp $CHAIN_CORE_HOME/tls.* $HOME/.chaincore0/
 
 # Start initial node

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -613,7 +613,7 @@ func (sv *Service) waitForNode(nodeID uint64) {
 // Evict removes the node with the provided address from the raft cluster.
 // It does not modify the allowed member list.
 func (sv *Service) Evict(ctx context.Context, nodeAddr string) error {
-	if !sv.initialized() {
+	if !sv.initialized() 
 		return ErrUninitialized
 	}
 

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -613,7 +613,7 @@ func (sv *Service) waitForNode(nodeID uint64) {
 // Evict removes the node with the provided address from the raft cluster.
 // It does not modify the allowed member list.
 func (sv *Service) Evict(ctx context.Context, nodeAddr string) error {
-	if !sv.initialized() 
+	if !sv.initialized() {
 		return ErrUninitialized
 	}
 


### PR DESCRIPTION
Adds goroutine for unconfigured cores to check for an updated config from sinkDB and exec themselves to update.

Also includes small fix to make sure raft run scripts don't break if chaincore directories exist already

Fixes #1371 