### PR TITLE
core/config: make migrateAccessTokens atomic in raft

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -368,8 +368,10 @@ func migrateAccessTokens(ctx context.Context, db pg.DB, sdb *sinkdb.DB) error {
 			networkGrants = append(networkGrants, &grant)
 		}
 	}
-	err = sdb.Exec(ctx, store.SaveAll(ctx, clientGrants, "client-readwrite"))
-	err = sdb.Exec(ctx, store.SaveAll(ctx, networkGrants, "crosscore"))
+	err = sdb.Exec(ctx,
+		store.Save(ctx, clientGrants...),
+		store.Save(ctx, networkGrants...),
+	)
 	if err != nil {
 		return errors.Wrap(err)
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -344,6 +344,8 @@ func migrateAccessTokens(ctx context.Context, db pg.DB, sdb *sinkdb.DB) error {
 		tokens = append(tokens, t)
 	})
 
+	var stores []sinkdb.Op
+
 	for _, token := range tokens {
 		data := map[string]interface{}{
 			"id": token.ID,
@@ -364,10 +366,11 @@ func migrateAccessTokens(ctx context.Context, db pg.DB, sdb *sinkdb.DB) error {
 		case "network":
 			grant.Policy = "crosscore"
 		}
-		err = sdb.Exec(ctx, store.Save(ctx, &grant))
-		if err != nil {
-			return errors.Wrap(err)
-		}
+		stores = append(stores, store.Save(ctx, &grant))
+	}
+	err = sdb.Exec(ctx, stores...)
+	if err != nil {
+		return errors.Wrap(err)
 	}
 	return err
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -329,8 +329,6 @@ func tryGenerator(ctx context.Context, url, accessToken, blockchainID string, ht
 	return nil
 }
 
-// TODO(tessr): make all of this atomic in raft, so we don't get halfway through
-// a postgres->raft migration and fail, losing the second half of the migration
 func migrateAccessTokens(ctx context.Context, db pg.DB, sdb *sinkdb.DB) error {
 	store := authz.NewStore(sdb, GrantPrefix)
 	const q = `SELECT id, type, created FROM access_tokens`

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -1,15 +1,21 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"testing"
+	"time"
 
+	"chain/core/accesstoken"
 	"chain/database/pg/pgtest"
 	"chain/database/sinkdb"
 	"chain/database/sinkdb/sinkdbtest"
 	"chain/errors"
+	"chain/net/http/authz"
+	"chain/protocol/bc"
 )
 
 func TestDetectStaleConfig(t *testing.T) {
@@ -68,6 +74,82 @@ func TestLoadConfigNoErr(t *testing.T) {
 		t.Errorf("Expected loaded config")
 	}
 	must(t, err)
+}
+
+func TestMigrateAccessTokens(t *testing.T) {
+	ctx := context.Background()
+	sdb := sinkdbtest.NewDB(t)
+	_, db := pgtest.NewDB(t, pgtest.SchemaPath)
+
+	// Saving test config to PG
+	const q = `INSERT INTO config (id, blockchain_id, configured_at, is_signer, is_generator, max_issuance_window_ms) 
+				VALUES ($1, $2, $3, $4, $5, $6)`
+	var blockchainID bc.Hash
+	blockchainID.UnmarshalText([]byte("test-blockchain"))
+	_, err := db.ExecContext(ctx, q, "test-id", &blockchainID, time.Now(), true, true, bc.DurationMillis(24*time.Hour))
+	must(t, err)
+
+	cs := &accesstoken.CredentialStore{DB: db}
+	var pgClientToken *accesstoken.Token
+	var pgNetworkToken *accesstoken.Token
+	pgClientToken, err = cs.Create(ctx, "a", "client")
+	pgNetworkToken, err = cs.Create(ctx, "b", "network")
+	must(t, err)
+
+	var c *Config
+	c, err = Load(ctx, db, sdb)
+	must(t, err)
+	if c == nil {
+		t.Errorf("Expected loaded config")
+	}
+
+	// Read access tokens from sinkDB
+	var Policies = []string{
+		"client-readwrite",
+		"crosscore",
+	}
+	var clientToken authz.Grant
+	var networkToken authz.Grant
+	for _, p := range Policies {
+		var accessTokens []authz.Grant
+		var grantList authz.GrantList
+		_, err = sdb.Get(ctx, GrantPrefix+p, &grantList)
+		must(t, err)
+		for _, g := range grantList.Grants {
+			accessTokens = append(accessTokens, *g)
+		}
+		if p == "client-readwrite" {
+			clientToken = accessTokens[0]
+		} else if p == "crosscore" {
+			networkToken = accessTokens[0]
+		}
+	}
+
+	// Check that sinkDB access tokens equal PG access tokens
+	var clientData []byte
+	var networkData []byte
+	clientData, err = json.Marshal(map[string]interface{}{"id": "a"})
+	must(t, err)
+	networkData, err = json.Marshal(map[string]interface{}{"id": "b"})
+	must(t, err)
+	if !bytes.Equal(clientToken.GuardData, clientData) {
+		t.Errorf("Guard data incorrect")
+	}
+	if clientToken.GuardType != "access_token" {
+		t.Errorf("Guard type incorrect: wanted %q, got %q", "access_token", clientToken.GuardType)
+	}
+	if clientToken.CreatedAt != pgClientToken.Created.Format(time.RFC3339) {
+		t.Errorf("Time created incorrect: wanted %q, got %q", pgClientToken.Created.Format(time.RFC3339), clientToken.CreatedAt)
+	}
+	if !bytes.Equal(networkToken.GuardData, networkData) {
+		t.Errorf("Guard data incorrect")
+	}
+	if networkToken.GuardType != "access_token" {
+		t.Errorf("Guard type incorrect: wanted %q, got %q", "access_token", networkToken.GuardType)
+	}
+	if networkToken.CreatedAt != pgNetworkToken.Created.Format(time.RFC3339) {
+		t.Errorf("Time created incorrect: wanted %q, got %q", pgNetworkToken.Created.Format(time.RFC3339), networkToken.CreatedAt)
+	}
 }
 
 // newTestConfig returns a new Config object

--- a/net/http/authz/store.go
+++ b/net/http/authz/store.go
@@ -59,7 +59,7 @@ func (s *Store) Save(ctx context.Context, g ...*Grant) sinkdb.Op {
 	var newGrants []*Grant
 	for _, grant := range g {
 		if grant.Policy != policy {
-			return sinkdb.Error(errors.New("Grants have mismatching policies"))
+			return sinkdb.Error(errors.New("grants have mismatching policies"))
 		}
 		if grant.CreatedAt == "" {
 			grant.CreatedAt = time.Now().UTC().Format(time.RFC3339)


### PR DESCRIPTION
Currently, we migrate each access token from postgres to raft one-by-one. This change migrates all access tokens from postgres to raft atomically, so we don't fail halfway through a postgres->raft migration and lose the second half of the migration