### PR TITLE
core/blocksigner: add EnclaveClient

### DIFF
--- a/core/blocksigner/blocksigner.go
+++ b/core/blocksigner/blocksigner.go
@@ -24,7 +24,7 @@ var ErrConsensusChange = errors.New("consensus program has changed")
 var ErrInvalidKey = errors.New("misconfigured signer public key")
 
 // Signer provides the interface for computing the block signature. It's
-// implemented by the MockHSM and our signerd client.
+// implemented by the MockHSM and EnclaveClient.
 type Signer interface {
 	Sign(context.Context, ed25519.PublicKey, *legacy.BlockHeader) ([]byte, error)
 }

--- a/core/blocksigner/enclave.go
+++ b/core/blocksigner/enclave.go
@@ -1,0 +1,57 @@
+package blocksigner
+
+import (
+	"context"
+	"time"
+
+	"chain/core/rpc"
+	"chain/crypto/ed25519"
+	"chain/encoding/json"
+	"chain/protocol/bc/legacy"
+)
+
+// enclaveTimeout is the time to wait for an HSM's response to a
+// sign-block request before moving on to the next HSM. Because
+// blocks are expected to be generated every second, one second
+// retireving a signature would be a very high latency.
+const enclaveTimeout = time.Second
+
+// EnclaveClient implements the Signer interface by calling
+// Chain Enclave to sign blocks.
+type EnclaveClient struct {
+	// URLs is called on every Sign request to retrieve the URLs
+	// and access tokens for Chain Enclave.
+	URLs       func() [][]string
+	BaseClient rpc.Client
+}
+
+type signRequestBody struct {
+	Block *legacy.BlockHeader `json:"block"`
+	Pub   json.HexBytes       `json:"pubkey"`
+}
+
+func (ec EnclaveClient) Sign(ctx context.Context, pk ed25519.PublicKey, bh *legacy.BlockHeader) ([]byte, error) {
+	body := signRequestBody{Block: bh, Pub: json.HexBytes(pk[:])}
+
+	// make a copy of the base rpc client on the stack so we
+	// can modify it with the HSM URLs and access tokens
+	client := ec.BaseClient
+
+	// grab the latest set of hsms from the configuration
+	hsmURLs := ec.URLs()
+
+	var signature []byte
+	var err error
+	for _, tup := range hsmURLs {
+		client.BaseURL = tup[0]
+		client.AccessToken = tup[1]
+
+		callCtx, cancel := context.WithTimeout(ctx, enclaveTimeout)
+		err = client.Call(callCtx, "/sign-block", body, &signature)
+		cancel()
+		if err == nil {
+			return signature, nil
+		}
+	}
+	return nil, err
+}

--- a/core/blocksigner/enclave.go
+++ b/core/blocksigner/enclave.go
@@ -42,11 +42,11 @@ func (ec EnclaveClient) Sign(ctx context.Context, pk ed25519.PublicKey, bh *lega
 		client.BaseURL = tup[0]
 		client.AccessToken = tup[1]
 
-		go func(client rpc.Client) {
+		go func() {
 			var signature []byte
 			err := client.Call(ctx, "/sign-block", body, &signature)
 			ch <- result{signature: signature, err: err}
-		}(client)
+		}()
 	}
 
 	var err error

--- a/core/blocksigner/enclave.go
+++ b/core/blocksigner/enclave.go
@@ -19,7 +19,7 @@ const enclaveTimeout = time.Second
 // EnclaveClient implements the Signer interface by calling
 // Chain Enclave to sign blocks.
 type EnclaveClient struct {
-	// URLs is called on every Sign request to retrieve the URLs
+	// URLs is called on every Sign call to retrieve the URLs
 	// and access tokens for Chain Enclave.
 	URLs       func() [][]string
 	BaseClient rpc.Client

--- a/core/blocksigner/enclave_test.go
+++ b/core/blocksigner/enclave_test.go
@@ -1,0 +1,70 @@
+package blocksigner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"chain/core/rpc"
+	"chain/crypto/ed25519"
+	"chain/protocol/bc/legacy"
+)
+
+func TestEnclaveClient(t *testing.T) {
+	fakeSignature := []byte(`fakesignature`)
+
+	// Create two test servers. One that always times out, the other
+	// that will immediately return a correct signature.
+	sv1 := httptest.NewServer(timeoutHandler(enclaveTimeout + time.Second))
+	defer sv1.Close()
+	sv2 := httptest.NewServer(fakeEnclavedHandler(t, "access-token-2", fakeSignature))
+	defer sv2.Close()
+
+	c := EnclaveClient{
+		URLs: func() [][]string {
+			return [][]string{
+				{sv1.URL, "chain-core:access-token-1"},
+				{sv2.URL, "chain-core:access-token-2"},
+			}
+		},
+		BaseClient: rpc.Client{},
+	}
+
+	ctx := context.Background()
+	var bh legacy.BlockHeader
+	sig, err := c.Sign(ctx, make(ed25519.PublicKey, ed25519.PublicKeySize), &bh)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(sig, fakeSignature) {
+		t.Errorf("got signature %x, want %x", sig, fakeSignature)
+	}
+}
+
+func timeoutHandler(sleep time.Duration) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		time.Sleep(sleep)
+		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
+		rw.WriteHeader(http.StatusRequestTimeout)
+		json.NewEncoder(rw).Encode("Request timed out.")
+	})
+}
+
+func fakeEnclavedHandler(t testing.TB, accessToken string, sig []byte) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		_, pass, ok := req.BasicAuth()
+		if !ok || pass != accessToken {
+			t.Fatalf("Got basic auth access token %q, want %q", pass, accessToken)
+		}
+
+		// Encode the signature as a json string containing the
+		// base64-encoded bytes. This is how enclaved formats its response.
+		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
+		rw.WriteHeader(http.StatusOK)
+		json.NewEncoder(rw).Encode(sig)
+	})
+}

--- a/core/blocksigner/enclave_test.go
+++ b/core/blocksigner/enclave_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"chain/core/rpc"
 	"chain/crypto/ed25519"
@@ -19,7 +18,7 @@ func TestEnclaveClient(t *testing.T) {
 
 	// Create two test servers. One that always times out, the other
 	// that will immediately return a correct signature.
-	sv1 := httptest.NewServer(timeoutHandler(enclaveTimeout + time.Second))
+	sv1 := httptest.NewServer(timeoutHandler())
 	defer sv1.Close()
 	sv2 := httptest.NewServer(fakeEnclavedHandler(t, "access-token-2", fakeSignature))
 	defer sv2.Close()
@@ -45,9 +44,8 @@ func TestEnclaveClient(t *testing.T) {
 	}
 }
 
-func timeoutHandler(sleep time.Duration) http.Handler {
+func timeoutHandler() http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		time.Sleep(sleep)
 		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 		rw.WriteHeader(http.StatusRequestTimeout)
 		json.NewEncoder(rw).Encode("Request timed out.")

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3315";
+	public final String Id = "main/rev3316";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3315"
+const ID string = "main/rev3316"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3315"
+export const rev_id = "main/rev3316"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3315".freeze
+	ID = "main/rev3316".freeze
 end


### PR DESCRIPTION
Move the Chain Enclave client from main.go into the core/blocksigner
package. Support multiple Chain Enclave URLs in the client to prepare
for retrieving multiple URLs from a core/config configuration option.

A future commit will define a new configuration option and propagate
its ListFunc closure to EnclaveClient.URLs.