### PR TITLE
core/config: add ListFunc

### DIFF
--- a/core/config/options.go
+++ b/core/config/options.go
@@ -114,7 +114,8 @@ func (opts *Options) ListFunc(key string) func() [][]string {
 	// configuration key. The returned closure will update it on
 	// every successful lookup. If an error occurs, the closure
 	// returns this value.
-	var old atomic.Value // [][]string
+	var old atomic.Value
+	old.Store([][]string(nil))
 
 	return func() [][]string {
 		var set configpb.ValueSet

--- a/core/config/options.go
+++ b/core/config/options.go
@@ -91,16 +91,16 @@ func (opts *Options) List(ctx context.Context, key string) ([][]string, error) {
 	return tuples, nil
 }
 
-// ListFunc returns a closure that returns the set of tuples for the
-// provided key.
+// ListFunc returns a closure that returns the set of tuples
+// for the provided key.
 //
 // The configuration option for key must be a set of tuples.
-// ListFunc will panic if the provided key is undefined in the schema or
-// is defined as a scalar.
+// ListFunc panics if the provided key is undefined or is
+// defined as a scalar.
 //
-// The returned function will perform a stale read of the
-// configuration value. If an error occurs while reading the value,
-// the old value is returned and the error is saved on the Options
+// The returned function performs a stale read of the configuration
+// value. If an error occurs while reading the value the old
+// value is returned, and the error is saved on the Options
 // type to be returned in Err.
 func (opts *Options) ListFunc(key string) func() [][]string {
 	opt, ok := opts.schema[key]
@@ -111,7 +111,7 @@ func (opts *Options) ListFunc(key string) func() [][]string {
 	}
 
 	// old is the last successfully retrieved tuple set for this
-	// configuration key. The returned closure will update it on
+	// configuration key. The returned closure updates it on
 	// every successful lookup. If an error occurs, the closure
 	// returns this value.
 	var old atomic.Value

--- a/core/config/options_test.go
+++ b/core/config/options_test.go
@@ -62,8 +62,7 @@ func TestListFunc(t *testing.T) {
 
 	// perform a linearizable read since ListFunc won't and we
 	// want a deterministic test case
-	_, err := opts.List(ctx, "example")
-	must(t, err)
+	must(t, sdb.RaftService().WaitRead(ctx))
 
 	got := opts.ListFunc("example")()
 	want := [][]string{{"foo"}, {"bar"}}

--- a/core/config/options_test.go
+++ b/core/config/options_test.go
@@ -65,8 +65,7 @@ func TestListFunc(t *testing.T) {
 	_, err := opts.List(ctx, "example")
 	must(t, err)
 
-	got, err := opts.ListFunc("example")()
-	must(t, err)
+	got := opts.ListFunc("example")()
 	want := [][]string{{"foo"}, {"bar"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %#v, want %#v", got, want)

--- a/core/config/options_test.go
+++ b/core/config/options_test.go
@@ -49,3 +49,26 @@ func TestSetTuples(t *testing.T) {
 		t.Errorf("got %#v, want %#v", got, want)
 	}
 }
+
+func TestListFunc(t *testing.T) {
+	sdb := sinkdbtest.NewDB(t)
+	opts := New(sdb)
+	opts.DefineSet("example", 1, identityFunc, reflectEquality)
+
+	ctx := context.Background()
+
+	must(t, sdb.Exec(ctx, opts.Add("example", []string{"foo"})))
+	must(t, sdb.Exec(ctx, opts.Add("example", []string{"bar"})))
+
+	// perform a linearizable read since ListFunc won't and we
+	// want a deterministic test case
+	_, err := opts.List(ctx, "example")
+	must(t, err)
+
+	got, err := opts.ListFunc("example")()
+	must(t, err)
+	want := [][]string{{"foo"}, {"bar"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3286";
+	public final String Id = "main/rev3287";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3286"
+const ID string = "main/rev3287"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3286"
+export const rev_id = "main/rev3287"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3286".freeze
+	ID = "main/rev3287".freeze
 end


### PR DESCRIPTION
Add a ListFunc method to return a closure that returns the current set
of values for a set configuration option. Packages consuming
configuration options can accept closures of type

  func() [][]string

without needing to import core/config. Passing around these closures
should also ease unit testing.