### PR TITLE
net/raft: add unit tests for node eviction

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3274";
+	public final String Id = "main/rev3275";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3274"
+const ID string = "main/rev3275"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3274"
+export const rev_id = "main/rev3275"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3274".freeze
+	ID = "main/rev3275".freeze
 end

--- a/net/raft/http.go
+++ b/net/raft/http.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"sync/atomic"
 
@@ -85,7 +84,7 @@ func (sv *Service) serveMsg(w http.ResponseWriter, req *http.Request) {
 // It receives notice that the node has been evicted and
 // kills the process.
 func (sv *Service) serveKill(w http.ResponseWriter, req *http.Request) {
-	os.Exit(0)
+	panic("Removed from cluster")
 }
 
 // serveJoin is registered as a handler for the /raft/join rpc.

--- a/net/raft/http.go
+++ b/net/raft/http.go
@@ -97,13 +97,6 @@ func (sv *Service) serveMsg(w http.ResponseWriter, req *http.Request) {
 	sv.raftNode.Step(req.Context(), m)
 }
 
-// serveKill is registered as a handler for the /raft/kill rpc.
-// It receives notice that the node has been evicted and
-// kills the process.
-func (sv *Service) serveKill(w http.ResponseWriter, req *http.Request) {
-	panic("Removed from cluster")
-}
-
 // serveJoin is registered as a handler for the /raft/join rpc.
 // If the provided node's address is allowed, it adds the node
 // to the cluster membership and returns a snapshot through which
@@ -178,17 +171,6 @@ func sendmsg(addr string, data []byte, client *http.Client) {
 	// eviction.
 	url := "https://" + addr + "/raft/msg"
 	resp, err := client.Post(url, contentType, bytes.NewReader(data))
-	if err != nil {
-		log.Printkv(context.Background(), "warning", err)
-		return
-	}
-	defer resp.Body.Close()
-}
-
-// Sends eviction notice to a node to kill the process
-func evictionNotice(addr string, client *http.Client) {
-	url := "https://" + addr + "/raft/kill"
-	resp, err := client.Post(url, contentType, nil)
 	if err != nil {
 		log.Printkv(context.Background(), "warning", err)
 		return

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -200,7 +200,6 @@ func Start(laddr, dir string, httpClient *http.Client, state State) (*Service, e
 	// TODO(kr): grpc
 	sv.mux.HandleFunc("/raft/join", sv.serveJoin)
 	sv.mux.HandleFunc("/raft/msg", sv.serveMsg)
-	sv.mux.HandleFunc("/raft/kill", sv.serveKill)
 
 	var err error
 	sv.wal, err = sv.recover()

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -397,6 +397,9 @@ func (sv *Service) runUpdatesReady(rd raft.Ready, wal *wal.WAL, writers map[stri
 	sv.raftNode.Advance()
 }
 
+// processMessages checks all the messages for valid To addresses, changing
+// to 0 if not found in peers so that we can drop the messages with invalid
+// destinations
 func (sv *Service) processMessages(msgs []raftpb.Message) []raftpb.Message {
 	for i := len(msgs) - 1; i >= 0; i-- {
 		if sv.state.Peers()[msgs[i].To] == "" {

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -741,9 +741,10 @@ func (sv *Service) applyEntry(ent raftpb.Entry, writers map[string]chan bool) {
 		case raftpb.ConfChangeAddNode, raftpb.ConfChangeUpdateNode:
 			sv.state.SetPeerAddr(cc.NodeID, string(cc.Context))
 		case raftpb.ConfChangeRemoveNode:
-			addr := sv.state.Peers()[cc.NodeID]
 			sv.state.RemovePeerAddr(cc.NodeID)
-			evictionNotice(addr, sv.client)
+			if cc.NodeID == sv.id {
+				os.Exit(0)
+			}
 		default:
 			panic(fmt.Errorf("unknown confchange type: %v", cc.Type))
 		}

--- a/net/raft/raft_test.go
+++ b/net/raft/raft_test.go
@@ -167,6 +167,9 @@ func TestEvictMultiple(t *testing.T) {
 
 	// Create new test cluster
 	nodeA, nodeB, nodeC := newTestCluster(ctx, t)
+	defer nodeA.cleanup()
+	defer nodeB.cleanup()
+	defer nodeC.cleanup()
 	addrB := nodeB.addr
 	addrC := nodeC.addr
 
@@ -187,6 +190,9 @@ func TestLeaderEviction(t *testing.T) {
 
 	// Create new test cluster
 	nodeA, nodeB, nodeC := newTestCluster(ctx, t)
+	defer nodeA.cleanup()
+	defer nodeB.cleanup()
+	defer nodeC.cleanup()
 	addrA := nodeA.addr
 
 	// Have nodeC evict nodeA
@@ -198,9 +204,6 @@ func TestLeaderEviction(t *testing.T) {
 			t.Errorf("expected node to be evicted: stil in peer list")
 		}
 	}
-	nodeA.cleanup()
-	nodeB.cleanup()
-	nodeC.cleanup()
 }
 
 func must(t *testing.T, err error) {


### PR DESCRIPTION
Adds two unit tests for node eviction: for evicting a single node, and multiple nodes. Also slightly refactors to add a helper function to create a test Raft cluster.