### PR TITLE
docker/de: remove recommendations to remove container

### DIFF
--- a/docker/de/Readme.md
+++ b/docker/de/Readme.md
@@ -17,7 +17,7 @@ $ sh bin/build-docker-de
 >**Note:** The `--name` flag allows you to name the container and refer to that name in subsequent commands.
 
 ```sh
-$ docker run --rm -p 1999:1999 --name chaincore chaincore/developer
+$ docker run -p 1999:1999 --name chaincore chaincore/developer
 ```
 
 By default, once you stop a running a container, all data is lost. Chain Core stores data in three locations: a data directory, a separate Postgres database, and a log directory. To persist the data, create directories on your development machine and mount them to the container on `docker run`:
@@ -26,7 +26,7 @@ By default, once you stop a running a container, all data is lost. Chain Core st
 $ mkdir -p /path/to/store/datadir
 $ mkdir -p /path/to/store/postgres
 $ mkdir -p path/to/store/logs
-$ docker run --rm -p 1999:1999 \
+$ docker run -p 1999:1999 \
     -v /path/to/store/datadir:/root/.chaincore \
     -v /path/to/store/postgres:/var/lib/postgresql/data \
     -v /path/to/store/logs:/var/log/chain \

--- a/docker/de/Readme.md
+++ b/docker/de/Readme.md
@@ -20,7 +20,7 @@ $ sh bin/build-docker-de
 $ docker run -p 1999:1999 --name chaincore chaincore/developer
 ```
 
-By default, once you stop a running a container, all data is lost. Chain Core stores data in three locations: a data directory, a separate Postgres database, and a log directory. To persist the data, create directories on your development machine and mount them to the container on `docker run`:
+Chain Core stores data in three locations: a data directory, a separate Postgres database, and a log directory. To persist the data, create directories on your development machine and mount them to the container on `docker run`:
 
 ```sh
 $ mkdir -p /path/to/store/datadir

--- a/docs/1.2/core/reference/changelog.md
+++ b/docs/1.2/core/reference/changelog.md
@@ -51,7 +51,7 @@ Chain Core now requires the use of the local filesystem for persistent data. As 
 **Docker users** should take care to mount a volume for the Chain Core data directory, or else the server state will not persist between runs of the container:
 
 ```
-$ docker run --rm -p 1999:1999 \
+$ docker run -p 1999:1999 \
     -v /path/to/store/datadir:/root/.chaincore \
     -v /path/to/store/postgres:/var/lib/postgresql/data \
     -v /path/to/store/logs:/var/log/chain \

--- a/docs/future/core/reference/changelog.md
+++ b/docs/future/core/reference/changelog.md
@@ -22,7 +22,7 @@ Chain Core now requires the use of the local filesystem for persistent data. As 
 **Docker users** should take care to mount a volume for the Chain Core data directory, or else the server state will not persist between runs of the container:
 
 ```
-$ docker run --rm -p 1999:1999 \
+$ docker run -p 1999:1999 \
     -v /path/to/store/datadir:/root/.chaincore \
     -v /path/to/store/postgres:/var/lib/postgresql/data \
     -v /path/to/store/logs:/var/log/chain \

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3291";
+	public final String Id = "main/rev3292";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3291"
+const ID string = "main/rev3292"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3291"
+export const rev_id = "main/rev3292"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3291".freeze
+	ID = "main/rev3292".freeze
 end


### PR DESCRIPTION
Most of our Docker docs use CLI examples that remove the container
after it has finished running. There doesn't appear to be any
reason for this related to running Chain Core itself, and it is
probably not what most people want when running Docker.