### PR TITLE
core/rpc: rename Client.Username

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -380,7 +380,7 @@ func launchConfiguredCore(ctx context.Context, sdb *sinkdb.DB, db *sql.DB, conf 
 		opts = append(opts, core.GeneratorRemote(&rpc.Client{
 			BaseURL:      conf.GeneratorUrl,
 			AccessToken:  conf.GeneratorAccessToken,
-			Username:     processID,
+			ProcessID:    processID,
 			CoreID:       conf.Id,
 			Version:      version,
 			BlockchainID: conf.BlockchainId.String(),
@@ -405,7 +405,7 @@ func initializeLocalSigner(ctx context.Context, conf *config.Config, db pg.DB, c
 		hsm = &remoteHSM{Client: &rpc.Client{
 			BaseURL:      conf.BlockHsmUrl,
 			AccessToken:  conf.BlockHsmAccessToken,
-			Username:     processID,
+			ProcessID:    processID,
 			CoreID:       conf.Id,
 			Version:      version,
 			BlockchainID: conf.BlockchainId.String(),
@@ -449,7 +449,7 @@ func remoteSignerInfo(ctx context.Context, processID, blockchainID string, conf 
 		client := &rpc.Client{
 			BaseURL:      u.String(),
 			AccessToken:  signer.AccessToken,
-			Username:     processID,
+			ProcessID:    processID,
 			CoreID:       conf.Id,
 			Version:      version,
 			BlockchainID: blockchainID,

--- a/cmd/metricsd/main.go
+++ b/cmd/metricsd/main.go
@@ -50,7 +50,7 @@ func main() {
 	ctx := context.Background()
 	client := &rpc.Client{
 		BaseURL:     *coredAddr,
-		Username:    userAgent,
+		ProcessID:   userAgent,
 		AccessToken: *coredAccessToken,
 	}
 

--- a/cmd/testnet-reset/main.go
+++ b/cmd/testnet-reset/main.go
@@ -35,7 +35,7 @@ func coreEnv(prefix string) (*rpc.Client, core) {
 	client := &rpc.Client{
 		BaseURL:     url,
 		AccessToken: clientTok,
-		Username:    "testnet-resetter", // for user-agent, not auth
+		ProcessID:   "testnet-resetter", // for user-agent, not auth
 		Version:     "none",
 	}
 

--- a/cmd/testnet-reset/main.go
+++ b/cmd/testnet-reset/main.go
@@ -35,7 +35,7 @@ func coreEnv(prefix string) (*rpc.Client, core) {
 	client := &rpc.Client{
 		BaseURL:     url,
 		AccessToken: clientTok,
-		ProcessID:   "testnet-resetter", // for user-agent, not auth
+		ProcessID:   "testnet-resetter",
 		Version:     "none",
 	}
 

--- a/core/rpc/rpc.go
+++ b/core/rpc/rpc.go
@@ -34,7 +34,7 @@ var ErrWrongNetwork = errors.New("connected to a peer on a different network")
 type Client struct {
 	BaseURL      string
 	AccessToken  string
-	Username     string
+	ProcessID    string
 	Version      string
 	BlockchainID string
 	CoreID       string
@@ -46,7 +46,7 @@ type Client struct {
 
 func (c Client) userAgent() string {
 	return fmt.Sprintf("Chain; process=%s; version=%s; blockchainID=%s",
-		c.Username, c.Version, c.BlockchainID)
+		c.ProcessID, c.Version, c.BlockchainID)
 }
 
 // ErrStatusCode is an error returned when an rpc fails with a non-200

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3296";
+	public final String Id = "main/rev3297";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3296"
+const ID string = "main/rev3297"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3296"
+export const rev_id = "main/rev3297"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3296".freeze
+	ID = "main/rev3297".freeze
 end


### PR DESCRIPTION
Rename Client.Username to ProcessID. Client uses basic auth when
AccessToken is not empty, but Username is the not the username used
in basic auth. Username is only used for the user agent. Rename it
prevent confusion.