### PR TITLE
net/http/authz: use stale read in Delete

### DIFF
--- a/core/access_tokens.go
+++ b/core/access_tokens.go
@@ -93,7 +93,7 @@ func (a *API) deleteAccessToken(ctx context.Context, x struct{ ID string }) erro
 		return err
 	}
 
-	err = a.sdb.Exec(ctx, a.deleteGrantsByAccessToken(ctx, x.ID))
+	err = a.sdb.Exec(ctx, a.deleteGrantsByAccessToken(x.ID))
 	if err != nil {
 		// well, technically we did delete the access token, so don't return the error
 		// TODO(tessr): make this whole operation atomic, such that we either delete

--- a/core/grants.go
+++ b/core/grants.go
@@ -206,7 +206,7 @@ func (a *API) deleteGrant(ctx context.Context, x apiGrant) error {
 		Protected: x.Protected, // should always be false
 	}
 
-	err = a.sdb.Exec(ctx, a.grants.Delete(ctx, x.Policy, func(g *authz.Grant) bool {
+	err = a.sdb.Exec(ctx, a.grants.Delete(x.Policy, func(g *authz.Grant) bool {
 		return authz.EqualGrants(*g, toDelete)
 	}))
 	return errors.Wrap(err)
@@ -215,10 +215,10 @@ func (a *API) deleteGrant(ctx context.Context, x apiGrant) error {
 // deleteGrantsByAccessToken returns a sinkdb operation to delete all of the
 // grants associated with an access token. It will delete a grant even if that
 // grant is protected.
-func (a *API) deleteGrantsByAccessToken(ctx context.Context, token string) sinkdb.Op {
+func (a *API) deleteGrantsByAccessToken(token string) sinkdb.Op {
 	var ops []sinkdb.Op
 	for _, p := range Policies {
-		ops = append(ops, a.grants.Delete(ctx, p, func(g *authz.Grant) bool {
+		ops = append(ops, a.grants.Delete(p, func(g *authz.Grant) bool {
 			if g.GuardType != "access_token" {
 				return false
 			}

--- a/core/grants_test.go
+++ b/core/grants_test.go
@@ -287,7 +287,7 @@ func TestDeleteGrantsByAccessToken(t *testing.T) {
 	}
 
 	// first check that we can delete a single grant
-	err = api.sdb.Exec(ctx, api.deleteGrantsByAccessToken(ctx, "test-token-1"))
+	err = api.sdb.Exec(ctx, api.deleteGrantsByAccessToken("test-token-1"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,7 +301,7 @@ func TestDeleteGrantsByAccessToken(t *testing.T) {
 	}
 
 	// next check on deleting an access token associates with multiple grants
-	err = api.sdb.Exec(ctx, api.deleteGrantsByAccessToken(ctx, "test-token-0"))
+	err = api.sdb.Exec(ctx, api.deleteGrantsByAccessToken("test-token-0"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3308";
+	public final String Id = "main/rev3309";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3308"
+const ID string = "main/rev3309"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3308"
+export const rev_id = "main/rev3309"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3308".freeze
+	ID = "main/rev3309".freeze
 end

--- a/net/http/authz/store.go
+++ b/net/http/authz/store.go
@@ -76,11 +76,11 @@ func (s *Store) Save(ctx context.Context, g *Grant) sinkdb.Op {
 }
 
 // Delete returns an Op to delete from policy all stored grants for which delete returns true.
-func (s *Store) Delete(ctx context.Context, policy string, delete func(*Grant) bool) sinkdb.Op {
+func (s *Store) Delete(policy string, delete func(*Grant) bool) sinkdb.Op {
 	key := s.keyPrefix + policy
 
 	var grantList GrantList
-	ver, err := s.sdb.Get(ctx, key, &grantList)
+	ver, err := s.sdb.GetStale(key, &grantList)
 	if err != nil || !ver.Exists() {
 		return sinkdb.Error(errors.Wrap(err)) // if !exists, errors.Wrap(err) is nil
 	}


### PR DESCRIPTION
The Delete method does a read-modify-write so the read doesn't need to
be linearizable. If it reads a stale value, the IfNotModified condition
will fail the sinkdb operation.

By avoiding a consensus round on every call to Delete we also bring
down deleteGrantsByAccessToken's # of consensus rounds from _n + 1_
to 1, where _n_ is the number of policies.