### PR TITLE
all: make unnecessary vars const

### DIFF
--- a/core/accesstoken/accesstoken.go
+++ b/core/accesstoken/accesstoken.go
@@ -17,7 +17,10 @@ import (
 	"chain/errors"
 )
 
-const tokenSize = 32
+const (
+	tokenSize    = 32
+	defaultLimit = 100
+)
 
 var (
 	// ErrBadID is returned when Create is called on an invalid id string.
@@ -26,8 +29,6 @@ var (
 	ErrDuplicateID = errors.New("duplicate access token ID")
 	// ErrBadType is returned when Create is called with a bad type.
 	ErrBadType = errors.New("type must be client or network")
-
-	defaultLimit = 100
 
 	// validIDRegexp checks that all characters are alphumeric, _ or -.
 	// It also must have a length of at least 1.

--- a/core/transact.go
+++ b/core/transact.go
@@ -18,7 +18,7 @@ import (
 	"chain/protocol/bc/legacy"
 )
 
-var defaultTxTTL = 5 * time.Minute
+const defaultTxTTL = 5 * time.Minute
 
 func (a *API) actionDecoder(action string) (func([]byte) (txbuilder.Action, error), bool) {
 	var decoder func([]byte) (txbuilder.Action, error)

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3339";
+	public final String Id = "main/rev3340";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3339"
+const ID string = "main/rev3340"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3339"
+export const rev_id = "main/rev3340"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3339".freeze
+	ID = "main/rev3340".freeze
 end

--- a/log/log.go
+++ b/log/log.go
@@ -17,8 +17,6 @@ import (
 	"chain/errors"
 )
 
-const rfc3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
-
 // context key type
 type key int
 
@@ -26,6 +24,13 @@ var (
 	logWriterMu sync.Mutex // protects the following
 	logWriter   io.Writer  = os.Stdout
 	procPrefix  []byte     // process-global prefix; see SetPrefix vs AddPrefixkv
+
+	// context key for log line prefixes
+	prefixKey key = 0
+)
+
+const (
+	rfc3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
 
 	// pairDelims contains a list of characters that may be used as delimeters
 	// between key-value pairs in a log entry. Keys and values will be quoted or
@@ -35,9 +40,6 @@ var (
 	// http://answers.splunk.com/answers/143368/default-delimiters-for-key-value-extraction.html
 	pairDelims      = " ,;|&\t\n\r"
 	illegalKeyChars = pairDelims + `="`
-
-	// context key for log line prefixes
-	prefixKey key = 0
 )
 
 // Conventional key names for log entries


### PR DESCRIPTION
Move some global vars to global consts. I found these
while auditing the code base for global state that might
prevent us from running multiple core.APIs in the same
process.