### PR TITLE
core/config: introduce AddOrUpdate

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -444,7 +444,13 @@ func get(client *rpc.Client, args []string) {
 }
 
 func add(client *rpc.Client, args []string) {
-	const usage = "usage: corectl add [key] [value]..."
+	const usage = "usage: corectl add [-u] [key] [value]..."
+
+	op := "add"
+	if len(args) > 0 && args[0] == "-u" {
+		op = "add-or-update"
+		args = args[1:]
+	}
 	if len(args) < 2 {
 		fatalln(usage)
 	}
@@ -452,7 +458,7 @@ func add(client *rpc.Client, args []string) {
 	req := map[string]interface{}{
 		"updates": []interface{}{
 			map[string]interface{}{
-				"op":    "add",
+				"op":    op,
 				"key":   args[0],
 				"tuple": args[1:],
 			},

--- a/core/config/options.go
+++ b/core/config/options.go
@@ -155,7 +155,7 @@ func (opts *Options) Add(key string, tup []string) sinkdb.Op {
 }
 
 // AddOrUpdate adds the provided tuple to the configuration option
-// set indicated by key. The the added tuple conflicts with an
+// set indicated by key. If the added tuple conflicts with an
 // existing tuple in the set, AddOrUpdate updates the conflicting
 // tuple to the provided tuple.
 func (opts *Options) AddOrUpdate(key string, tup []string) sinkdb.Op {

--- a/core/config/options.go
+++ b/core/config/options.go
@@ -271,9 +271,10 @@ func tupleIndex(set []*configpb.ValueTuple, search []string, equal func(a, b []s
 }
 
 func exactlyEqual(a, b []string) bool {
-	eq := true
 	for i := range a {
-		eq = eq && a[i] == b[i]
+		if a[i] != b[i] {
+			return false
+		}
 	}
-	return eq
+	return true
 }

--- a/core/config/options.go
+++ b/core/config/options.go
@@ -203,8 +203,9 @@ func (opts *Options) add(key string, tup []string, onConflict func(new, existing
 		// is a no-op
 		return sinkdb.IfNotModified(ver)
 	} else {
-		// tup's key matches an existing tuple but not exactly.
-		// use onConflict to determine how to handle the conflict
+		// tup's key matches an existing tuple but the rest of
+		// tup does not match. use onConflict to determine how
+		// to handle the conflict
 		err = onConflict(cleaned, set.Tuples[idx].Values)
 		if err != nil {
 			return sinkdb.Error(err)

--- a/core/config/options_test.go
+++ b/core/config/options_test.go
@@ -10,6 +10,7 @@ import (
 
 func identityFunc(tup []string) error    { return nil }
 func reflectEquality(a, b []string) bool { return reflect.DeepEqual(a, b) }
+func firstEqual(a, b []string) bool      { return a[0] == b[0] }
 
 func must(t testing.TB, err error) {
 	if err != nil {
@@ -45,6 +46,26 @@ func TestSetTuples(t *testing.T) {
 	got, err = opts.List(ctx, "example")
 	must(t, err)
 	want = [][]string{{"baz", "bax"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestSetTuplesOverwrite(t *testing.T) {
+	sdb := sinkdbtest.NewDB(t)
+	opts := New(sdb)
+	opts.DefineSet("example", 2, identityFunc, firstEqual)
+
+	ctx := context.Background()
+	must(t, sdb.Exec(ctx, opts.Add("example", []string{"foo", "bar"})))
+	must(t, sdb.Exec(ctx, opts.Add("example", []string{"foo", "baz"})))
+
+	// Because equality is defined on the first tuple, "example" should
+	// now have a single tuple in its set: (foo, baz).
+
+	got, err := opts.List(ctx, "example")
+	must(t, err)
+	want := [][]string{{"foo", "baz"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %#v, want %#v", got, want)
 	}

--- a/core/config/options_test.go
+++ b/core/config/options_test.go
@@ -60,7 +60,7 @@ func TestAddOrUpdate(t *testing.T) {
 	must(t, sdb.Exec(ctx, opts.AddOrUpdate("example", []string{"foo", "bar"})))
 	must(t, sdb.Exec(ctx, opts.AddOrUpdate("example", []string{"foo", "baz"})))
 
-	// Because equality is defined on the first tuple, "example" should
+	// Because equality is defined on the first value, "example" should
 	// now have a single tuple in its set: (foo, baz).
 
 	got, err := opts.List(ctx, "example")

--- a/core/config/options_test.go
+++ b/core/config/options_test.go
@@ -18,7 +18,7 @@ func must(t testing.TB, err error) {
 	}
 }
 
-func TestSetTuples(t *testing.T) {
+func TestAdd(t *testing.T) {
 	sdb := sinkdbtest.NewDB(t)
 	opts := New(sdb)
 	opts.DefineSet("example", 2, identityFunc, reflectEquality)
@@ -51,14 +51,14 @@ func TestSetTuples(t *testing.T) {
 	}
 }
 
-func TestSetTuplesOverwrite(t *testing.T) {
+func TestAddOrUpdate(t *testing.T) {
 	sdb := sinkdbtest.NewDB(t)
 	opts := New(sdb)
 	opts.DefineSet("example", 2, identityFunc, firstEqual)
 
 	ctx := context.Background()
-	must(t, sdb.Exec(ctx, opts.Add("example", []string{"foo", "bar"})))
-	must(t, sdb.Exec(ctx, opts.Add("example", []string{"foo", "baz"})))
+	must(t, sdb.Exec(ctx, opts.AddOrUpdate("example", []string{"foo", "bar"})))
+	must(t, sdb.Exec(ctx, opts.AddOrUpdate("example", []string{"foo", "baz"})))
 
 	// Because equality is defined on the first tuple, "example" should
 	// now have a single tuple in its set: (foo, baz).

--- a/core/core.go
+++ b/core/core.go
@@ -173,6 +173,8 @@ func (a *API) configure(ctx context.Context, req configureRequest) error {
 		switch update.Op {
 		case "add":
 			ops = append(ops, a.options.Add(update.Key, update.Tuple))
+		case "add-or-update":
+			ops = append(ops, a.options.AddOrUpdate(update.Key, update.Tuple))
 		case "rm":
 			ops = append(ops, a.options.Remove(update.Key, update.Tuple))
 		default:

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3290";
+	public final String Id = "main/rev3291";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3290"
+const ID string = "main/rev3291"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3290"
+export const rev_id = "main/rev3291"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3290".freeze
+	ID = "main/rev3291".freeze
 end


### PR DESCRIPTION
For set configuration options, equality may be defined on a subset of
the fields of the tuple. Previously, we treated an Add of a tuple with
an existing key as a no-op. This splits the Add method into Add and
AddOrUpdate. Add will error if a tuple's key conflicts with an existing
tuple that is not exactly equal to the new tuple. AddOrUpdate will
replace the conflicting tuple.

This commit also updates corectl to allow providing the `-u` flag to
use the AddOrUpdate behavior.