### PR TITLE
net/raft: add unit test for node restart

### DIFF
--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -95,7 +95,8 @@ func (s *state) RestoreSnapshot(data []byte, index uint64) error {
 
 	// Chain Core 1.2.x generates snapshots without populating versions,
 	// so we manually initialize here to avoid nil errors after marshaling
-	// and unmarshaling the snapshot
+	// and unmarshaling the snapshot, which turns an initialized-but-empty
+	// map into a nil map
 	if s.version == nil {
 		s.version = make(map[string]uint64)
 	}

--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -92,6 +92,13 @@ func (s *state) RestoreSnapshot(data []byte, index uint64) error {
 	s.peers = snapshot.Peers
 	s.state = snapshot.State
 	s.version = snapshot.Version
+
+	if s.version == nil {
+		s.version = make(map[string]uint64)
+	}
+	if s.peers == nil {
+		s.peers = make(map[uint64]string)
+	}
 	return errors.Wrap(err)
 }
 
@@ -105,6 +112,7 @@ func (s *state) Snapshot() ([]byte, uint64, error) {
 		State:   s.state,
 		Peers:   s.peers,
 	})
+
 	return data, s.appliedIndex, errors.Wrap(err)
 }
 

--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -93,11 +93,11 @@ func (s *state) RestoreSnapshot(data []byte, index uint64) error {
 	s.state = snapshot.State
 	s.version = snapshot.Version
 
+	// Chain Core 1.2.x generates snapshots without populating versions,
+	// so we manually initialize here to avoid nil errors after marshaling
+	// and unmarshaling the snapshot
 	if s.version == nil {
 		s.version = make(map[string]uint64)
-	}
-	if s.peers == nil {
-		s.peers = make(map[uint64]string)
 	}
 	return errors.Wrap(err)
 }

--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -112,7 +112,6 @@ func (s *state) Snapshot() ([]byte, uint64, error) {
 		State:   s.state,
 		Peers:   s.peers,
 	})
-
 	return data, s.appliedIndex, errors.Wrap(err)
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3276";
+	public final String Id = "main/rev3277";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3276"
+const ID string = "main/rev3277"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3276"
+export const rev_id = "main/rev3277"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3276".freeze
+	ID = "main/rev3277".freeze
 end


### PR DESCRIPTION
Adds unit tests and a fix for restarting a node in a cluster. Previously, restarting the initial node in a cluster would segfault since there was no snapshot to restore from. 

Now, we trigger snapshot while initializing a raft cluster to ensure that we can always restart nodes without errors.