### PR TITLE
core/config: use path for forming sinkdb keys

### DIFF
--- a/core/config/options.go
+++ b/core/config/options.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"context"
-	"path/filepath"
+	"path"
 
 	"chain/core/config/internal/configpb"
 	"chain/database/sinkdb"
@@ -60,7 +60,7 @@ func (opts *Options) List(ctx context.Context, key string) ([][]string, error) {
 		return nil, errors.WithDetailf(ErrConfigOp, "Configuration option %q is undefined.", key)
 	}
 	var set configpb.ValueSet
-	_, err := opts.sdb.Get(ctx, filepath.Join(sinkdbPrefix, key), &set)
+	_, err := opts.sdb.Get(ctx, path.Join(sinkdbPrefix, key), &set)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func (opts *Options) Add(key string, tup []string) sinkdb.Op {
 	}
 
 	var existing configpb.ValueSet
-	ver, err := opts.sdb.GetStale(filepath.Join(sinkdbPrefix, key), &existing)
+	ver, err := opts.sdb.GetStale(path.Join(sinkdbPrefix, key), &existing)
 	if err != nil {
 		return sinkdb.Error(err)
 	}
@@ -109,7 +109,7 @@ func (opts *Options) Add(key string, tup []string) sinkdb.Op {
 	modified.Tuples = append(existing.Tuples, &configpb.ValueTuple{Values: cleaned})
 	return sinkdb.All(
 		sinkdb.IfNotModified(ver),
-		sinkdb.Set(filepath.Join(sinkdbPrefix, key), modified),
+		sinkdb.Set(path.Join(sinkdbPrefix, key), modified),
 	)
 }
 
@@ -136,7 +136,7 @@ func (opts *Options) Remove(key string, tup []string) sinkdb.Op {
 	}
 
 	var existing configpb.ValueSet
-	ver, err := opts.sdb.GetStale(filepath.Join(sinkdbPrefix, key), &existing)
+	ver, err := opts.sdb.GetStale(path.Join(sinkdbPrefix, key), &existing)
 	if err != nil {
 		return sinkdb.Error(err)
 	}
@@ -153,7 +153,7 @@ func (opts *Options) Remove(key string, tup []string) sinkdb.Op {
 	modified.Tuples = append(modified.Tuples, existing.Tuples[idx+1:]...)
 	return sinkdb.All(
 		sinkdb.IfNotModified(ver),
-		sinkdb.Set(filepath.Join(sinkdbPrefix, key), modified),
+		sinkdb.Set(path.Join(sinkdbPrefix, key), modified),
 	)
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3284";
+	public final String Id = "main/rev3285";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3284"
+const ID string = "main/rev3285"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3284"
+export const rev_id = "main/rev3285"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3284".freeze
+	ID = "main/rev3285".freeze
 end


### PR DESCRIPTION
Use the path package instead of path/filepath for forming sinkdb keys.