### PR TITLE
sdk/node: support CA transaction flow

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3321";
+	public final String Id = "main/rev3322";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3321"
+const ID string = "main/rev3322"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3321"
+export const rev_id = "main/rev3322"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3321".freeze
+	ID = "main/rev3322".freeze
 end

--- a/sdk/node/src/api/hsmSigner.js
+++ b/sdk/node/src/api/hsmSigner.js
@@ -1,4 +1,4 @@
-const shared = require('./shared')
+const shared = require('../shared')
 
 /**
  * @class
@@ -6,7 +6,7 @@ const shared = require('./shared')
  * created in Chain Core and sent to the HSM for signing. The HSM signs the
  * transaction without ever revealing the private key. Once signed, the
  * transaction can be submitted to the blockchain successfully.
- * 
+ *
  * More info: {@link https://chain.com/docs/core/build-applications/keys}
  */
 class HsmSigner {

--- a/sdk/node/src/api/transactions.js
+++ b/sdk/node/src/api/transactions.js
@@ -415,6 +415,7 @@ const transactionsAPI = (client) => {
      *                         added, as well as errors.
      */
     signBatch: (templates, cb) => finalizeBatch(templates)
+      // TODO: merge batch errors from finalizeBatch
       .then(finalized => client.signer.signBatch(finalized.successes, cb)),
 
     /**

--- a/sdk/node/src/api/transactions.js
+++ b/sdk/node/src/api/transactions.js
@@ -385,6 +385,25 @@ const transactionsAPI = (client) => {
     },
 
     /**
+     * sign - Sign a single transaction.
+     *
+     * @param {Object} template - A single transaction template.
+     * @param {objectCallback} [callback] - Optional callback. Use instead of Promise return value as desired.
+     * @returns {Object} Transaction template with all possible signatures added.
+     */
+    sign: (template, cb) => client.signer.sign(template, cb),
+
+    /**
+     * signBatch - Sign a batch of transactions.
+     *
+     * @param {Array<Object>} templates Array of transaction templates.
+     * @param {objectCallback} [callback] - Optional callback. Use instead of Promise return value as desired.
+     * @returns {BatchResponse} Tranasaction templates with all possible signatures
+     *                         added, as well as errors.
+     */
+    signBatch: (templates, cb) => client.signer.signBatch(templates, cb),
+
+    /**
      * Submit a signed transaction to the blockchain.
      *
      * @param {Object} signed - A fully signed transaction template.

--- a/sdk/node/src/api/transactions.js
+++ b/sdk/node/src/api/transactions.js
@@ -303,6 +303,18 @@ const transactionsAPI = (client) => {
    * @param {TransactionBuilder} builder
    */
 
+  // TODO: implement finalize
+  const finalize = (template, cb) => shared.tryCallback(
+    Promise.resolve(template),
+    cb
+  )
+
+  // TODO: implement finalizeBatch
+  const finalizeBatch = (templates, cb) => shared.tryCallback(
+    Promise.resolve(new shared.BatchResponse(templates)),
+    cb
+  )
+
   return {
     /**
      * Get one page of transactions matching the specified query.
@@ -391,7 +403,8 @@ const transactionsAPI = (client) => {
      * @param {objectCallback} [callback] - Optional callback. Use instead of Promise return value as desired.
      * @returns {Object} Transaction template with all possible signatures added.
      */
-    sign: (template, cb) => client.signer.sign(template, cb),
+    sign: (template, cb) => finalize(template)
+      .then(finalized => client.signer.sign(finalized, cb)),
 
     /**
      * signBatch - Sign a batch of transactions.
@@ -401,7 +414,18 @@ const transactionsAPI = (client) => {
      * @returns {BatchResponse} Tranasaction templates with all possible signatures
      *                         added, as well as errors.
      */
-    signBatch: (templates, cb) => client.signer.signBatch(templates, cb),
+    signBatch: (templates, cb) => finalizeBatch(templates)
+      .then(finalized => client.signer.signBatch(finalized.successes, cb)),
+
+    /**
+     * finalize - Finalize a single transaction
+     */
+    finalize,
+
+    /**
+     * finalizeBatch - Finalize a batch of transactions
+     */
+    finalizeBatch,
 
     /**
      * Submit a signed transaction to the blockchain.

--- a/sdk/node/src/api/transactions.js
+++ b/sdk/node/src/api/transactions.js
@@ -418,16 +418,6 @@ const transactionsAPI = (client) => {
       .then(finalized => client.signer.signBatch(finalized.successes, cb)),
 
     /**
-     * finalize - Finalize a single transaction
-     */
-    finalize,
-
-    /**
-     * finalizeBatch - Finalize a batch of transactions
-     */
-    finalizeBatch,
-
-    /**
      * Submit a signed transaction to the blockchain.
      *
      * @param {Object} signed - A fully signed transaction template.

--- a/sdk/node/src/client.js
+++ b/sdk/node/src/client.js
@@ -5,6 +5,7 @@ const accountsAPI = require('./api/accounts')
 const assetsAPI = require('./api/assets')
 const balancesAPI = require('./api/balances')
 const configAPI = require('./api/config')
+const hsmSigner = require('./api/hsmSigner')
 const mockHsmKeysAPI = require('./api/mockHsmKeys')
 const transactionsAPI = require('./api/transactions')
 const transactionFeedsAPI = require('./api/transactionFeeds')
@@ -41,6 +42,7 @@ class Client {
     }
     opts.url = opts.url || 'http://localhost:1999'
     this.connection = new Connection(opts.url, opts.accessToken, opts.agent)
+    this.signer = new hsmSigner()
 
     /**
      * API actions for access tokens

--- a/sdk/node/src/index.js
+++ b/sdk/node/src/index.js
@@ -1,9 +1,7 @@
 const Client = require('./client')
-const HsmSigner = require('./hsmSigner')
 const Connection = require('./connection')
 
 module.exports = {
   Client,
-  HsmSigner,
   Connection,
 }

--- a/sdk/node/test/receivers.js
+++ b/sdk/node/test/receivers.js
@@ -8,7 +8,7 @@ const chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
-import { client, createAccount, createAsset, signer } from './testHelpers'
+import { client, createAccount, createAsset } from './testHelpers'
 
 describe('Receiver', () => {
 
@@ -76,7 +76,7 @@ describe('Receiver', () => {
           amount: 1,
         })
       })
-    .then((issuance) => signer.sign(issuance))
+    .then((issuance) => client.transactions.sign(issuance))
     .then((signed) => client.transactions.submit(signed))
     .then((tx) => expect(tx.id).not.to.be.empty)
     })

--- a/sdk/node/test/testHelpers.js
+++ b/sdk/node/test/testHelpers.js
@@ -1,7 +1,6 @@
 const chain = require('../dist/index.js')
 const uuid = require('uuid')
 const client = new chain.Client()
-const signer = new chain.HsmSigner()
 
 const balanceByAssetAlias = (balances) => {
   let res = {}
@@ -17,7 +16,7 @@ const balanceByAssetAlias = (balances) => {
 const createAccount = (account = 'account') => {
   return client.mockHsm.keys.create()
     .then((key) => {
-      signer.addKey(key, client.mockHsm.signerConnection)
+      client.signer.addKey(key, client.mockHsm.signerConnection)
       return client.accounts.create({
         alias: `${account}-${uuid.v4()}`,
         rootXpubs: [key.xpub],
@@ -29,7 +28,7 @@ const createAccount = (account = 'account') => {
 const createAsset = (asset = 'asset') => {
   return client.mockHsm.keys.create()
     .then((key) => {
-      signer.addKey(key, client.mockHsm.signerConnection)
+      client.signer.addKey(key, client.mockHsm.signerConnection)
       return client.assets.create({
         alias: `${asset}-${uuid.v4()}`,
         rootXpubs: [key.xpub],
@@ -40,9 +39,8 @@ const createAsset = (asset = 'asset') => {
 
 const buildSignSubmit = (buildFunc, optClient, optSigner) => {
   const c = optClient || client
-  const s = optSigner || signer
   return c.transactions.build(buildFunc)
-    .then(tpl => s.sign(tpl))
+    .then(tpl => c.transactions.sign(tpl))
     .then(tpl => c.transactions.submit(tpl))
 }
 
@@ -51,6 +49,5 @@ module.exports = {
   client,
   createAccount,
   createAsset,
-  signer,
   buildSignSubmit,
 }

--- a/sdk/node/test/transactions.js
+++ b/sdk/node/test/transactions.js
@@ -8,7 +8,7 @@ const chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
-const { balanceByAssetAlias, client, createAccount, createAsset, signer } = require('./testHelpers')
+const { balanceByAssetAlias, client, createAccount, createAsset } = require('./testHelpers')
 
 describe('Transaction', () => {
 
@@ -48,7 +48,7 @@ describe('Transaction', () => {
           amount: 200
         })
       }))
-      .then((issuance) => signer.sign(issuance))
+      .then((issuance) => client.transactions.sign(issuance))
       .then((signed) => client.transactions.submit(signed))
     })
 
@@ -99,7 +99,7 @@ describe('Transaction', () => {
           amount: 200
         })
       }))
-      .then((issuance) => signer.sign(issuance))
+      .then((issuance) => client.transactions.sign(issuance))
       .then((signed) => client.transactions.submit(signed))
       .then(() => client.transactions.build(builder => {
         builder.spendFromAccount({
@@ -115,7 +115,7 @@ describe('Transaction', () => {
       }))
       .then((swapProposal) => {
         swapProposal.allowAdditionalActions = true
-        return signer.sign(swapProposal)
+        return client.transactions.sign(swapProposal)
       })
       .then((swapProposal) =>
         client.transactions.build(builder => {
@@ -131,7 +131,7 @@ describe('Transaction', () => {
             amount: 10
           })
         }))
-        .then((swapTx) => signer.sign(swapTx))
+        .then((swapTx) => client.transactions.sign(swapTx))
         .then((signed) => client.transactions.submit(signed))
     })
 
@@ -181,7 +181,7 @@ describe('Transaction', () => {
         })
       })
     )
-    .then(issuance => signer.sign(issuance))
+    .then(issuance => client.transactions.sign(issuance))
     .then(signed => expect(client.transactions.submit(signed)).to.be.rejectedWith('CH735'))
   })
 
@@ -203,7 +203,7 @@ describe('Transaction', () => {
           })
         })
       ).then(txtpl =>
-        signer.sign(txtpl)
+        client.transactions.sign(txtpl)
       ).then(signed =>
         client.transactions.submit(signed)
       ).then(tx =>

--- a/sdk/node/test/transactionsBatch.js
+++ b/sdk/node/test/transactionsBatch.js
@@ -8,7 +8,7 @@ const chaiAsPromised = require('chai-as-promised')
 chai.use(chaiAsPromised)
 const expect = chai.expect
 
-import { client, createAccount, createAsset, signer } from './testHelpers'
+import { client, createAccount, createAsset } from './testHelpers'
 
 describe('Transaction batch', () => {
   let buildBatchResponse, signedBatchResponse, submittedBatchResponse = {}
@@ -76,7 +76,7 @@ describe('Transaction batch', () => {
       }]))
     .then(buildBatch => {
       buildBatchResponse = buildBatch
-      return signer.signBatch(buildBatch.successes)
+      return client.transactions.signBatch(buildBatch.successes)
     })
     .then(signedBatch => {
       signedBatchResponse = signedBatch
@@ -130,7 +130,7 @@ describe('Transaction batch', () => {
     })
 
     it('Batch transaction sign', (done) => {
-      signer.signBatch(
+      client.transactions.signBatch(
         [], // intentionally blank
         () => done() // intentionally ignore errors
       )


### PR DESCRIPTION
This moves the HSM signer object underneath the main
`client` object, and adds a placeholder for the `finalize`
call, that passes through the original object, appropriately
wrapped in a batch response as expected.