### PR TITLE
docker/ci: Update Rust to nightly-2017-07-19

### DIFF
--- a/docker/ci/Readme.md
+++ b/docker/ci/Readme.md
@@ -3,6 +3,7 @@ This dockerfile produces the image used for continuous integration. Installed so
 - Go 1.8
 - Java 1.7
 - Ruby 2.0.0
+- Rust 1.20.0-nightly (582af6e1a 2017-07-19)
 - Node 4.8.0
 - CodeSafe 12.10.01
 - various build/test dependencies

--- a/docker/ci/install/install-rust
+++ b/docker/ci/install/install-rust
@@ -3,13 +3,13 @@
 set -e
 
 # Pin to a specific nightly until we can get off nightly entirely
-RUST_VERSION="nightly-2017-06-20"
+RUST_VERSION="nightly-2017-07-19"
 
-# Pin to this version of rustfmt
-RUSTFMT_VERSION="0.9.0"
+# Pin to this version of rustfmt-nightly
+RUSTFMT_NIGHTLY_VERSION="0.1.9"
 
 # Pin to this version of clippy
-CLIPPY_VERSION="0.0.140"
+CLIPPY_VERSION="0.0.144"
 
 # Pin to this version of cargo-audit
 CARGO_AUDIT_VERSION="0.2.0"
@@ -21,6 +21,6 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION}
 ~/.cargo/bin/rustup target add powerpc-unknown-linux-gnu
 
 # Use cargo to install build-time tools
-~/.cargo/bin/cargo install rustfmt --vers ${RUSTFMT_VERSION}
+~/.cargo/bin/cargo install rustfmt-nightly --vers ${RUSTFMT_NIGHTLY_VERSION}
 ~/.cargo/bin/cargo install clippy --vers ${CLIPPY_VERSION}
 ~/.cargo/bin/cargo install cargo-audit --vers ${CARGO_AUDIT_VERSION}

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: chaindev/ci:20170710
+box: chaindev/ci:20170720
 # To update the docker image for this "box",
 # see $CHAIN/docker/ci.
 


### PR DESCRIPTION
This release includes features which were stabilized in Rust 1.19, which means
we can remove them from csemodule and get closer to getting off nightly.