### PR TITLE
cmd/corectl: remove hsm-url, hsm-token flags

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -114,8 +114,6 @@ func configGenerator(client *rpc.Client, args []string) {
 	var flags flag.FlagSet
 	maxIssuanceWindow := flags.Duration("w", 24*time.Hour, "the maximum issuance window `duration` for this generator")
 	flagK := flags.String("k", "", "local `pubkey` for signing blocks")
-	flagHSMURL := flags.String("hsm-url", "", "hsm `url` for signing blocks (mockhsm if empty)")
-	flagHSMToken := flags.String("hsm-token", "", "hsm `access-token` for connecting to hsm")
 
 	flags.Usage = func() {
 		fmt.Println(usage)
@@ -124,16 +122,6 @@ func configGenerator(client *rpc.Client, args []string) {
 	}
 	flags.Parse(args)
 	args = flags.Args()
-
-	// not a blocksigner
-	if *flagK == "" && *flagHSMURL != "" {
-		fatalln("error: flag -hsm-url has no effect without -k")
-	}
-
-	// TODO(ameets): update when switching to x.509 authorization
-	if (*flagHSMURL == "") != (*flagHSMToken == "") {
-		fatalln("error: flags -hsm-url and -hsm-token must be given together")
-	}
 
 	if len(args) == 0 {
 		if *flagK != "" {
@@ -179,8 +167,6 @@ func configGenerator(client *rpc.Client, args []string) {
 		MaxIssuanceWindowMs: bc.DurationMillis(*maxIssuanceWindow),
 		IsSigner:            *flagK != "",
 		BlockPub:            blockPub,
-		BlockHsmUrl:         *flagHSMURL,
-		BlockHsmAccessToken: *flagHSMToken,
 	}
 
 	err = client.Call(context.Background(), "/configure", conf, nil)
@@ -250,8 +236,6 @@ func configNongenerator(client *rpc.Client, args []string) {
 	var flags flag.FlagSet
 	flagT := flags.String("t", "", "generator access `token`")
 	flagK := flags.String("k", "", "local `pubkey` for signing blocks")
-	flagHSMURL := flags.String("hsm-url", "", "hsm `url` for signing blocks (mockhsm if empty)")
-	flagHSMToken := flags.String("hsm-token", "", "hsm `access-token` for connecting to hsm")
 
 	flags.Usage = func() {
 		fmt.Println(usage)
@@ -262,16 +246,6 @@ func configNongenerator(client *rpc.Client, args []string) {
 	args = flags.Args()
 	if len(args) < 2 {
 		fatalln(usage)
-	}
-
-	// not a blocksigner
-	if *flagK == "" && *flagHSMURL != "" {
-		fatalln("error: flag -hsm-url has no effect without -k")
-	}
-
-	// TODO(ameets): update when switching to x.509 authorization
-	if (*flagHSMURL == "") != (*flagHSMToken == "") {
-		fatalln("error: flags -hsm-url and -hsm-token must be given together")
 	}
 
 	var blockchainID bc.Hash
@@ -294,8 +268,6 @@ func configNongenerator(client *rpc.Client, args []string) {
 	conf.GeneratorAccessToken = *flagT
 	conf.IsSigner = *flagK != ""
 	conf.BlockPub = blockPub
-	conf.BlockHsmUrl = *flagHSMURL
-	conf.BlockHsmAccessToken = *flagHSMToken
 
 	client.BlockchainID = blockchainID.String()
 	err = client.Call(context.Background(), "/configure", conf, nil)

--- a/docs/future/core/reference/corectl.md
+++ b/docs/future/core/reference/corectl.md
@@ -101,8 +101,6 @@ Flags:
 * **-k \<pubkey>**: Local pubkey for signing blocks; indicates that this core
 will be a signer. If **-k** is not given, the core will be a participant (not a generator or a signer).
 * **-w \<duration>**: The maximum issuance window duration for this generator (default 24h0m0s).
-* **-hsm-url \<url>**: HSM url for signing blocks (MockHSM if empty).
-* **-hsm-token \<access-token>**:  HSM access-token for connecting to HSM.
 
 Arguments:
 
@@ -130,8 +128,6 @@ Flags:
  will be a signer. If **-k** is not given, the core will be a participant (not a generator or a signer).
  * **-t \<token>**: Authentication token with access to the network API provided
 by the generator.
- * **-hsm-url \<url>**: HSM url for signing blocks (MockHSM if empty).
- * **-hsm-token \<access-token>**:  HSM access-token for connecting to HSM.
 
 Arguments:
 

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3332";
+	public final String Id = "main/rev3333";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3332"
+const ID string = "main/rev3333"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3332"
+export const rev_id = "main/rev3333"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3332".freeze
+	ID = "main/rev3333".freeze
 end


### PR DESCRIPTION
Remove the hsm-url and hsm-token flags. These flags have been replaced
by a new configuration option that is modified through:

```
corectl add enclave <url> <token>
corectl rm enclave <url> <token>
```