### PR TITLE
errors: lazily load stack trace info

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -16,7 +16,7 @@ type wrapperError struct {
 	msg    string
 	detail []string
 	data   map[string]interface{}
-	stack  []StackFrame
+	stack  []uintptr
 	root   error
 }
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -30,11 +30,12 @@ func TestWrap(t *testing.T) {
 	}
 
 	stack := Stack(err1)
-	if len(stack) == 0 {
-		t.Fatalf("len(stack) = %v want > 0", len(stack))
+	frame, ok := stack.Next()
+	if !ok {
+		t.Fatalf("len(stack) = 0 want > 0")
 	}
-	if !strings.Contains(stack[0].String(), "TestWrap") {
-		t.Fatalf("first stack frame should contain \"TestWrap\": %v", stack[0].String())
+	if !strings.Contains(frame.Function, "TestWrap") {
+		t.Fatalf("first stack frame should contain \"TestWrap\": %v", frame.Function)
 	}
 
 	if !reflect.DeepEqual(Stack(err2), Stack(err1)) {

--- a/errors/stack.go
+++ b/errors/stack.go
@@ -1,51 +1,19 @@
 package errors
 
-import (
-	"fmt"
-	"runtime"
-)
+import "runtime"
 
 const stackTraceSize = 10
 
-// StackFrame represents a single entry in a stack trace.
-type StackFrame struct {
-	Func string
-	File string
-	Line int
+// Stack returns the stack trace of an error.
+// If the error has no stack information, it
+// returns an empty stack trace.
+func Stack(err error) *runtime.Frames {
+	wErr, _ := err.(wrapperError)
+	return runtime.CallersFrames(wErr.stack)
 }
 
-// String satisfies the fmt.Stringer interface.
-func (f StackFrame) String() string {
-	return fmt.Sprintf("%s:%d - %s", f.File, f.Line, f.Func)
-}
-
-// Stack returns the stack trace of an error. The error must contain the stack
-// trace, or wrap an error that has a stack trace,
-func Stack(err error) []StackFrame {
-	if wErr, ok := err.(wrapperError); ok {
-		return wErr.stack
-	}
-	return nil
-}
-
-// getStack is a formatting wrapper around runtime.Callers. It returns a stack
-// trace in the form of a StackFrame slice.
-func getStack(skip int, size int) []StackFrame {
-	var (
-		pc    = make([]uintptr, size)
-		calls = runtime.Callers(skip+1, pc)
-		trace []StackFrame
-	)
-
-	for i := 0; i < calls; i++ {
-		f := runtime.FuncForPC(pc[i])
-		file, line := f.FileLine(pc[i] - 1)
-		trace = append(trace, StackFrame{
-			Func: f.Name(),
-			File: file,
-			Line: line,
-		})
-	}
-
-	return trace
+// getStack is an allocating wrapper around runtime.Callers.
+func getStack(skip int, max int) []uintptr {
+	pcs := make([]uintptr, max)
+	return pcs[:runtime.Callers(skip+1, pcs)]
 }

--- a/generated/rev/RevId.java
+++ b/generated/rev/RevId.java
@@ -1,4 +1,4 @@
 
 public final class RevId {
-	public final String Id = "main/rev3342";
+	public final String Id = "main/rev3343";
 }

--- a/generated/rev/revid.go
+++ b/generated/rev/revid.go
@@ -1,3 +1,3 @@
 package rev
 
-const ID string = "main/rev3342"
+const ID string = "main/rev3343"

--- a/generated/rev/revid.js
+++ b/generated/rev/revid.js
@@ -1,2 +1,2 @@
 
-export const rev_id = "main/rev3342"
+export const rev_id = "main/rev3343"

--- a/generated/rev/revid.rb
+++ b/generated/rev/revid.rb
@@ -1,4 +1,4 @@
 
 module Chain::Rev
-	ID = "main/rev3342".freeze
+	ID = "main/rev3343".freeze
 end

--- a/testutil/expect.go
+++ b/testutil/expect.go
@@ -14,12 +14,13 @@ var wd, _ = os.Getwd()
 
 func FatalErr(t testing.TB, err error) {
 	args := []interface{}{err}
-	for _, frame := range errors.Stack(err) {
+	stack := errors.Stack(err)
+	for frame, ok := stack.Next(); ok; frame, ok = stack.Next() {
 		file := frame.File
 		if rel, err := filepath.Rel(wd, file); err == nil && !strings.HasPrefix(rel, "../") {
 			file = rel
 		}
-		funcname := frame.Func[strings.IndexByte(frame.Func, '.')+1:]
+		funcname := frame.Function[strings.IndexByte(frame.Function, '.')+1:]
 		s := fmt.Sprintf("\n%s:%d: %s", file, frame.Line, funcname)
 		args = append(args, s)
 	}


### PR DESCRIPTION
The standard library now provides a more convenient and robust way to get stack frame information, that correctly handles panic frames and non-Go (e.g. cgo) frames. At the same time, we can save some allocations and CPU time while capturing a stack trace by storing just the "callers" slice of PC values as returned by runtime.Callers.