### PR TITLE
dashboard: coalesce transaction summaries by control program

### DIFF
--- a/dashboard/src/features/transactions/components/Summary/Summary.jsx
+++ b/dashboard/src/features/transactions/components/Summary/Summary.jsx
@@ -24,12 +24,16 @@ class Summary extends React.Component {
       if (['issue', 'retire'].includes(inout.type)) {
         asset[inout.type] += inout.amount
       } else {
-        let accountKey = inout.accountId || 'external'
+        let accountKey = inout.accountId || inout.controlProgram
         let account = asset[accountKey]
         if (!account) account = asset[accountKey] = {
           alias: inout.accountAlias,
           spend: 0,
           control: 0
+        }
+
+        if (!inout.accountId) {
+          account.external = true
         }
 
         if (inout.type == 'spend') {
@@ -72,7 +76,7 @@ class Summary extends React.Component {
         const account = asset[accountId]
         if (!account) return
 
-        if (accountId == 'external') {
+        if (account.external) {
           account.alias = 'external'
           accountId = null
         }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3292";
+	public final String Id = "main/rev3293";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3292"
+const ID string = "main/rev3293"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3292"
+export const rev_id = "main/rev3293"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3292".freeze
+	ID = "main/rev3293".freeze
 end


### PR DESCRIPTION
When observing transactions that contain only external 
accounts, users would see identical "Spend" and "Control" 
amounts regardless of the actual inputs and outputs.

External outputs are now coalesced by control program, 
allowing users to see the amount they expect to see on 
the control-side of the transaction, and the resulting 
`change` outputs.