### PR TITLE
database/sinkdb: move file reading from net/raft

### DIFF
--- a/database/sinkdb/state.go
+++ b/database/sinkdb/state.go
@@ -3,6 +3,7 @@ package sinkdb
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
 	"sync"
 
@@ -232,6 +233,16 @@ func (s *state) EmptyWrite() (instruction []byte) {
 			Value: []byte(""),
 		}}})
 	return instruction
+}
+
+// ReadFile wraps ioutil.ReadFile for future dependcy injection
+func (s *state) ReadFile(filename string) (data []byte, err error) {
+	data, err = ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	return data, nil
 }
 
 // WriteFile is like ioutil.WriteFile, but it writes safely and atomically.

--- a/net/raft/raft.go
+++ b/net/raft/raft.go
@@ -806,8 +806,8 @@ func (sv *Service) recover() (*wal.WAL, error) {
 
 	var raftSnap raftpb.Snapshot
 	snapData, err := sv.state.ReadFile(sv.snapFile())
-	if err != nil && !os.IsNotExist(err) {
-		return nil, errors.Wrap(err)
+	if err != nil && !os.IsNotExist(errors.Root(err)) {
+		return nil, err
 	}
 	if err == nil {
 		err = decodeSnapshot(snapData, &raftSnap)

--- a/net/raft/raft_test.go
+++ b/net/raft/raft_test.go
@@ -78,6 +78,7 @@ var idErrorCases = [][]byte{
 }
 
 func TestReadIDError(t *testing.T) {
+	sv := Service{state: newTestState()}
 	dir, err := ioutil.TempDir("", "raft_test.go")
 	if err != nil {
 		t.Fatal(err)
@@ -90,7 +91,7 @@ func TestReadIDError(t *testing.T) {
 			continue
 		}
 
-		_, err := readID(dir)
+		_, err := sv.readID(dir)
 		if err == nil {
 			t.Errorf("readID of %v => err = nil, want error", test)
 		}
@@ -105,7 +106,7 @@ func TestStartUninitialized(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	sv, err := Start("", dir, http.DefaultClient, nil)
+	sv, err := Start("", dir, http.DefaultClient, newTestState())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/net/raft/raft_test.go
+++ b/net/raft/raft_test.go
@@ -46,6 +46,7 @@ func TestWriteID(t *testing.T) {
 }
 
 func TestReadID(t *testing.T) {
+	sv := Service{state: newTestState()}
 	dir, err := ioutil.TempDir("", "raft_test.go")
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +59,7 @@ func TestReadID(t *testing.T) {
 			continue
 		}
 
-		got, err := readID(dir)
+		got, err := sv.readID(dir)
 		if err != nil {
 			t.Error(err)
 			continue

--- a/net/raft/state_test.go
+++ b/net/raft/state_test.go
@@ -56,6 +56,10 @@ func (s *state) EmptyWrite() []byte {
 	return encodeInstruction(instruction{})
 }
 
+func (s *state) ReadFile(filename string) (data []byte, err error) {
+	return ioutil.ReadFile(filename)
+}
+
 func (s *state) WriteFile(name string, data []byte, perm os.FileMode) error {
 	return ioutil.WriteFile(name, data, perm)
 }


### PR DESCRIPTION
Following #1380, this moves file reading from the raft package 
into the sinkdb package to prepare for future interfaces.