### PR TITLE
core/config: check for stale Raft config

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -113,7 +113,7 @@ func idMatchesPG(ctx context.Context, id string, db pg.DB) (bool, error) {
 	const q = `SELECT id FROM core_id`
 	var pgID string
 	err := db.QueryRowContext(ctx, q).Scan(&pgID)
-	if err != sql.ErrNoRows {
+	if err != nil && err != sql.ErrNoRows {
 		return false, errors.Wrap(err)
 	}
 	return err == nil && pgID == id, nil

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"time"
 
 	"chain/core/accesstoken"
@@ -68,7 +69,7 @@ func Load(ctx context.Context, db pg.DB, sdb *sinkdb.DB) (*Config, error) {
 	} else if ver.Exists() {
 		raftID := c.Id
 		if !idMatchesPG(ctx, raftID, db) {
-			raftDir := HomeDirFromEnvironment() + "/raft"
+			raftDir := filepath.Join(HomeDirFromEnvironment(), "raft")
 			return nil, errors.Wrap(ErrStaleRaftConfig, "Stale Raft config in "+raftDir)
 		}
 		return c, nil

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -11,12 +11,6 @@ import (
 )
 
 func TestDetectStaleConfig(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic detecting stale config")
-		}
-	}()
-
 	ctx := context.Background()
 	sdb := sinkdbtest.NewDB(t)
 	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
@@ -24,11 +18,13 @@ func TestDetectStaleConfig(t *testing.T) {
 
 	// Write config to sinkdb
 	sdb.Exec(ctx,
-		sinkdb.IfNotExists("/core/config"),
 		sinkdb.Set("/core/config", c),
 	)
 
-	Load(ctx, db, sdb)
+	c, _ = Load(ctx, db, sdb)
+	if c != nil {
+		t.Errorf("Expected nil config")
+	}
 }
 
 // newTestConfig returns a new Config object

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -1,13 +1,14 @@
 package config
 
 import (
-	"chain/database/pg/pgtest"
-	"chain/database/sinkdb"
-	"chain/database/sinkdb/sinkdbtest"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"testing"
+
+	"chain/database/pg/pgtest"
+	"chain/database/sinkdb"
+	"chain/database/sinkdb/sinkdbtest"
 )
 
 func TestDetectStaleConfig(t *testing.T) {

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"chain/database/pg/pgtest"
+	"chain/database/sinkdb"
+	"chain/database/sinkdb/sinkdbtest"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"testing"
+)
+
+func TestDetectStaleConfig(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic detecting stale config")
+		}
+	}()
+
+	ctx := context.Background()
+	sdb := sinkdbtest.NewDB(t)
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+	c := newTestConfig(t)
+
+	// Write config to sinkdb
+	sdb.Exec(ctx,
+		sinkdb.IfNotExists("/core/config"),
+		sinkdb.Set("/core/config", c),
+	)
+
+	Load(ctx, db, sdb)
+}
+
+// newTestConfig returns a new Config object
+// which has an ID, but no other fields set
+func newTestConfig(t *testing.T) *Config {
+	c := new(Config)
+	b := make([]byte, 10)
+	rand.Read(b)
+	c.Id = hex.EncodeToString(b)
+	return c
+}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3283";
+	public final String Id = "main/rev3284";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3283"
+const ID string = "main/rev3284"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3283"
+export const rev_id = "main/rev3284"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3283".freeze
+	ID = "main/rev3284".freeze
 end


### PR DESCRIPTION
See https://github.com/chain/chain/issues/1167

In https://github.com/chain/chain/pull/1385 and https://github.com/chain/chain/pull/1387, we write the config coreID to postgres whenever we configure a new cored process. This is to detect stale Raft configs resulting from when you restart a cored process, create a new Postgres db, but do not remove ~/.chaincore, preserving an old Raft config.

This PR checks the coreID stored in Raft against the coreID in Postgres (if any), and panics if there is a mismatch, suggesting that the user clean their Raft directory. Also adds a test to make sure we correctly detect stale configs.