### PR TITLE
net/tls.go: harden TLS ciphersuite configuration

### DIFF
--- a/net/tls.go
+++ b/net/tls.go
@@ -17,5 +17,27 @@ func DefaultTLSConfig() *tls.Config {
 			tls.X25519,
 			tls.CurveP256,
 		},
+		// The standard Go ciphersuites from crypto/tls/cipher_suites.go, sans
+		// 3DES as it has a 64-bit block size and is therefore vulnerable to
+		// Sweet32.
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
 	}
 }


### PR DESCRIPTION
net/tls.go: Harden TLS ciphersuite configuration

The default Go TLS ciphersuite list includes some 3DES ciphers:

https://golang.org/src/crypto/tls/cipher_suites.go#L78

These ciphers are (potentially) vulnerable to Sweet32, and we have received
some
customer complaints about this.

This list is the standard ciphersuites configuration used by Go, with the
3DES
ciphersuites removed.

We may want to further harden it, although I've tried removing the SHA-1
and CBC mode ciphersuites and if I remove either of these they break the
existing Java integration tests.

Though Go has countermeasures for Lucky13-style attacks on CBC modes, they
don't seem particularly great:

https://github.com/golang/go/commit/f28cf8346c4ce7cb74bf97c7c69da21c43a78034

Note Filippo's warning about these countermeasures being potentially
leaky:

    This should have no explicit secret-dependent timings, but it does NOT
    attempt to normalize memory accesses to prevent cache timing leaks.

Ideally we would move to AEAD modes only, i.e. AES-GCM and
ChaCha20Poly1305.

Cherry-picked from 7a0320851cdb45cc5db21828d4120ac0c5bf66ba.