### PR TITLE
protocol: fix ApplyValidBlock unprotected access

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3298";
+	public final String Id = "main/rev3299";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3298"
+const ID string = "main/rev3299"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3298"
+export const rev_id = "main/rev3299"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3298".freeze
+	ID = "main/rev3299".freeze
 end

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -125,7 +125,7 @@ func NewChain(ctx context.Context, initialBlockHash bc.Hash, store Store, height
 		return nil, errors.Wrap(err, "looking up blockchain height")
 	}
 
-	// Note that c.height.n may still be zero here.
+	// Note that c.state.height may still be zero here.
 	if heights != nil {
 		go func() {
 			for h := range heights {


### PR DESCRIPTION
The current snapshot (c.state.snapshot) is protected by the mutex
c.state.cond.L. Previously ApplyValidBlock accessed the snapshot
without acquiring the mutex.

Also, fix a few comments in chain/protocol.