### PR TITLE
dashboard: generate licenses during production builds

### DIFF
--- a/bin/bundle-dashboard
+++ b/bin/bundle-dashboard
@@ -2,6 +2,7 @@
 rm -rf $CHAIN/dashboard/node_modules/chain-sdk
 npm --prefix $CHAIN/dashboard install
 npm --prefix $CHAIN/dashboard run build
+rm -f $CHAIN/dashboard/public/3rdpartylicenses.txt # Don't need this for the bundle itself.
 go install chain/cmd/gobundle
 mkdir -p $CHAIN/generated/dashboard
 gobundle -package dashboard $CHAIN/dashboard/public > $CHAIN/generated/dashboard/dashboard.go

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -83,6 +83,7 @@
     "wdio-mocha-framework": "~0.5.8",
     "wdio-selenium-standalone-service": "0.0.7",
     "wdio-spec-reporter": "0.0.5",
-    "webdriverio": "~4.6.2"
+    "webdriverio": "~4.6.2",
+    "license-webpack-plugin": "=0.5.0"
   }
 }

--- a/dashboard/webpack/webpack.app.js
+++ b/dashboard/webpack/webpack.app.js
@@ -6,6 +6,7 @@
 var webpack = require('webpack')
 var getConfig = require('hjs-webpack')
 var path = require('path')
+let LicenseWebpackPlugin = require('license-webpack-plugin')
 
 // Set base path to JS and CSS files when
 // required by other files
@@ -114,6 +115,11 @@ config.plugins.push(new webpack.DefinePlugin({
   'process.env.PROXY_API_HOST': JSON.stringify(process.env.PROXY_API_HOST),
   'process.env.TESTNET_INFO_URL': JSON.stringify(process.env.TESTNET_INFO_URL),
   'process.env.TESTNET_GENERATOR_URL': JSON.stringify(process.env.TESTNET_GENERATOR_URL),
+}))
+
+config.plugins.push(new LicenseWebpackPlugin({
+  pattern: /^.*$/,
+  includeUndefined: true,
 }))
 
 // Enable babel-polyfill

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3310";
+	public final String Id = "main/rev3311";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3310"
+const ID string = "main/rev3311"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3310"
+export const rev_id = "main/rev3311"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3310".freeze
+	ID = "main/rev3311".freeze
 end


### PR DESCRIPTION
This commit adds `license-webpack-plugin` to the dashboard build pipeline. A new file, `3rdpartylicenses.txt`, will be generated in our production webpack bundle. The primary use case for this file is to as the basis for a more accurate NOTICE file in our dashboard source directory, one that only includes licenses for dependencies that we are actually re-distributing.