### PR TITLE
core: allow block period to be configured

### DIFF
--- a/core/run.go
+++ b/core/run.go
@@ -24,14 +24,16 @@ import (
 	"chain/core/txfeed"
 	"chain/database/pg"
 	"chain/database/sinkdb"
+	"chain/env"
 	"chain/log"
 	"chain/net/http/authz"
 	"chain/protocol"
 	"chain/protocol/bc/legacy"
 )
 
+var blockPeriod = env.Duration("BLOCK_PERIOD", 1000*time.Millisecond)
+
 const (
-	blockPeriod              = time.Second
 	expireReservationsPeriod = time.Second
 )
 

--- a/docs/1.2/core/reference/cored.md
+++ b/docs/1.2/core/reference/cored.md
@@ -94,6 +94,11 @@ a member of a cluster, this has no effect.
     This should be the URL of any `cored` process already in the cluster,
     or a load balancer that forwards requests to any node.
 
+* **BLOCK_PERIOD**: Frequency that transaction blocks are generated,
+defaults to 1 second. Set to any valid
+[ParseDuration](https://golang.org/pkg/time/#ParseDuration) value. For
+example: `250ms` for 250 milliseconds.
+
 ## Mutual TLS
 
 Chain Core 1.2 introduces support for mutual TLS authentication. This means both Chain Core and the client SDKs can authenticate each other using X.509 certificates and the TLS protocol. Previously, client authentication was facilitated through the use of access tokens and HTTP Basic Auth. While still supported, client access tokens are now deprecated.

--- a/env/env.go
+++ b/env/env.go
@@ -75,35 +75,21 @@ func BoolVar(p *bool, name string, value bool) {
 	})
 }
 
-// Duration returns a new time.Duration pointer.
-// When Parse is called,
-// env var name will be parsed
-// and the resulting value
-// will be assigned to the returned location.
-func Duration(name string, value time.Duration) *time.Duration {
-	p := new(time.Duration)
-	DurationVar(p, name, value)
-	return p
-}
-
-// DurationVar defines a time.Duration var with
-// the specified name and default value. The
-// argument p points to a time.Duration variable
-// in which to store the value of the environment
-// variable.
-func DurationVar(p *time.Duration, name string, value time.Duration) {
-	*p = value
-	funcs = append(funcs, func() bool {
-		if s := os.Getenv(name); s != "" {
-			v, err := time.ParseDuration(s)
-			if err != nil {
-				log.Println(name, err)
-				return false
-			}
-			*p = v
+// Duration returns the value of the named environment variable,
+// interpreted as a time.Duration (using time.ParseDuration).
+// If there is an error parsing the value, it prints a
+// diagnostic message to the log and calls os.Exit(1).
+// If name isn't in the environment, it returns value.
+func Duration(name string, value time.Duration) time.Duration {
+	if s := os.Getenv(name); s != "" {
+		var err error
+		value, err = time.ParseDuration(s)
+		if err != nil {
+			log.Println(name, err)
+			os.Exit(1)
 		}
-		return true
-	})
+	}
+	return value
 }
 
 // URL returns a new url.URL pointer.

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -96,29 +96,6 @@ func TestBoolVar(t *testing.T) {
 
 func TestDuration(t *testing.T) {
 	result := Duration("nonexistent", 15*time.Second)
-	Parse()
-
-	if *result != 15*time.Second {
-		t.Fatalf("expected result=15s, got result=%v", *result)
-	}
-
-	err := os.Setenv("duration-key", "25s")
-	if err != nil {
-		t.Fatal("unexpected error", err)
-	}
-
-	result = Duration("duration-key", 15*time.Second)
-	Parse()
-
-	if *result != 25*time.Second {
-		t.Fatalf("expected result=25s, got result=%v", *result)
-	}
-}
-
-func TestDurationVar(t *testing.T) {
-	var result time.Duration
-	DurationVar(&result, "nonexistent", 15*time.Second)
-	Parse()
 
 	if result != 15*time.Second {
 		t.Fatalf("expected result=15s, got result=%v", result)
@@ -129,8 +106,7 @@ func TestDurationVar(t *testing.T) {
 		t.Fatal("unexpected error", err)
 	}
 
-	DurationVar(&result, "duration-key", 15*time.Second)
-	Parse()
+	result = Duration("duration-key", 15*time.Second)
 
 	if result != 25*time.Second {
 		t.Fatalf("expected result=25s, got result=%v", result)


### PR DESCRIPTION
Some applications may want to change the block frequency
based on their traffic patterns.

For example, a value of 250 milliseconds (a factor of four)
improved performance in one application we observed.

This variable can set to any value that can be parsed by
https://golang.org/pkg/time/#ParseDuration such as `250ms`.