### PR TITLE
log: fix test for verisoned go toolchains

### DIFF
--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3331";
+	public final String Id = "main/rev3332";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3331"
+const ID string = "main/rev3332"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3331"
+export const rev_id = "main/rev3332"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3331".freeze
+	ID = "main/rev3332".freeze
 end

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -224,7 +224,7 @@ func TestPrintkvStack(t *testing.T) {
 
 		// stack trace
 		"TestPrintkvStack\n",
-		"/go/",
+		"/go",
 	}
 
 	t.Logf("output:\n%s", got)
@@ -256,7 +256,7 @@ func TestError(t *testing.T) {
 
 		// stack trace
 		"TestError\n",
-		"/go/",
+		"/go",
 	}
 
 	t.Logf("output:\n%s", got)


### PR DESCRIPTION
Fix log package test to work with versioned go installations, like
go1.9beta2: https://godoc.org/golang.org/x/build/version/go1.9beta2