### PR TITLE
core/fetch: encapsulate state

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -57,6 +57,7 @@ var (
 
 // API serves the Chain HTTP API
 type API struct {
+	ctx             context.Context
 	chain           *protocol.Chain
 	store           *txdb.Store
 	pinStore        *pin.Store
@@ -78,6 +79,7 @@ type API struct {
 	signer          func(context.Context, *legacy.Block) ([]byte, error)
 	requestLimits   []requestLimit
 	generator       *generator.Generator
+	replicator      *fetch.Replicator
 	remoteGenerator *rpc.Client
 	indexTxs        bool
 	internalSubj    pkix.Name

--- a/core/api.go
+++ b/core/api.go
@@ -57,7 +57,6 @@ var (
 
 // API serves the Chain HTTP API
 type API struct {
-	ctx             context.Context
 	chain           *protocol.Chain
 	store           *txdb.Store
 	pinStore        *pin.Store

--- a/core/core.go
+++ b/core/core.go
@@ -11,7 +11,6 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"chain/core/config"
-	"chain/core/fetch"
 	"chain/core/leader"
 	"chain/database/sinkdb"
 	"chain/errors"
@@ -82,7 +81,7 @@ func (a *API) leaderInfo(ctx context.Context) (map[string]interface{}, error) {
 		generatorHeight = localHeight
 		generatorFetched = now
 	} else {
-		fetchHeight, fetchTime := fetch.GeneratorHeight()
+		fetchHeight, fetchTime := a.replicator.PeerHeight()
 		// Because everything is asynchronous, it's possible for the localHeight to
 		// be higher than our cached generator height. In that case, display the
 		// local height as the generator height.

--- a/core/fetch/fetch.go
+++ b/core/fetch/fetch.go
@@ -91,9 +91,9 @@ func (rep *Replicator) Fetch(ctx context.Context, c *protocol.Chain, health func
 	}
 }
 
-// PollGeneratorHeight periodically polls the configured peer for
+// PollRemoteHeight periodically polls the configured peer for
 // its blockchain height. It blocks until the ctx is canceled.
-func (rep *Replicator) PollGeneratorHeight(ctx context.Context) {
+func (rep *Replicator) PollRemoteHeight(ctx context.Context) {
 	rep.updateGeneratorHeight(ctx)
 
 	ticker := time.NewTicker(heightPollingPeriod)

--- a/core/fetch/fetch.go
+++ b/core/fetch/fetch.go
@@ -24,13 +24,8 @@ const heightPollingPeriod = 3 * time.Second
 // the peer's blockchain height, and will stop only when ctx is
 // cancelled. To begin replicating blocks, the caller must call
 // Fetch.
-func New(ctx context.Context, peer *rpc.Client) *Replicator {
-	rep := &Replicator{peer: peer}
-
-	// Fetch the generator height periodically.
-	go rep.pollGeneratorHeight(ctx)
-
-	return rep
+func New(peer *rpc.Client) *Replicator {
+	return &Replicator{peer: peer}
 }
 
 // Replicator implements block replication.
@@ -96,7 +91,9 @@ func (rep *Replicator) Fetch(ctx context.Context, c *protocol.Chain, health func
 	}
 }
 
-func (rep *Replicator) pollGeneratorHeight(ctx context.Context) {
+// PollGeneratorHeight periodically polls the configured peer for
+// its blockchain height. It blocks until the ctx is canceled.
+func (rep *Replicator) PollGeneratorHeight(ctx context.Context) {
 	rep.updateGeneratorHeight(ctx)
 
 	ticker := time.NewTicker(heightPollingPeriod)

--- a/core/fetch/fetch.go
+++ b/core/fetch/fetch.go
@@ -100,7 +100,7 @@ func (rep *Replicator) PollRemoteHeight(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			log.Printf(ctx, "Deposed, pollGeneratorHeight exiting")
+			log.Printf(ctx, "Deposed, PollRemoteHeight exiting")
 			ticker.Stop()
 			return
 		case <-ticker.C:

--- a/core/run.go
+++ b/core/run.go
@@ -95,7 +95,7 @@ func GeneratorRemote(client *rpc.Client) RunOption {
 		}
 		a.remoteGenerator = client
 		a.submitter = &txbuilder.RemoteGenerator{Peer: client}
-		a.replicator = fetch.New(a.ctx, client)
+		a.replicator = fetch.New(client)
 	}
 }
 
@@ -178,7 +178,6 @@ func Run(
 	indexer := query.NewIndexer(db, c, pinStore)
 
 	a := &API{
-		ctx:          ctx,
 		chain:        c,
 		store:        store,
 		pinStore:     pinStore,
@@ -200,6 +199,10 @@ func Run(
 	}
 	if a.remoteGenerator == nil && a.generator == nil {
 		return nil, errors.New("no generator configured")
+	}
+
+	if a.replicator != nil {
+		go a.replicator.PollGeneratorHeight(ctx)
 	}
 
 	if a.indexTxs {

--- a/core/run.go
+++ b/core/run.go
@@ -95,6 +95,7 @@ func GeneratorRemote(client *rpc.Client) RunOption {
 		}
 		a.remoteGenerator = client
 		a.submitter = &txbuilder.RemoteGenerator{Peer: client}
+		a.replicator = fetch.New(a.ctx, client)
 	}
 }
 
@@ -177,6 +178,7 @@ func Run(
 	indexer := query.NewIndexer(db, c, pinStore)
 
 	a := &API{
+		ctx:          ctx,
 		chain:        c,
 		store:        store,
 		pinStore:     pinStore,
@@ -228,7 +230,6 @@ func Run(
 // becomes leader of the Core.
 func (a *API) lead(ctx context.Context) {
 	if !a.config.IsGenerator {
-		fetch.Init(ctx, a.remoteGenerator)
 		// If don't have any blocks, bootstrap from the generator's
 		// latest snapshot.
 		if a.chain.Height() == 0 {
@@ -273,7 +274,7 @@ func (a *API) lead(ctx context.Context) {
 		a.downloadingSnapshot = nil
 		a.downloadingSnapshotMu.Unlock()
 
-		go fetch.Fetch(ctx, a.chain, a.remoteGenerator, a.healthSetter("fetch"))
+		go a.replicator.Fetch(ctx, a.chain, a.healthSetter("fetch"))
 	}
 	go a.accounts.ProcessBlocks(ctx)
 	go a.assets.ProcessBlocks(ctx)

--- a/core/run.go
+++ b/core/run.go
@@ -202,7 +202,7 @@ func Run(
 	}
 
 	if a.replicator != nil {
-		go a.replicator.PollGeneratorHeight(ctx)
+		go a.replicator.PollRemoteHeight(ctx)
 	}
 
 	if a.indexTxs {

--- a/core/transact.go
+++ b/core/transact.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"chain/core/fetch"
 	"chain/core/leader"
 	"chain/core/txbuilder"
 	"chain/database/pg"
@@ -214,7 +213,10 @@ func cleanUpSubmittedTxs(ctx context.Context, db pg.DB) {
 func (a *API) finalizeTxWait(ctx context.Context, txTemplate *txbuilder.Template, waitUntil string) error {
 	// Use the current generator height as the lower bound of the block height
 	// that the transaction may appear in.
-	generatorHeight, _ := fetch.GeneratorHeight()
+	var generatorHeight uint64
+	if a.replicator != nil {
+		generatorHeight, _ = a.replicator.PeerHeight()
+	}
 	localHeight := a.chain.Height()
 	if localHeight > generatorHeight {
 		generatorHeight = localHeight

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3338";
+	public final String Id = "main/rev3339";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3338"
+const ID string = "main/rev3339"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3338"
+export const rev_id = "main/rev3339"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3338".freeze
+	ID = "main/rev3339".freeze
 end


### PR DESCRIPTION
Remove package-level globals, encapsulate all state in a Replicator
struct.