### PR TITLE
core/config: move HomeDirFromEnvironment from core to config

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -30,7 +30,7 @@ import (
 
 // config vars
 var (
-	home    = core.HomeDirFromEnvironment()
+	home    = config.HomeDirFromEnvironment()
 	coreURL = env.String("CORE_URL", "http://localhost:1999")
 
 	// build vars; initialized by the linker

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -69,7 +69,7 @@ var (
 	rpsToken      = env.Int("RATELIMIT_TOKEN", 0)       // reqs/sec
 	rpsRemoteAddr = env.Int("RATELIMIT_REMOTE_ADDR", 0) // reqs/sec
 	indexTxs      = env.Bool("INDEX_TRANSACTIONS", true)
-	home          = core.HomeDirFromEnvironment()
+	home          = config.HomeDirFromEnvironment()
 
 	version string // initialized in init()
 

--- a/core/config/env.go
+++ b/core/config/env.go
@@ -1,4 +1,4 @@
-package core
+package config
 
 import (
 	"os"

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3282";
+	public final String Id = "main/rev3283";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3282"
+const ID string = "main/rev3283"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3282"
+export const rev_id = "main/rev3283"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3282".freeze
+	ID = "main/rev3283".freeze
 end


### PR DESCRIPTION
For https://github.com/chain/chain/pull/1390, we need to call HomeDirFromEnvironment in the config package so we can identify the raft directory. Moving from core into config to avoid circular imports. 