### PR TITLE
core/migrate: add core_id table

### DIFF
--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -72,4 +72,11 @@ var migrations = []migration{
 		DROP INDEX signers_type_id_idx;
 		DROP INDEX assets_sort_id;
 	`},
+	{Name: `2017-06-28.0.core.coreid.sql`, SQL: `
+		CREATE TABLE core_id (
+			singleton boolean DEFAULT true NOT NULL,
+			id text);
+		ALTER TABLE ONLY core_id
+			ADD CONSTRAINT core_id_pkey PRIMARY KEY (singleton);
+	`},
 }

--- a/core/migrate/data.go
+++ b/core/migrate/data.go
@@ -75,7 +75,9 @@ var migrations = []migration{
 	{Name: `2017-06-28.0.core.coreid.sql`, SQL: `
 		CREATE TABLE core_id (
 			singleton boolean DEFAULT true NOT NULL,
-			id text);
+			id text,
+			CONSTRAINT core_id_singleton CHECK (singleton)
+		);
 		ALTER TABLE ONLY core_id
 			ADD CONSTRAINT core_id_pkey PRIMARY KEY (singleton);
 	`},

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -2,6 +2,7 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;
@@ -340,6 +341,13 @@ CREATE TABLE config (
 
 
 
+CREATE TABLE core_id (
+    singleton boolean DEFAULT true NOT NULL,
+    id text
+);
+
+
+
 CREATE TABLE generator_pending_block (
     singleton boolean DEFAULT true NOT NULL,
     data bytea NOT NULL,
@@ -549,6 +557,11 @@ ALTER TABLE ONLY config
 
 
 
+ALTER TABLE ONLY core_id
+    ADD CONSTRAINT core_id_pkey PRIMARY KEY (singleton);
+
+
+
 ALTER TABLE ONLY generator_pending_block
     ADD CONSTRAINT generator_pending_block_pkey PRIMARY KEY (singleton);
 
@@ -654,3 +667,4 @@ insert into migrations (filename, hash) values ('2017-04-13.0.query.block-transa
 insert into migrations (filename, hash) values ('2017-04-17.0.core.null-token-type.sql', '185942cec464c12a2573f19ae386153389328f8e282af071024706e105e37eeb');
 insert into migrations (filename, hash) values ('2017-04-27.0.generator.pending-block-height.sql', 'bfe4fe5eec143e4367a91fd952cb5e3879f1c311f649ec13bfe95b202e94d4ec');
 insert into migrations (filename, hash) values ('2017-05-08.0.core.drop-redundant-indexes.sql', '5140e53b287b058c57ddf361d61cff3d3d1cbc3259a9de413b11574a71d09bec');
+insert into migrations (filename, hash) values ('2017-06-28.0.core.coreid.sql', '6ec8189a0be0e66ded98edf4ec7b9a90cff10cc33b2bf8c53012f06e2fa5af24');

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -342,7 +342,8 @@ CREATE TABLE config (
 
 CREATE TABLE core_id (
     singleton boolean DEFAULT true NOT NULL,
-    id text
+    id text,
+    CONSTRAINT core_id_singleton CHECK (singleton)
 );
 
 
@@ -666,4 +667,4 @@ insert into migrations (filename, hash) values ('2017-04-13.0.query.block-transa
 insert into migrations (filename, hash) values ('2017-04-17.0.core.null-token-type.sql', '185942cec464c12a2573f19ae386153389328f8e282af071024706e105e37eeb');
 insert into migrations (filename, hash) values ('2017-04-27.0.generator.pending-block-height.sql', 'bfe4fe5eec143e4367a91fd952cb5e3879f1c311f649ec13bfe95b202e94d4ec');
 insert into migrations (filename, hash) values ('2017-05-08.0.core.drop-redundant-indexes.sql', '5140e53b287b058c57ddf361d61cff3d3d1cbc3259a9de413b11574a71d09bec');
-insert into migrations (filename, hash) values ('2017-06-28.0.core.coreid.sql', '6ec8189a0be0e66ded98edf4ec7b9a90cff10cc33b2bf8c53012f06e2fa5af24');
+insert into migrations (filename, hash) values ('2017-06-28.0.core.coreid.sql', 'a147b93ba1bf404265efedde066532c937070a87e15123b1d9277daba431ee01');

--- a/core/schema.sql
+++ b/core/schema.sql
@@ -2,7 +2,6 @@
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
-SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SET check_function_bodies = false;

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3278";
+	public final String Id = "main/rev3279";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3278"
+const ID string = "main/rev3279"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3278"
+export const rev_id = "main/rev3279"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3278".freeze
+	ID = "main/rev3279".freeze
 end


### PR DESCRIPTION
To detect and report out-of-date raft configs (see https://github.com/chain/chain/issues/1167), we'll be writing the core ID to postgres and raft. This migration adds a core ID table to postgres to be able to crosscheck the core ID that we'll write to raft.