### PR TITLE
core/config: write core ID to postgres

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -277,6 +277,14 @@ func Configure(ctx context.Context, db pg.DB, sdb *sinkdb.DB, httpClient *http.C
 	c.Id = hex.EncodeToString(b)
 	c.ConfiguredAt = bc.Millis(time.Now())
 
+	// Write core ID to postgres to check for matching config between
+	// postgres and raft
+	const q = `INSERT INTO core_id (id) VALUES ($1)`
+	_, err = db.ExecContext(ctx, q, c.Id)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
 	return sdb.Exec(ctx,
 		sinkdb.IfNotExists("/core/config"),
 		sinkdb.Set("/core/config", c),

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3279";
+	public final String Id = "main/rev3280";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3279"
+const ID string = "main/rev3280"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3279"
+export const rev_id = "main/rev3280"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3279".freeze
+	ID = "main/rev3280".freeze
 end


### PR DESCRIPTION
To detect and report out-of-date raft configs (see https://github.com/chain/chain/issues/1167), we'll be writing the core ID to postgres and raft. 

This writes the core ID to postgres when we configure.