### PR TITLE
cmd/cored: handle uninitialized raft cluster

### DIFF
--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -263,7 +263,7 @@ func main() {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 	confOpts, err := core.Config(ctx, db, sdb)
-	if err != nil {
+	if err != nil && errors.Root(err) != raft.ErrUninitialized {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 

--- a/cmd/cored/main.go
+++ b/cmd/cored/main.go
@@ -263,7 +263,7 @@ func main() {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 	confOpts, err := core.Config(ctx, db, sdb)
-	if err != nil && errors.Root(err) != raft.ErrUninitialized {
+	if err != nil {
 		chainlog.Fatalkv(ctx, chainlog.KeyError, err)
 	}
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3325";
+	public final String Id = "main/rev3326";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3325"
+const ID string = "main/rev3326"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3325"
+export const rev_id = "main/rev3326"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3325".freeze
+	ID = "main/rev3326".freeze
 end


### PR DESCRIPTION
core.Config can return raft.ErrUninitialized if the raft cluster is
uninitialized. Like in the config.Load call above, it should be ignored.