### PR TITLE
dashboard: prevent default tutorial state from hiding new tx button

### DIFF
--- a/dashboard/src/features/shared/components/PageTitle/PageTitle.jsx
+++ b/dashboard/src/features/shared/components/PageTitle/PageTitle.jsx
@@ -75,7 +75,7 @@ const mapStateToProps = (state) => {
   return {
     breadcrumbs,
     flashMessages: state.app.flashMessages,
-    hideActions: state.routing.locationBeforeTransitions.pathname.includes(state.tutorial.route),
+    hideActions: state.tutorial.isShowing && state.routing.locationBeforeTransitions.pathname.includes(state.tutorial.route),
   }
 }
 

--- a/dashboard/src/features/tutorial/reducers.js
+++ b/dashboard/src/features/tutorial/reducers.js
@@ -15,12 +15,12 @@ export const isShowing = (state = process.env.NODE_ENV != 'test', action) => {
   return state
 }
 
-export const route = (currentStep) => (state = 'transactions', action) => {
+export const route = (currentStep) => (state = '/', action) => {
   if (action.type == 'TUTORIAL_NEXT_STEP') return action.route
   if (action.type == 'UPDATE_TUTORIAL' && currentStep.objectType == action.object) {
     return action.object + 's'
   }
-  if (action.type == 'DISMISS_TUTORIAL') return 'transactions'
+  if (action.type == 'DISMISS_TUTORIAL') return '/'
   return state
 }
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3316";
+	public final String Id = "main/rev3317";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3316"
+const ID string = "main/rev3317"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3316"
+export const rev_id = "main/rev3317"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3316".freeze
+	ID = "main/rev3317".freeze
 end


### PR DESCRIPTION
A bug fix in two parts:

- Dashboard no longer attempts to hide page actions if the tutorial isn't showing
- The default `route` key for tutorials is no longer a page with content