### PR TITLE
core: add incremental config options

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -65,6 +65,9 @@ var commands = map[string]*command{
 	"init":                 {initCluster},
 	"evict":                {evictNode},
 	"allow-address":        {allowRaftMember},
+	"get":                  {get},
+	"add":                  {add},
+	"rm":                   {rm},
 	"wait":                 {wait},
 }
 
@@ -417,6 +420,69 @@ func evictNode(client *rpc.Client, args []string) {
 
 	req := map[string]string{"node_address": args[0]}
 	err := client.Call(context.Background(), "/evict", req, nil)
+	dieOnRPCError(err)
+}
+
+func get(client *rpc.Client, args []string) {
+	const usage = "usage: corectl get [key]"
+	if len(args) != 1 {
+		fatalln(usage)
+	}
+
+	req := map[string]interface{}{
+		"keys": []interface{}{args[0]},
+	}
+
+	var resp map[string][][]string
+	err := client.Call(context.Background(), "/config", req, &resp)
+	dieOnRPCError(err)
+	for key, tuples := range resp {
+		if len(tuples) == 1 {
+			fmt.Printf("%s: %s\n", key, strings.Join(tuples[0], " "))
+		} else {
+			fmt.Printf("%s:\n", key)
+			for _, tup := range tuples {
+				fmt.Printf(" - %s\n", strings.Join(tup, " "))
+			}
+		}
+	}
+}
+
+func add(client *rpc.Client, args []string) {
+	const usage = "usage: corectl add [key] [value]..."
+	if len(args) < 2 {
+		fatalln(usage)
+	}
+
+	req := map[string]interface{}{
+		"updates": []interface{}{
+			map[string]interface{}{
+				"op":    "add",
+				"key":   args[0],
+				"tuple": args[1:],
+			},
+		},
+	}
+	err := client.Call(context.Background(), "/configure", req, nil)
+	dieOnRPCError(err)
+}
+
+func rm(client *rpc.Client, args []string) {
+	const usage = "usage: corectl rm [key] [value]..."
+	if len(args) < 2 {
+		fatalln(usage)
+	}
+
+	req := map[string]interface{}{
+		"updates": []interface{}{
+			map[string]interface{}{
+				"op":    "rm",
+				"key":   args[0],
+				"tuple": args[1:],
+			},
+		},
+	}
+	err := client.Call(context.Background(), "/configure", req, nil)
 	dieOnRPCError(err)
 }
 

--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -436,14 +436,9 @@ func get(client *rpc.Client, args []string) {
 	var resp map[string][][]string
 	err := client.Call(context.Background(), "/config", req, &resp)
 	dieOnRPCError(err)
-	for key, tuples := range resp {
-		if len(tuples) == 1 {
-			fmt.Printf("%s: %s\n", key, strings.Join(tuples[0], " "))
-		} else {
-			fmt.Printf("%s:\n", key)
-			for _, tup := range tuples {
-				fmt.Printf(" - %s\n", strings.Join(tup, " "))
-			}
+	for _, tuples := range resp {
+		for _, tup := range tuples {
+			fmt.Println(strings.Join(tup, " "))
 		}
 	}
 }

--- a/core/api.go
+++ b/core/api.go
@@ -67,6 +67,7 @@ type API struct {
 	accessTokens    *accesstoken.CredentialStore
 	grants          *authz.Store
 	config          *config.Config
+	options         *config.Options
 	submitter       txbuilder.Submitter
 	db              pg.DB
 	sdb             *sinkdb.DB
@@ -183,6 +184,7 @@ func (a *API) buildHandler() {
 	m.Handle("/join-cluster", jsonHandler(a.joinCluster))
 	m.Handle("/evict", jsonHandler(a.evict))
 	m.Handle("/configure", jsonHandler(a.configure))
+	m.Handle("/config", jsonHandler(a.retrieveConfig))
 	m.Handle("/info", jsonHandler(a.info))
 
 	m.Handle("/debug/vars", expvar.Handler())

--- a/core/authz.go
+++ b/core/authz.go
@@ -58,6 +58,7 @@ var policyByRoute = map[string][]string{
 	"/join-cluster":               {"internal"},
 	"/evict":                      {"internal"},
 	"/configure":                  {"client-readwrite", "internal"},
+	"/config":                     {"client-readwrite", "client-readonly", "monitoring", "internal"},
 	"/info":                       {"client-readwrite", "client-readonly", "crosscore", "crosscore-signblock", "monitoring", "internal"},
 
 	"/debug/": {"client-readwrite", "client-readonly", "monitoring"},

--- a/core/core.go
+++ b/core/core.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+
 	"chain/core/config"
 	"chain/core/fetch"
 	"chain/core/leader"
@@ -137,16 +139,63 @@ func (a *API) leaderInfo(ctx context.Context) (map[string]interface{}, error) {
 	return m, nil
 }
 
-func (a *API) configure(ctx context.Context, x *config.Config) error {
+type configureRequest struct {
+	// Config is the old-style monolithic Config object. If any of its
+	// fields are present in the request, the Chain Core must not already
+	// be configured.
+	config.Config
+
+	// Updates contains incremental updates to configuration options.
+	Updates []configUpdate `json:"updates"`
+}
+
+type configUpdate struct {
+	Op    string   `json:"op"`
+	Key   string   `json:"key"`
+	Tuple []string `json:"tuple,omitempty"`
+}
+
+// configure implements the RPC handler for the /configure endpoint.
+//
+// Chain Core has two types of config settings:
+// - the monolithic config.Config struct/protobuf that is required
+//   before a Chain Core can participate in any blockchain network.
+// - individual options set via the config.Options type. Some Chain
+//   Core features may be gated on the presence of options.
+//
+// Eventually if possible, we'd like to replace the monolithic config
+// type with the incremental config options.
+func (a *API) configure(ctx context.Context, req configureRequest) error {
+	// First, apply any of the incremental config updates as one
+	// single, atomic sinkdb batch.
+	var ops []sinkdb.Op
+	for _, update := range req.Updates {
+		switch update.Op {
+		case "add":
+			ops = append(ops, a.options.Add(update.Key, update.Tuple))
+		case "rm":
+			ops = append(ops, a.options.Remove(update.Key, update.Tuple))
+		default:
+			return errors.WithDetailf(config.ErrConfigOp, "Unknown config operation %q.", update.Op)
+		}
+	}
+	err := a.sdb.Exec(ctx, ops...)
+	if err != nil {
+		return err
+	}
+
+	// If the monolithic Config is populated, also perform the
+	// one-time configure of the Core.
+	if proto.Equal(&req.Config, &config.Config{}) {
+		return nil
+	}
 	if a.config != nil {
 		return errAlreadyConfigured
 	}
-
-	if x.IsGenerator && x.MaxIssuanceWindowMs == 0 {
-		x.MaxIssuanceWindowMs = bc.DurationMillis(24 * time.Hour)
+	if req.Config.IsGenerator && req.Config.MaxIssuanceWindowMs == 0 {
+		req.Config.MaxIssuanceWindowMs = bc.DurationMillis(24 * time.Hour)
 	}
-
-	err := config.Configure(ctx, a.db, a.sdb, a.httpClient, x)
+	err = config.Configure(ctx, a.db, a.sdb, a.httpClient, &req.Config)
 	if err != nil {
 		return err
 	}
@@ -154,6 +203,22 @@ func (a *API) configure(ctx context.Context, x *config.Config) error {
 	closeConnOK(httpjson.ResponseWriter(ctx), httpjson.Request(ctx))
 	execSelf("")
 	panic("unreached")
+}
+
+func (a *API) retrieveConfig(ctx context.Context, x struct {
+	Keys []string `json:"keys"`
+}) (map[string][][]string, error) {
+	// TODO(jackson): This waits for len(x.Keys) consensus
+	// rounds. We should batch the reads instead.
+	results := make(map[string][][]string)
+	for _, key := range x.Keys {
+		tups, err := a.options.List(ctx, key)
+		if err != nil {
+			return nil, errors.Wrap(err)
+		}
+		results[key] = tups
+	}
+	return results, nil
 }
 
 func CheckConfigMaybeExec(ctx context.Context, sdb *sinkdb.DB, nodeAddr string) {

--- a/core/core.go
+++ b/core/core.go
@@ -183,6 +183,8 @@ func (a *API) configure(ctx context.Context, req configureRequest) error {
 	if err != nil {
 		return err
 	}
+	// TODO(jackson): make the config.Configure atomic with the above
+	// incremental updates.
 
 	// If the monolithic Config is populated, also perform the
 	// one-time configure of the Core.

--- a/core/errors.go
+++ b/core/errors.go
@@ -95,6 +95,7 @@ var errorFormatter = httperror.Formatter{
 		raft.ErrExistingCluster:        {400, "CH164", "Already connected to a cluster"},
 		raft.ErrPeerUninitialized:      {400, "CH165", "Peer node is uninitialized"},
 		raft.ErrUnknownPeer:            {400, "CH166", "Unknown peer"},
+		config.ErrConfigOp:             {400, "CH170", "Invalid configuration operation"},
 
 		// Signers error namespace (2xx)
 		signers.ErrBadQuorum: {400, "CH200", "Quorum must be greater than 1 and less than or equal to the length of xpubs"},

--- a/core/health.go
+++ b/core/health.go
@@ -28,6 +28,9 @@ func (a *API) health() (x struct {
 	if err := a.sdb.RaftService().Err(); err != nil {
 		x.Errors["raft"] = err.Error()
 	}
+	if err := a.options.Err(); err != nil {
+		x.Errors["config"] = err.Error()
+	}
 
 	a.healthMu.Lock()
 	defer a.healthMu.Unlock()

--- a/core/run.go
+++ b/core/run.go
@@ -127,6 +127,7 @@ func RunUnconfigured(ctx context.Context, db pg.DB, sdb *sinkdb.DB, routableAddr
 		sdb:          sdb,
 		accessTokens: &accesstoken.CredentialStore{DB: db},
 		grants:       authz.NewStore(sdb, GrantPrefix),
+		options:      config.New(sdb),
 		mux:          http.NewServeMux(),
 		addr:         routableAddress,
 	}
@@ -185,6 +186,7 @@ func Run(
 		accessTokens: &accesstoken.CredentialStore{DB: db},
 		grants:       authz.NewStore(sdb, GrantPrefix),
 		config:       conf,
+		options:      config.New(sdb),
 		db:           db,
 		sdb:          sdb,
 		mux:          http.NewServeMux(),

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3287";
+	public final String Id = "main/rev3288";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3287"
+const ID string = "main/rev3288"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3287"
+export const rev_id = "main/rev3288"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3287".freeze
+	ID = "main/rev3288".freeze
 end


### PR DESCRIPTION
Add support for setting and retrieving incremental configuration
options. There are still no configuration options defined so for now
these commands are useless.

* Add a field to /configure to support modifying incremental
  config options.
* Add a /config endpoint for retrieving configuration values.
* Add three subcommands to corectl: get, add and rm for retrieving and
  manipulating set configuration options.