### PR TITLE
core/config: add single-tuple config options

### DIFF
--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -68,6 +68,8 @@ var commands = map[string]*command{
 	"get":                  {get},
 	"add":                  {add},
 	"rm":                   {rm},
+	"set":                  {set},
+	"unset":                {unset},
 	"wait":                 {wait},
 }
 
@@ -452,6 +454,43 @@ func rm(client *rpc.Client, args []string) {
 				"op":    "rm",
 				"key":   args[0],
 				"tuple": args[1:],
+			},
+		},
+	}
+	err := client.Call(context.Background(), "/configure", req, nil)
+	dieOnRPCError(err)
+}
+
+func set(client *rpc.Client, args []string) {
+	const usage = "usage: corectl set [key] [value]..."
+	if len(args) < 2 {
+		fatalln(usage)
+	}
+
+	req := map[string]interface{}{
+		"updates": []interface{}{
+			map[string]interface{}{
+				"op":    "set",
+				"key":   args[0],
+				"tuple": args[1:],
+			},
+		},
+	}
+	err := client.Call(context.Background(), "/configure", req, nil)
+	dieOnRPCError(err)
+}
+
+func unset(client *rpc.Client, args []string) {
+	const usage = "usage: corectl unset [key]"
+	if len(args) != 1 {
+		fatalln(usage)
+	}
+
+	req := map[string]interface{}{
+		"updates": []interface{}{
+			map[string]interface{}{
+				"op":  "unset",
+				"key": args[0],
 			},
 		},
 	}

--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -69,7 +69,6 @@ var commands = map[string]*command{
 	"add":                  {add},
 	"rm":                   {rm},
 	"set":                  {set},
-	"unset":                {unset},
 	"wait":                 {wait},
 }
 
@@ -473,24 +472,6 @@ func set(client *rpc.Client, args []string) {
 				"op":    "set",
 				"key":   args[0],
 				"tuple": args[1:],
-			},
-		},
-	}
-	err := client.Call(context.Background(), "/configure", req, nil)
-	dieOnRPCError(err)
-}
-
-func unset(client *rpc.Client, args []string) {
-	const usage = "usage: corectl unset [key]"
-	if len(args) != 1 {
-		fatalln(usage)
-	}
-
-	req := map[string]interface{}{
-		"updates": []interface{}{
-			map[string]interface{}{
-				"op":  "unset",
-				"key": args[0],
 			},
 		},
 	}

--- a/core/config/options.go
+++ b/core/config/options.go
@@ -160,7 +160,7 @@ func (opts *Options) ListFunc(key string) func() [][]string {
 // undefined or is defined as a set of tuples.
 //
 // The returned function performs a stale read of the configuration
-// value. If an error occurs while reading the value the old
+// value. If an error occurs while reading the value, the old
 // value is returned, and the error is saved on the Options
 // type to be returned in Err.
 func (opts *Options) GetFunc(key string) func() []string {

--- a/core/config/options.go
+++ b/core/config/options.go
@@ -314,9 +314,6 @@ func (opts *Options) Remove(key string, tup []string) sinkdb.Op {
 	if opt.tupleSize != len(tup) {
 		return sinkdb.Error(errors.WithDetailf(ErrConfigOp, "Configuration option %q expects %d arguments.", key, opt.tupleSize))
 	}
-	if opt.equalFunc == nil {
-		return sinkdb.Error(errors.WithDetailf(ErrConfigOp, "Configuration option %q is a scalar. Use corectl unset instead."))
-	}
 
 	// make a copy to avoid mutating tup
 	cleaned := make([]string, len(tup))
@@ -346,19 +343,6 @@ func (opts *Options) Remove(key string, tup []string) sinkdb.Op {
 		sinkdb.IfNotModified(ver),
 		sinkdb.Set(path.Join(sinkdbPrefix, key), modified),
 	)
-}
-
-// Unset clears any value from the single-value configuration option
-// indicated by key.
-func (opts *Options) Unset(key string) sinkdb.Op {
-	opt, ok := opts.schema[key]
-	if !ok {
-		return sinkdb.Error(errors.WithDetailf(ErrConfigOp, "Configuration option %q undefined", key))
-	}
-	if opt.equalFunc != nil {
-		return sinkdb.Error(errors.WithDetailf(ErrConfigOp, "Configuration option %q is a set. Use corectl rm instead."))
-	}
-	return sinkdb.Delete(path.Join(sinkdbPrefix, key))
 }
 
 func tupleIndex(set []*configpb.ValueTuple, search []string, equal func(a, b []string) bool) int {

--- a/core/config/options_test.go
+++ b/core/config/options_test.go
@@ -115,7 +115,7 @@ func TestSet(t *testing.T) {
 		t.Errorf("got %#v, want %#v", got, want)
 	}
 
-	must(t, sdb.Exec(ctx, opts.Remove("example", []string{"baz", "bax"})))
+	must(t, sdb.Exec(ctx, opts.Remove("example", nil)))
 	got, err = opts.List(ctx, "example")
 	must(t, err)
 	if got != nil {

--- a/core/config/options_test.go
+++ b/core/config/options_test.go
@@ -115,7 +115,7 @@ func TestSet(t *testing.T) {
 		t.Errorf("got %#v, want %#v", got, want)
 	}
 
-	must(t, sdb.Exec(ctx, opts.Unset("example")))
+	must(t, sdb.Exec(ctx, opts.Remove("example", []string{"baz", "bax"})))
 	got, err = opts.List(ctx, "example")
 	must(t, err)
 	if got != nil {

--- a/core/config/options_test.go
+++ b/core/config/options_test.go
@@ -91,3 +91,53 @@ func TestListFunc(t *testing.T) {
 		t.Errorf("got %#v, want %#v", got, want)
 	}
 }
+
+func TestSet(t *testing.T) {
+	sdb := sinkdbtest.NewDB(t)
+	opts := New(sdb)
+	opts.DefineSingle("example", 2, identityFunc)
+
+	ctx := context.Background()
+
+	must(t, sdb.Exec(ctx, opts.Set("example", []string{"foo", "bar"})))
+	got, err := opts.List(ctx, "example")
+	must(t, err)
+	want := [][]string{{"foo", "bar"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	must(t, sdb.Exec(ctx, opts.Set("example", []string{"baz", "bax"})))
+	got, err = opts.List(ctx, "example")
+	must(t, err)
+	want = [][]string{{"baz", "bax"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	must(t, sdb.Exec(ctx, opts.Unset("example")))
+	got, err = opts.List(ctx, "example")
+	must(t, err)
+	if got != nil {
+		t.Errorf("got %#v, want nil", got)
+	}
+}
+
+func TestGetFunc(t *testing.T) {
+	sdb := sinkdbtest.NewDB(t)
+	opts := New(sdb)
+	opts.DefineSingle("example", 1, identityFunc)
+
+	ctx := context.Background()
+	must(t, sdb.Exec(ctx, opts.Set("example", []string{"foo"})))
+
+	// perform a linearizable read since GetFunc won't and we
+	// want a deterministic test case
+	must(t, sdb.RaftService().WaitRead(ctx))
+
+	got := opts.GetFunc("example")()
+	want := []string{"foo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("GetFunc(\"example\")() = %#v, want %#v", got, want)
+	}
+}

--- a/core/core.go
+++ b/core/core.go
@@ -178,8 +178,6 @@ func (a *API) configure(ctx context.Context, req configureRequest) error {
 			ops = append(ops, a.options.Remove(update.Key, update.Tuple))
 		case "set":
 			ops = append(ops, a.options.Set(update.Key, update.Tuple))
-		case "unset":
-			ops = append(ops, a.options.Unset(update.Key))
 		default:
 			return errors.WithDetailf(config.ErrConfigOp, "Unknown config operation %q.", update.Op)
 		}

--- a/core/core.go
+++ b/core/core.go
@@ -176,6 +176,10 @@ func (a *API) configure(ctx context.Context, req configureRequest) error {
 			ops = append(ops, a.options.AddOrUpdate(update.Key, update.Tuple))
 		case "rm":
 			ops = append(ops, a.options.Remove(update.Key, update.Tuple))
+		case "set":
+			ops = append(ops, a.options.Set(update.Key, update.Tuple))
+		case "unset":
+			ops = append(ops, a.options.Unset(update.Key))
 		default:
 			return errors.WithDetailf(config.ErrConfigOp, "Unknown config operation %q.", update.Op)
 		}

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3345";
+	public final String Id = "main/rev3346";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3345"
+const ID string = "main/rev3346"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3345"
+export const rev_id = "main/rev3346"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3345".freeze
+	ID = "main/rev3346".freeze
 end


### PR DESCRIPTION
Add corectl set command.

As-is, GetFunc provides no distinction between values that are not set and values that are set to the empty byte slice. I'm unsure if we have any need for that distinction or how we should expose it if we do.

Also, I stored the tuples in the same format as sets (a ValueSet protobuf), so that all config options can be accessed through List regardless of their type.