### PR TITLE
protocol: make block committing idempotent

### DIFF
--- a/core/fetch/fetch.go
+++ b/core/fetch/fetch.go
@@ -161,11 +161,7 @@ func applyBlock(ctx context.Context, c *protocol.Chain, prevSnap *state.Snapshot
 	if err != nil {
 		return errors.Wrap(err, "validating fetched block")
 	}
-	snap, err := c.ApplyValidBlock(block)
-	if err != nil {
-		return errors.Wrap(err, "applying fetched block")
-	}
-	err = c.CommitAppliedBlock(ctx, block, snap)
+	err = c.CommitBlock(ctx, block)
 	return errors.Wrap(err, "committing block")
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3314";
+	public final String Id = "main/rev3315";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3314"
+const ID string = "main/rev3315"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3314"
+export const rev_id = "main/rev3315"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3314".freeze
+	ID = "main/rev3315".freeze
 end

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -251,7 +251,7 @@ func TestCommitBlockIdempotence(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
-		go func(i int) {
+		go func() {
 			for j := 0; j < len(blocks); j++ {
 				err := c.CommitBlock(ctx, blocks[j])
 				if err != nil {
@@ -259,7 +259,7 @@ func TestCommitBlockIdempotence(t *testing.T) {
 				}
 			}
 			wg.Done()
-		}(i)
+		}()
 	}
 	wg.Wait()
 

--- a/protocol/block_test.go
+++ b/protocol/block_test.go
@@ -3,6 +3,8 @@ package protocol
 import (
 	"context"
 	"encoding/hex"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -208,6 +210,65 @@ func TestValidateBlockForSig(t *testing.T) {
 	err = c.ValidateBlockForSig(ctx, initialBlock)
 	if err != nil {
 		t.Error("unexpected error ", err)
+	}
+}
+
+func TestCommitBlockIdempotence(t *testing.T) {
+	const numOfBlocks = 10
+	const concurrency = 5
+	ctx := context.Background()
+
+	now := time.Now()
+	c, b1 := newTestChain(t, now)
+
+	var blocks []*legacy.Block
+	b, s := b1, state.Empty()
+	for i := 0; i < numOfBlocks; i++ {
+		tx, _, _ := issue(t, nil, nil, 1)
+		newBlock, newSnapshot, err := c.GenerateBlock(ctx, b, s, now.Add(time.Duration(i+1)*time.Second), []*legacy.Tx{tx})
+		if err != nil {
+			testutil.FatalErr(t, err)
+		}
+		err = c.CommitAppliedBlock(ctx, newBlock, newSnapshot)
+		if err != nil {
+			testutil.FatalErr(t, err)
+		}
+		blocks = append(blocks, newBlock)
+		b, s = newBlock, newSnapshot
+	}
+	wantBlock, wantSnapshot := b, s
+
+	// Create a fresh Chain for the same blockchain / initial hash.
+	c, err := NewChain(ctx, b1.Hash(), memstore.New(), nil)
+	if err != nil {
+		testutil.FatalErr(t, err)
+	}
+	c.MaxIssuanceWindow = 48 * time.Hour
+	c.setState(b1, state.Empty())
+
+	// Apply all of the blocks concurrently in separate goroutines
+	// using CommitBlock. They should all succeed.
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			for j := 0; j < len(blocks); j++ {
+				err := c.CommitBlock(ctx, blocks[j])
+				if err != nil {
+					testutil.FatalErr(t, err)
+				}
+			}
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+
+	gotBlock, gotSnapshot := c.State()
+	if !reflect.DeepEqual(gotBlock, wantBlock) {
+		t.Errorf("got block %#v, want %#v", gotBlock, wantBlock)
+	}
+	if !reflect.DeepEqual(gotSnapshot, wantSnapshot) {
+		t.Errorf("got block %#v, want %#v", gotSnapshot, wantSnapshot)
 	}
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -38,7 +38,10 @@ to TXSIGHASH.
 
 New block sequence
 
-Every new block must be validated against the existing blockchain state. New blocks are validated by calling ValidateBlock. Blocks produced by GenerateBlock are already known to be valid.
+Every new block must be validated against the existing
+blockchain state. New blocks are validated by calling
+ValidateBlock. Blocks produced by GenerateBlock are already
+known to be valid.
 
 A new block goes through the sequence:
   - If not generated locally, the block is validated by

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -15,7 +15,7 @@ other nodes and putting them into blocks.
 
 To add a new block to the blockchain, call GenerateBlock,
 sign the block (possibly collecting signatures from other
-parties), and call CommitBlock.
+parties), and call CommitAppliedBlock.
 
 Signer
 
@@ -36,7 +36,41 @@ transaction has been either confirmed or rejected. Note
 that transactions may be malleable if there's no commitment
 to TXSIGHASH.
 
-To ingest a block, call ValidateBlock and CommitBlock.
+New block sequence
+
+Every new block must be validated against the existing blockchain state. New blocks are validated by calling ValidateBlock. Blocks produced by GenerateBlock are already known to be valid.
+
+A new block goes through the sequence:
+  - If not generated locally, the block is validated by
+    calling ValidateBlock.
+  - The new block is committed to the Chain's Store through
+    its SaveBlock method. This is the linearization point.
+    Once a block is saved to the Store, it's committed and
+    can be recovered after a crash.
+  - The Chain's in-memory representation of the blockchain
+    state is updated. If the block was remotely-generated,
+    the Chain must apply the new block to its current state
+    to retrieve the new state. If the block was generated
+    locally, the resulting state is already known and does
+    not need to be recalculated.
+  - Other cored processes are notified of the new block
+    through Store.FinalizeBlock.
+
+Committing a block
+
+As a consumer of the package, there are two ways to
+commit a new block: CommitBlock and CommitAppliedBlock.
+
+When generating new blocks, GenerateBlock will return
+the resulting state snapshot with the new block. To
+ingest a block with a known resulting state snapshot,
+call CommitAppliedBlock.
+
+When ingesting remotely-generated blocks, the state after
+the block must be calculated by taking the Chain's
+current state and applying the new block. To ingest a
+block without a known resulting state snapshot, call
+CommitBlock.
 */
 package protocol
 


### PR DESCRIPTION
Previously, we only called CommitAppliedBlock from a single goroutine:
either the core/generator or the core/fetch goroutine. This meant we
could access c.State() and apply new blocks to it without the possiblity
of another goroutine applying newer blocks first.

When we modify Chain to always have an up-to-date state tree regardless
of leader status, the goroutine listening to txdb.ListenBlocks heights
will need to also apply blocks. In preparation for this change, we need
to make committing & applying a block idempotent.