### PR TITLE
Allow overriding AWS S3 Region with env var

### DIFF
--- a/cmd/blockcache/main.go
+++ b/cmd/blockcache/main.go
@@ -41,10 +41,8 @@ var (
 	tlsKey     = env.String("TLSKEY", "")
 
 	// aws relies on AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY being set
-	region   = "us-east-1" // TODO(kr): figure out how to not hard code this
-	awsSess  = session.Must(session.NewSession(aws.NewConfig().WithRegion(region)))
-	awsS3    = s3.New(awsSess)
-	s3Bucket = env.String("CACHEBUCKET", "blocks-cache")
+	awsRegion = env.String("AWS_REGION", "us-east-1")
+	s3Bucket  = env.String("CACHEBUCKET", "blocks-cache")
 
 	s3ACL      = aws.String("public-read")
 	s3Encoding = aws.String("gzip")
@@ -63,6 +61,9 @@ func main() {
 	if err != nil {
 		log.Fatalkv(context.Background(), log.KeyError, err)
 	}
+
+	awsSess = session.Must(session.NewSession(aws.NewConfig().WithRegion(awsRegion)))
+	awsS3 = s3.New(awsSess)
 
 	var errorFormatter = httperror.Formatter{
 		Default:     httperror.Info{500, "CH000", "Chain API Error"},
@@ -96,6 +97,7 @@ func main() {
 	cache := &blockCache{
 		db:     db,
 		gz:     gzip.NewWriter(nil),
+		s3:     awsS3,
 		id:     id,
 		height: height,
 	}
@@ -164,6 +166,7 @@ type blockCache struct {
 
 	db *sql.DB
 	gz *gzip.Writer
+	s3 *s3.S3
 }
 
 func (c *blockCache) save(ctx context.Context, id string, height uint64, block *legacy.Block) error {
@@ -175,7 +178,7 @@ func (c *blockCache) save(ctx context.Context, id string, height uint64, block *
 	}
 	c.gz.Close()
 
-	_, err = awsS3.PutObject(&s3.PutObjectInput{
+	_, err = c.s3.PutObject(&s3.PutObjectInput{
 		ACL:             s3ACL,
 		Bucket:          s3Bucket,
 		Key:             aws.String(fmt.Sprintf("%s/%d", id, height)),

--- a/cmd/blockcache/main.go
+++ b/cmd/blockcache/main.go
@@ -41,8 +41,8 @@ var (
 	tlsKey     = env.String("TLSKEY", "")
 
 	// aws relies on AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY being set
-	awsRegion = env.String("AWS_REGION", "us-east-1")
-	s3Bucket  = env.String("CACHEBUCKET", "blocks-cache")
+	region   = env.String("AWS_REGION", "us-east-1")
+	s3Bucket = env.String("CACHEBUCKET", "blocks-cache")
 
 	s3ACL      = aws.String("public-read")
 	s3Encoding = aws.String("gzip")
@@ -62,7 +62,7 @@ func main() {
 		log.Fatalkv(context.Background(), log.KeyError, err)
 	}
 
-	awsSess = session.Must(session.NewSession(aws.NewConfig().WithRegion(awsRegion)))
+	awsSess = session.Must(session.NewSession(aws.NewConfig().WithRegion(region)))
 	awsS3 = s3.New(awsSess)
 
 	var errorFormatter = httperror.Formatter{


### PR DESCRIPTION
Previously the S3 connection was initialized as the global variable before `env.Parse()` was called. 

By moving the initialization into the main func we can leverage the env helper functions.

* Add s3 connection to blockCache
* Initialize s3 connection after env has been parsed

Addresses:

```
region = "us-east-1" // TODO(kr): figure out how to not hard code this
```

From commit: https://github.com/chain/chain/commit/aca1da719fc31f34df9a96c20ef3715a9e3493d4