### PR TITLE
sdk/node: transaction builder errors should surface in promise rejection

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3271";
+	public final String Id = "main/rev3272";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3271"
+const ID string = "main/rev3272"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3271"
+export const rev_id = "main/rev3272"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3271".freeze
+	ID = "main/rev3272".freeze
 end

--- a/sdk/node/src/api/transactions.js
+++ b/sdk/node/src/api/transactions.js
@@ -104,7 +104,7 @@ function checkForError(resp) {
  * creates others. An output is considered unspent when it has not yet been used
  * as an input to a new transaction. All asset units on a blockchain exist in
  * the unspent output set.
- * 
+ *
  * More info: {@link https://chain.com/docs/core/build-applications/unspent-outputs}
  * @typedef {Object} TransactionOutput
  * @global
@@ -347,7 +347,12 @@ const transactionsAPI = (client) => {
      */
     build: (builderBlock, cb) => {
       const builder = new TransactionBuilder()
-      builderBlock(builder)
+
+      try {
+        builderBlock(builder)
+      } catch(err) {
+        return Promise.reject(err)
+      }
 
       return shared.tryCallback(
         client.request('/build-transaction', [builder]).then(resp => checkForError(resp[0])),
@@ -365,11 +370,16 @@ const transactionsAPI = (client) => {
      * @returns {Promise<BatchResponse>} Batch of unsigned transaction templates, or errors.
      */
     buildBatch: (builderBlocks, cb) => {
-      const builders = builderBlocks.map((builderBlock) => {
-        const builder = new TransactionBuilder()
-        builderBlock(builder)
-        return builder
-      })
+      const builders = []
+      for (let i in builderBlocks) {
+        const b = new TransactionBuilder()
+        try {
+          builderBlocks[i](b)
+        } catch(err) {
+          return Promise.reject(err)
+        }
+        builders.push(b)
+      }
 
       return shared.createBatch(client, '/build-transaction', builders, {cb})
     },

--- a/sdk/node/src/api/transactions.js
+++ b/sdk/node/src/api/transactions.js
@@ -350,7 +350,7 @@ const transactionsAPI = (client) => {
 
       try {
         builderBlock(builder)
-      } catch(err) {
+      } catch (err) {
         return Promise.reject(err)
       }
 
@@ -375,7 +375,7 @@ const transactionsAPI = (client) => {
         const b = new TransactionBuilder()
         try {
           builderBlocks[i](b)
-        } catch(err) {
+        } catch (err) {
           return Promise.reject(err)
         }
         builders.push(b)

--- a/sdk/node/test/transactions.js
+++ b/sdk/node/test/transactions.js
@@ -219,6 +219,26 @@ describe('Transaction', () => {
     })
   })
 
+  describe('Builder function errors', () => {
+    it('rejects via promise', () =>
+      expect(
+        client.transactions.build(() => {
+          throw new Error("test error")
+        })
+      ).to.be.rejectedWith("test error")
+    )
+
+    it('rejects batch errors via promise', () =>
+      expect(
+        client.transactions.buildBatch([
+          () => { /* do nothing */ },
+          () => { throw new Error("test error") },
+          () => { /* do nothing */ },
+        ])
+      ).to.be.rejectedWith("test error")
+    )
+  })
+
   // These just test that the callback is engaged correctly. Behavior is
   // tested in the promises test.
   describe('Callback support', () => {


### PR DESCRIPTION
Per the principle of least surprise, errors in transaction builder functions should bubble up via the promise chain, rather than via a `throw`.

Supersedes #1369.