### PR TITLE
net/http/reqid: remove path, coreid

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -324,7 +324,7 @@ func loggingHandler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		ctx = log.AddPrefixkv(ctx, "path", req.URL.Path)
-		if userAgent := req.Header.Get("User-Agent"); userAgent != "" {
+		if userAgent := req.UserAgent(); userAgent != "" {
 			ctx = log.AddPrefixkv(ctx, "useragent", userAgent)
 		}
 		if coreID := req.Header.Get("Chain-Core-ID"); coreID != "" {

--- a/core/metrics.go
+++ b/core/metrics.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"chain/metrics"
-	"chain/net/http/reqid"
 )
 
 var (
@@ -52,7 +51,9 @@ var (
 
 func coreCounter(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		countCore(reqid.CoreIDFromContext(req.Context()))
+		if coreID := req.Header.Get("Chain-Core-ID"); coreID != "" {
+			countCore(coreID)
+		}
 		h.ServeHTTP(w, req)
 	})
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3309";
+	public final String Id = "main/rev3310";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3309"
+const ID string = "main/rev3310"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3309"
+export const rev_id = "main/rev3310"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3309".freeze
+	ID = "main/rev3310".freeze
 end

--- a/net/http/httperror/httperror.go
+++ b/net/http/httperror/httperror.go
@@ -11,7 +11,6 @@ import (
 	"chain/errors"
 	"chain/log"
 	"chain/net/http/httpjson"
-	"chain/net/http/reqid"
 )
 
 func init() {
@@ -101,7 +100,6 @@ func (f Formatter) Log(ctx context.Context, err error) {
 	keyvals := []interface{}{
 		"status", resp.HTTPStatus,
 		"chaincode", resp.ChainCode,
-		"path", reqid.PathFromContext(ctx),
 		log.KeyError, errorMessage,
 	}
 	if resp.HTTPStatus == 500 {

--- a/net/http/reqid/reqid.go
+++ b/net/http/reqid/reqid.go
@@ -23,11 +23,6 @@ const (
 	// unexported; clients use NewSubContext and FromSubContext
 	// instead of using this key directly.
 	subReqIDKey
-	// coreIDKey is the key for Chain-Core-ID request header field values.
-	// It is only for statistics; don't use it for authorization.
-	coreIDKey
-	// pathKey is the key for the request path being handled.
-	pathKey
 )
 
 // New generates a random request ID.
@@ -64,20 +59,6 @@ func FromContext(ctx context.Context) string {
 	return reqID
 }
 
-// CoreIDFromContext returns the Chain-Core-ID stored in ctx,
-// or the empty string.
-func CoreIDFromContext(ctx context.Context) string {
-	id, _ := ctx.Value(coreIDKey).(string)
-	return id
-}
-
-// PathFromContext returns the HTTP path stored in ctx,
-// or the empty string.
-func PathFromContext(ctx context.Context) string {
-	path, _ := ctx.Value(pathKey).(string)
-	return path
-}
-
 // NewSubContext returns a new Context that carries subreqid
 // It also adds a log prefix to print the sub-request ID using
 // package chain/log.
@@ -100,11 +81,6 @@ func Handler(handler http.Handler) http.Handler {
 		// TODO(kr): take half of request ID from the client
 		id := New()
 		ctx = NewContext(ctx, id)
-		ctx = context.WithValue(ctx, pathKey, req.URL.Path)
-		if coreID := req.Header.Get("Chain-Core-ID"); coreID != "" {
-			ctx = context.WithValue(ctx, coreIDKey, coreID)
-			ctx = log.AddPrefixkv(ctx, "coreid", coreID)
-		}
 
 		defer func() {
 			if err := recover(); err != nil {


### PR DESCRIPTION
Remove the Path and Core ID context annotation from net/http/reqid.
Replace it with additional middleware in chian/core.

Add logging of request user agents.