### PR TITLE
core: add warning for using mockhsm with multi-process Chain Core

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -25,6 +25,7 @@ var (
 	errAlreadyConfigured = errors.New("core is already configured; must reset first")
 	errUnconfigured      = errors.New("core is not configured")
 	errNoMockHSM         = errors.New("core is not configured with a mockhsm")
+	errMulticoreMockHSM  = errors.New("starting multi-core process with mockhsm")
 	errNoReset           = errors.New("core is not configured with reset capabilities")
 	errBadBlockPub       = errors.New("supplied block pub key is invalid")
 	errNoClientTokens    = errors.New("cannot enable client auth without client access tokens")
@@ -240,6 +241,9 @@ func (a *API) initCluster(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if config.BuildConfig.MockHSM {
+		log.Printkv(ctx, "warning", errMulticoreMockHSM)
+	}
 
 	// TODO(jackson): make adding this process's address
 	// atomic with initializing the cluster
@@ -262,6 +266,9 @@ func (a *API) joinCluster(ctx context.Context, x struct {
 		return err
 	}
 
+	if config.BuildConfig.MockHSM {
+		log.Printkv(ctx, "warning", errMulticoreMockHSM)
+	}
 	// The cluster we joined might already be configured. Exec self
 	// to restart cored and attempt to load the config.
 	closeConnOK(httpjson.ResponseWriter(ctx), httpjson.Request(ctx))

--- a/core/core.go
+++ b/core/core.go
@@ -25,7 +25,6 @@ var (
 	errAlreadyConfigured = errors.New("core is already configured; must reset first")
 	errUnconfigured      = errors.New("core is not configured")
 	errNoMockHSM         = errors.New("core is not configured with a mockhsm")
-	errMockHSM           = errors.New("starting core with mockhsm: should only be used in development")
 	errNoReset           = errors.New("core is not configured with reset capabilities")
 	errBadBlockPub       = errors.New("supplied block pub key is invalid")
 	errNoClientTokens    = errors.New("cannot enable client auth without client access tokens")
@@ -242,7 +241,7 @@ func (a *API) initCluster(ctx context.Context) error {
 		return err
 	}
 	if config.BuildConfig.MockHSM {
-		log.Printkv(ctx, "warning", errMockHSM)
+		log.Printkv(ctx, "warning", "this core uses a mockhsm. mockhsm data does not sync across coreds")
 	}
 
 	// TODO(jackson): make adding this process's address
@@ -267,7 +266,7 @@ func (a *API) joinCluster(ctx context.Context, x struct {
 	}
 
 	if config.BuildConfig.MockHSM {
-		log.Printkv(ctx, "warning", errMockHSM)
+		log.Printkv(ctx, "warning", "this core uses a mockhsm. mockhsm data does not sync across coreds")
 	}
 	// The cluster we joined might already be configured. Exec self
 	// to restart cored and attempt to load the config.

--- a/core/core.go
+++ b/core/core.go
@@ -25,7 +25,7 @@ var (
 	errAlreadyConfigured = errors.New("core is already configured; must reset first")
 	errUnconfigured      = errors.New("core is not configured")
 	errNoMockHSM         = errors.New("core is not configured with a mockhsm")
-	errMulticoreMockHSM  = errors.New("starting multi-core process with mockhsm")
+	errMockHSM           = errors.New("starting core with mockhsm: should only be used in development")
 	errNoReset           = errors.New("core is not configured with reset capabilities")
 	errBadBlockPub       = errors.New("supplied block pub key is invalid")
 	errNoClientTokens    = errors.New("cannot enable client auth without client access tokens")
@@ -242,7 +242,7 @@ func (a *API) initCluster(ctx context.Context) error {
 		return err
 	}
 	if config.BuildConfig.MockHSM {
-		log.Printkv(ctx, "warning", errMulticoreMockHSM)
+		log.Printkv(ctx, "warning", errMockHSM)
 	}
 
 	// TODO(jackson): make adding this process's address
@@ -267,7 +267,7 @@ func (a *API) joinCluster(ctx context.Context, x struct {
 	}
 
 	if config.BuildConfig.MockHSM {
-		log.Printkv(ctx, "warning", errMulticoreMockHSM)
+		log.Printkv(ctx, "warning", errMockHSM)
 	}
 	// The cluster we joined might already be configured. Exec self
 	// to restart cored and attempt to load the config.

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3319";
+	public final String Id = "main/rev3320";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3319"
+const ID string = "main/rev3320"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3319"
+export const rev_id = "main/rev3320"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3319".freeze
+	ID = "main/rev3320".freeze
 end


### PR DESCRIPTION
As we move mockhsm into localdb, mockhsm will no longer be consistent across a multi-process raft cluster. This shouldn't be a problem, as we expect the only people running mockhsm with multiple processes to be folks internally doing testing. 