### PR TITLE
net/raft: refactor locking

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3280";
+	public final String Id = "main/rev3281";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3280"
+const ID string = "main/rev3281"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3280"
+export const rev_id = "main/rev3281"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3280".freeze
+	ID = "main/rev3281".freeze
 end

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -855,8 +855,8 @@ func (sv *Service) getSnapshot() *raftpb.Snapshot {
 		panic(err)
 	}
 	sv.confMu.Lock()
-	defer sv.confMu.Unlock()
 	snap, err := sv.raftStorage.CreateSnapshot(index, &sv.confState, data)
+	sv.confMu.Unlock()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fix a data race in TestEvictMultiple detected by `go test -race`.
There were a few places where we locked stateMu before accessing State
and a few places where we didn't.

The State implementation from database/sinkdb does its own locking,
so this wasn't a real race in Chain Core, only in tests using the
net/raft state implementation.

We could remove the net/raft's mutex altogether if it weren't for two
things:
* the ConfState stored on Service that needs to be updated every time
  the raft configuration changes
* the stateCond condition variable used for waiting until applyEntry
  changes the state

This change
* adds a mutex to the net/raft test state
* documents that the State interface must be safe for concurrent access
* adds a new confMu mutex for protecting the ConfState
* removes all unnecessary uses of stateMu outside of the condition
  variable
* renames stateMu/stateCond to applyMu/applyCond to reflect that it's
  now only used for the applyEntry condition variable and not for
  protecting the state

An alternative to this approach could be to _always_ lock stateMu before
accessing State, but that would add unnecessary locking because sinkdb's
State requires its own locking regardless.