### PR TITLE
docs: remove Windows installer

### DIFF
--- a/docs/1.0/core/get-started/install.partial.html
+++ b/docs/1.0/core/get-started/install.partial.html
@@ -44,19 +44,6 @@
 
 
         <div id="windows" class="tabcontent">
-          <h2>Download Windows installer</h2>
-          <p>Download and run the <strong>Chain Core installer</strong>. After installation, open the <strong>Start menu</strong> and run <strong>Chain Core</strong>.</p>
-
-          <p>
-            <a href="https://download.chain.com/windows/Chain_Core_Latest.exe" onclick="track('download-app','windows')" class="downloadBtn btn success">
-              Download Installer
-              <img src="/docs/common/images/download-icon.png" class="btn-icon icon-download">
-            </a>
-          </p>
-
-          <hr class="separator-line">
-          <span class="separator-tag">or</span>
-
           <h2>Install with Docker</h2>
 
           <p>Install <a href="https://www.docker.com/products/docker#/windows">Docker for Windows</a> and run the following command. Docker will automatically download and run Chain Core.</p>

--- a/docs/1.1/core/get-started/install.partial.html
+++ b/docs/1.1/core/get-started/install.partial.html
@@ -44,19 +44,6 @@
 
 
         <div id="windows" class="tabcontent">
-          <h2>Download Windows installer</h2>
-          <p>Download and run the <strong>Chain Core installer</strong>. After installation, open the <strong>Start menu</strong> and run <strong>Chain Core</strong>.</p>
-
-          <p>
-            <a href="https://download.chain.com/windows/Chain_Core_Latest.exe" onclick="track('download-app','windows')" class="downloadBtn btn success">
-              Download Installer
-              <img src="/docs/common/images/download-icon.png" class="btn-icon icon-download">
-            </a>
-          </p>
-
-          <hr class="separator-line">
-          <span class="separator-tag">or</span>
-
           <h2>Install with Docker</h2>
 
           <p>Install <a href="https://www.docker.com/products/docker#/windows">Docker for Windows</a> and run the following command. Docker will automatically download and run Chain Core.</p>

--- a/docs/1.2/core/get-started/install.partial.html
+++ b/docs/1.2/core/get-started/install.partial.html
@@ -40,19 +40,6 @@
 
 
         <div id="windows" class="tabcontent">
-          <h2>Download Windows installer</h2>
-          <p>Download and run the <strong>Chain Core installer</strong>. After installation, open the <strong>Start menu</strong> and run <strong>Chain Core</strong>.</p>
-
-          <p>
-            <a href="https://download.chain.com/windows/Chain_Core_Latest.exe" onclick="track('download-app','windows')" class="downloadBtn btn success">
-              Download Installer
-              <img src="/docs/common/images/download-icon.png" class="btn-icon icon-download">
-            </a>
-          </p>
-
-          <hr class="separator-line">
-          <span class="separator-tag">or</span>
-
           <h2>Install with Docker</h2>
 
           <p>Install <a href="https://www.docker.com/products/docker#/windows">Docker for Windows</a> and run the following command. Docker will automatically download and run Chain Core.</p>


### PR DESCRIPTION
We're a small team, focused on making [Sequence](https://seq.com)
a great product over the last few months. We think Sequence is a going
to be a great upgrade path for many Chain Core Developer Edition users.

In the meantime, we're continuing to support Chain Core DE in the
[Community Slack account](https://chain.slack.com/) and elsewhere.

However, we feel we can no longer provide great support specifically for
the Windows installer for Chain Core DE.

This change removes the instructions for using that installer, leaving
Docker as the preferred installation method on Windows.