### PR TITLE
sdk/java: fix gson concurrency bug

### DIFF
--- a/sdk/java/src/main/java/com/chain/common/Utils.java
+++ b/sdk/java/src/main/java/com/chain/common/Utils.java
@@ -1,8 +1,0 @@
-package com.chain.common;
-
-import com.google.gson.*;
-
-public class Utils {
-  public static String rfc3339DateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
-  public static final Gson serializer = new GsonBuilder().setDateFormat(rfc3339DateFormat).create();
-}

--- a/sdk/java/src/test/java/com/chain/integration/CreateTest.java
+++ b/sdk/java/src/test/java/com/chain/integration/CreateTest.java
@@ -5,7 +5,6 @@ import com.chain.api.*;
 import com.chain.exception.APIException;
 import com.chain.http.BatchResponse;
 import com.chain.http.Client;
-import com.chain.common.Utils;
 
 import org.junit.Test;
 
@@ -179,7 +178,7 @@ public class CreateTest {
     assertTrue(r.expiresAt.after(new Date()));
 
     Date expiresAt =
-        new SimpleDateFormat(Utils.rfc3339DateFormat).parse("2020-01-01T00:00:00.000Z");
+        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").parse("2020-01-01T00:00:00.000Z");
     r = new Account.ReceiverBuilder().setAccountAlias(alice).setExpiresAt(expiresAt).create(client);
 
     assertNotNull(r.controlProgram);


### PR DESCRIPTION
It seems that our serializer is not safe to use across threads. This patch removes our global serializer object and adds a serializer instance variable on the Client object. If folks instantiate client objects across threads, then we should be ok here.

Example stack trace from a customer:

```
Caused by: java.util.ConcurrentModificationException
    at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901)
    at java.util.ArrayList$Itr.next(ArrayList.java:851)
    at com.chain.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.write(CollectionTypeAdapterFactory.java:96)
    at com.chain.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.write(CollectionTypeAdapterFactory.java:61)
    at com.chain.google.gson.internal.bind.TypeAdapterRuntimeTypeWrapper.write(TypeAdapterRuntimeTypeWrapper.java:68)
    at com.chain.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.write(MapTypeAdapterFactory.java:208)
    at com.chain.google.gson.internal.bind.MapTypeAdapterFactory$Adapter.write(MapTypeAdapterFactory.java:145)
    at com.chain.google.gson.Gson.toJson(Gson.java:661)
    at com.chain.google.gson.Gson.toJson(Gson.java:640)
    at com.chain.google.gson.Gson.toJson(Gson.java:595)
    at com.chain.google.gson.Gson.toJson(Gson.java:575)
    at com.chain.http.Client.post(Client.java:342)
    at com.chain.http.Client.singletonBatchRequest(Client.java:235)
    at com.chain.signing.HsmSigner.sign(HsmSigner.java:70)
```

Related issue in gson: https://github.com/google/gson/issues/1159