### PR TITLE
docker/ci: fix rocksDB and snappy segfault

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -19,7 +19,7 @@ ENV CHAIN="/go/src/chain" \
 ADD install /usr/bin
 
 RUN yum -y update \
-    && yum install -y autoconf automake bash bzip2 bzip2-devel curl gcc gcc-c++ git libtool make openssl-devel ruby tar wget unzip \
+    && yum install -y autoconf automake bash bzip2 bzip2-devel curl gcc gcc-c++ git libtool make openssl-devel ruby snappy snappy-devel tar wget unzip \
     && install-go && rm -f /usr/bin/install-go \
     && install-rocksdb \
     && install-node && rm -f /usr/bin/install-node \

--- a/docker/ci/install/install-rocksdb
+++ b/docker/ci/install/install-rocksdb
@@ -9,5 +9,5 @@ source /opt/rh/devtoolset-2/enable
 
 # Installing RocksDB and Snappy
 cd /usr/local/lib
-wget -q https://s3-us-west-1.amazonaws.com/chain-build/librocksdb.a
-wget -q https://s3-us-west-1.amazonaws.com/chain-build/libsnappy.a
+wget -q https://s3.amazonaws.com/chain-ci/librocksdb.a
+wget -q https://s3.amazonaws.com/chain-ci/libsnappy.a

--- a/docker/ci/install/install-rocksdb
+++ b/docker/ci/install/install-rocksdb
@@ -2,6 +2,11 @@
 
 set -eo pipefail
 
+# Install GCC 4.8 
+wget -O /etc/yum.repos.d/devtools-2.repo https://people.centos.org/tru/devtools-2/devtools-2.repo
+yum -y install devtoolset-2-binutils devtoolset-2-gcc devtoolset-2-gcc-c++
+source /opt/rh/devtoolset-2/enable
+
 # Installing RocksDB and Snappy
 cd /usr/local/lib
 wget -q https://s3-us-west-1.amazonaws.com/chain-build/librocksdb.a

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3317";
+	public final String Id = "main/rev3318";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3317"
+const ID string = "main/rev3318"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3317"
+export const rev_id = "main/rev3318"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3317".freeze
+	ID = "main/rev3318".freeze
 end

--- a/vendor/github.com/tecbot/gorocksdb/dynflag.go
+++ b/vendor/github.com/tecbot/gorocksdb/dynflag.go
@@ -4,12 +4,13 @@ package gorocksdb
 // #cgo CPPFLAGS: -I${SRCDIR}/../../facebook/rocksdb/include
 // #cgo CFLAGS: -I${SRCDIR}/../../facebook/rocksdb/include
 // #cgo LDFLAGS: -I${SRCDIR}/../../facebook/rocksdb
+// #cgo LDFLAGS: -I${SRCDIR}/../../google/snappy
 // #cgo LDFLAGS: ${SRCDIR}/../../facebook/rocksdb/librocksdb.a
+// #cgo LDFLAGS: ${SRCDIR}/../../google/snappy/build/libsnappy.a
 // #cgo LDFLAGS: -lstdc++
 // #cgo LDFLAGS: -lm
 // #cgo LDFLAGS: -lz
 // #cgo LDFLAGS: -lbz2
-// #cgo LDFLAGS: ${SRCDIR}/../../google/snappy/build/libsnappy.a
 // #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
 // #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all -lrt
 import "C"

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20170706
+box: chaindev/ci:20170710
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -15,6 +15,7 @@ cored:
         name: core tests
         code: |
           cp -a $WERCKER_SOURCE_DIR $CHAIN
+          source /opt/rh/devtoolset-2/enable
           mv /usr/local/lib/librocksdb.a $CHAIN/vendor/github.com/facebook/rocksdb/
           mkdir -p $CHAIN/vendor/github.com/google/snappy/build
           mv /usr/local/lib/libsnappy.a $CHAIN/vendor/github.com/google/snappy/build/


### PR DESCRIPTION
The wercker tests for `database/localdb` failed with a shell segfault. This change installs correct dependencies, including GCC 4.8, to avoid segfaulting on starting up localDB