### PR TITLE
core: delete access token grants in a batch

### DIFF
--- a/core/access_tokens.go
+++ b/core/access_tokens.go
@@ -93,7 +93,7 @@ func (a *API) deleteAccessToken(ctx context.Context, x struct{ ID string }) erro
 		return err
 	}
 
-	err = a.deleteGrantsByAccessToken(ctx, x.ID)
+	err = a.sdb.Exec(ctx, a.deleteGrantsByAccessToken(ctx, x.ID))
 	if err != nil {
 		// well, technically we did delete the access token, so don't return the error
 		// TODO(tessr): make this whole operation atomic, such that we either delete

--- a/core/grants_test.go
+++ b/core/grants_test.go
@@ -287,7 +287,7 @@ func TestDeleteGrantsByAccessToken(t *testing.T) {
 	}
 
 	// first check that we can delete a single grant
-	err = api.deleteGrantsByAccessToken(ctx, "test-token-1")
+	err = api.sdb.Exec(ctx, api.deleteGrantsByAccessToken(ctx, "test-token-1"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +301,7 @@ func TestDeleteGrantsByAccessToken(t *testing.T) {
 	}
 
 	// next check on deleting an access token associates with multiple grants
-	err = api.deleteGrantsByAccessToken(ctx, "test-token-0")
+	err = api.sdb.Exec(ctx, api.deleteGrantsByAccessToken(ctx, "test-token-0"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3295";
+	public final String Id = "main/rev3296";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3295"
+const ID string = "main/rev3296"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3295"
+export const rev_id = "main/rev3296"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3295".freeze
+	ID = "main/rev3296".freeze
 end


### PR DESCRIPTION
When deleting an access token, delete all of the associated
grants in a single batch. Previously, we'd delete the grants for
each policy separately.

If _n_ is the number of policies, we'd need to wait for _2n_ raft
consensus rounds to delete all of the grants (1 for a linearizable
read, 1 for the write). Now we wait _n+1_ consensus rounds. Since
grants.Delete is just doing a read-modify-write, we should be able
to do an optimistic stale read so we only have to wait for a
single consensus round.

Since this change returns a sinkdb.Op, it'll also make it easier
to delete access tokens and their grants atomically down the
road.